### PR TITLE
Reduce resource with two-level synthetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +999,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
+ "backon",
  "bytes",
  "chrono",
  "clap",
@@ -1297,6 +1309,18 @@ dependencies = [
  "bitflags 2.6.0",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,27 +862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,15 +977,12 @@ dependencies = [
  "anyhow",
  "arrow",
  "arrow-array",
- "arrow-schema",
  "backon",
  "bytes",
  "chrono",
  "clap",
- "csv",
  "duckdb",
  "env_logger",
- "futures",
  "hex",
  "oauth2",
  "parquet",
@@ -1018,13 +994,11 @@ dependencies = [
  "sea-query",
  "serde",
  "serde_arrow",
- "serde_bytes",
  "serde_json",
  "serde_repr",
  "serde_yaml_ng",
  "sha2",
  "tera",
- "unbounded-interval-tree",
  "uuid",
  "wax",
  "zstd",
@@ -1171,21 +1145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,32 +1161,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
 
 [[package]]
 name = "futures-sink"
@@ -1247,10 +1184,8 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -3119,15 +3054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,15 +3629,6 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "unbounded-interval-tree"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac967d0ba617b6fd7f558750a2924a7086998ae52524b75aba74a719c11264"
-dependencies = [
- "rand",
-]
 
 [[package]]
 name = "unic-char-property"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "num",
+ "num 0.4.3",
 ]
 
 [[package]]
@@ -188,7 +188,7 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown 0.14.5",
- "num",
+ "num 0.4.3",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ checksum = "9e51e05228852ffe3eb391ce7178a0f97d2cf80cc6ef91d3c4a6b3cb688049ec"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num 0.4.3",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ dependencies = [
  "comfy-table",
  "half",
  "lexical-core",
- "num",
+ "num 0.4.3",
  "ryu",
 ]
 
@@ -232,7 +232,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num 0.4.3",
 ]
 
 [[package]]
@@ -261,7 +261,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "half",
- "num",
+ "num 0.4.3",
 ]
 
 [[package]]
@@ -298,7 +298,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num 0.4.3",
 ]
 
 [[package]]
@@ -313,7 +313,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num 0.4.3",
  "regex",
  "regex-syntax",
 ]
@@ -1010,6 +1010,7 @@ dependencies = [
  "hex",
  "oauth2",
  "parquet",
+ "parse_duration",
  "rand",
  "regex",
  "reqwest 0.12.9",
@@ -2130,15 +2131,40 @@ dependencies = [
 
 [[package]]
 name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint 0.2.6",
+ "num-complex 0.2.4",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
+name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
- "num-complex",
+ "num-bigint 0.4.6",
+ "num-complex 0.4.6",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.4.2",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2149,6 +2175,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
  "num-traits",
 ]
 
@@ -2189,11 +2225,23 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -2328,8 +2376,8 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "lz4_flex",
- "num",
- "num-bigint",
+ "num 0.4.3",
+ "num-bigint 0.4.6",
  "paste",
  "seq-macro",
  "snap",
@@ -2345,6 +2393,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "parse_duration"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
+dependencies = [
+ "lazy_static",
+ "num 0.2.1",
  "regex",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,15 @@ serde_json = "1.0.116"
 arrow = { version = "*", default-features = false, features = ["prettyprint"] }
 parquet = "53"
 arrow-array = "53"
-arrow-schema = "53"
 serde_arrow = { version = "0.11.2", features = ["arrow-53"] }
 clap = { version = "4.5.4", features = ["derive"] }
 anyhow = "1.0.82"
 chrono = "0.4.38"
-futures = "0.3.30"
 serde_yaml_ng = "0.9.36"
 uuid = { version = "1.8.0", features = ["serde", "v4"] }
 sha2 = "0.10.8"
 hex = "0.4.3"
 duckdb = { version = "1.1.1", features = ["bundled"] }
-serde_bytes = "0.11.14"
 serde_repr = "0.1.19"
 rust-s3 = { version = "0.34.0", default-features = false, features = ["sync-native-tls"] }
 rand = "0.8.5"
@@ -33,8 +30,6 @@ bytes = "1.6.0"
 wax = "0.6.0"
 tera = "1"
 zstd = "0.13.2"
-csv = "1.3.0"
-unbounded-interval-tree = "1.1.2"
 sea-query = { version = "0", features = ["with-chrono"] }
 regex = "1.11.1"
 backon = { version = "1.3.0", features = ["std-blocking-sleep"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ csv = "1.3.0"
 unbounded-interval-tree = "1.1.2"
 sea-query = { version = "0", features = ["with-chrono"] }
 regex = "1.11.1"
+backon = { version = "1.3.0", features = ["std-blocking-sleep"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ unbounded-interval-tree = "1.1.2"
 sea-query = { version = "0", features = ["with-chrono"] }
 regex = "1.11.1"
 backon = { version = "1.3.0", features = ["std-blocking-sleep"] }
+parse_duration = "2.1.1"

--- a/README.md
+++ b/README.md
@@ -294,11 +294,12 @@ Writes a sert of matching files to corresponding paths in the host
 file system.
 
 ```
-duckpond export -d OUTPUT_DIR -p PATTERN 
+duckpond export -d OUTPUT_DIR -p PATTERN --temporal=year,month
 ```
 
 Series and Table-type data will be exported in date-partitioned
-Parquet files.
+Parquet files.  The `--temporal` argument determines the partition
+keys for the output (which must include `year`).
 
 ## Configuration template expansion
 

--- a/README.md
+++ b/README.md
@@ -299,3 +299,19 @@ duckpond export -d OUTPUT_DIR -p PATTERN
 
 Series and Table-type data will be exported in date-partitioned
 Parquet files.
+
+## Configuration template expansion
+
+Configuration values that are String typed have template expansion applied,
+meaning that a line of configuration such as:
+
+```
+property: "{{ variable }}"
+```
+
+can be configured during `duckpond apply`.  As an special case, the
+Template resource's `template` field itself is not expanded.  For example,
+
+```
+duckpond apply -f config.yaml -v variable=value
+```

--- a/example/inbox.yaml
+++ b/example/inbox.yaml
@@ -1,6 +1,6 @@
 apiVersion: github.com/jmacd/duckpond/v1
 kind: Inbox
-name: oteljson
+name: laketechcsv
 desc: Dropbox for testing OTel JSON file inputs.
 spec:
   pattern: /Users/jmacd/src/duckpond/inbox/**

--- a/example/laketech.yaml
+++ b/example/laketech.yaml
@@ -11,7 +11,7 @@ spec:
   # fishy about SQL and timestamps.
 
   collections:
-  - pattern: "{{ resource }}/*surface*.csv"
+  - pattern: "/Inbox/laketechcsv/*surface*.csv"
     name: SurfaceMeasurements
     query: >
       
@@ -57,7 +57,7 @@ spec:
       
       ORDER BY TIMES.T
 
-  - pattern: "{{ resource }}/*bottom*.csv"
+  - pattern: "/Inbox/laketechcsv/*bottom*.csv"
     name: BottomMeasurements
     query: >
       
@@ -97,7 +97,7 @@ spec:
       
       ORDER BY TIMES.T
 
-  - pattern: "{{ resource }}/*vulink*.csv"
+  - pattern: "/Inbox/laketechcsv/*vulink*.csv"
     name: VulinkMeasurements
     query: >
       

--- a/example/noyo.yaml
+++ b/example/noyo.yaml
@@ -1,10 +1,10 @@
 apiVersion: www.hydrovu.com/v1
 kind: HydroVu
-name: noyo-harbor
+name: noyoharbor
 desc: Noyo Harbor Blue Economy
 spec:
-  key: {{ key }}
-  secret: {{ secret }}
+  key: "{{ key }}"
+  secret: "{{ secret }}"
   devices:
   - name:  BDockVulink
     scope: Vulink

--- a/example/noyodata.yaml
+++ b/example/noyodata.yaml
@@ -1,14 +1,14 @@
 apiVersion: www.hydrovu.com/v1
 kind: Combine
-name: noyo-data
+name: noyodata
 desc: Noyo harbor instrument collections
 spec:
   scopes:
   - name: FieldStation
     series:
-    - pattern: "{{ derive }}/SurfaceMeasurements/*"
-    - pattern: "{{ derive }}/BottomMeasurements/*"
-    - pattern: "{{ derive }}/VulinkMeasurements/*"
+    - pattern: "/Derive/csvextract/SurfaceMeasurements/*"
+    - pattern: "/Derive/csvextract/BottomMeasurements/*"
+    - pattern: "/Derive/csvextract/VulinkMeasurements/*"
 
   # - name: BDock
   #   series:

--- a/example/noyodata.yaml
+++ b/example/noyodata.yaml
@@ -10,17 +10,17 @@ spec:
     - pattern: "/Derive/csvextract/BottomMeasurements/*"
     - pattern: "/Derive/csvextract/VulinkMeasurements/*"
 
-  # - name: BDock
-  #   series:
-  #   - pattern: "{{ hydrovu }}/data/BDockVulink*"
-  #   - pattern: "{{ hydrovu }}/data/BDockAT500*"
-  # - name: Princess
-  #   series:
-  #   - pattern: "{{ hydrovu }}/data/PrincessVulink*"
-  #   - pattern: "{{ hydrovu }}/data/PrincessAT500*"
-  # - name: Silver
-  #   series:
-  #   # Note Silver has two Vulinks matching, one a replacement.
-  #   - pattern: "{{ hydrovu }}/data/SilverVulink*"
-  #   - pattern: "{{ hydrovu }}/data/SilverAT500*"
+  - name: BDock
+    series:
+    - pattern: "/HydroVu/noyoharbor/data/BDockVulink*"
+    - pattern: "/HydroVu/noyoharbor/data/BDockAT500*"
+  - name: Princess
+    series:
+    - pattern: "/HydroVu/noyoharbor/data/PrincessVulink*"
+    - pattern: "/HydroVu/noyoharbor/data/PrincessAT500*"
+  - name: Silver
+    series:
+    # Note Silver has two Vulinks matching, one a replacement.
+    - pattern: "/HydroVu/noyoharbor/data/SilverVulink*"
+    - pattern: "/HydroVu/noyoharbor/data/SilverAT500*"
 

--- a/example/observe.yaml
+++ b/example/observe.yaml
@@ -5,7 +5,7 @@ desc: Observable framework generator
 spec:
   collections:
   - name: hello
-    in_pattern: "/Combine/noyodata/*/combine"
+    in_pattern: "/Reduce/downsampled/single_instrument/res=1h/reduce-*"
     out_pattern: "$0.md"
     template: |-
       ---

--- a/example/observe.yaml
+++ b/example/observe.yaml
@@ -5,7 +5,7 @@ desc: Observable framework generator
 spec:
   collections:
   - name: hello
-    in_pattern: "{{ combine }}/*/combine"
+    in_pattern: "/Combine/noyodata/*/combine"
     out_pattern: "$0.md"
     template: |-
       ---

--- a/example/observe.yaml
+++ b/example/observe.yaml
@@ -12,6 +12,9 @@ spec:
       toc: false
       title: Water Quality
       ---
+      ```js
+      import {schemeObservable10} from "npm:d3-scale-chromatic";
+      ```
 
       ```js
       html`<link type="text/css" href="${await FileAttachment('style.css').url()}" rel="stylesheet" />`
@@ -66,21 +69,26 @@ spec:
         data: FileAttachment("./data/combined-FieldStation.parquet").parquet(),
       });
 
-      var all = await duck.sql`select {% for field in schema.fields %} "{{ field.instrument }}.{{ field.name }}.{{ field.unit }}" as V{{ loop.index }}, {% endfor %} "Timestamp"*1000 as UTC from data where UTC >= ${begin}`;
+      var all = await duck.sql`select {% for key, fields in group(by="name", in=schema.fields) %} {% set oloopidx = loop.index %} {% for field in fields %} "{{ field.instrument }}.{{ field.name }}.{{ field.unit }}" as V{{ oloopidx }}{{ loop.index }}, {% endfor %}{% endfor %} "Timestamp"*1000 as UTC from data where UTC >= ${begin}`;
       ```
       
       </details>
       
       <div class="grid grid-cols-1">
-      {% for field in schema.fields %}
+      {% for key, fields in group(by="name",in=schema.fields) %}
+        {% set oloopidx = loop.index %}
         <div class="card">${
           resize((width) => Plot.plot({
-            title: "{{ field.instrument }} {{ field.name }}",
+            title: "{{ key }}",
             width,
             x: {grid: true, type: "time", label: "Date", domain: [begin, now]},
-            y: {grid: true, label: "{{ field.unit }}", zero: true},
+            y: {grid: true, label: "{{ fields[0].unit }}", zero: true},
             color: {legend: true},
-            marks: [Plot.lineY(all, {x: "UTC", y: "V{{ loop.index }}"})],
+            marks: [
+            {% for field in fields -%}
+              Plot.lineY(all, {x: "UTC", y: "V{{ oloopidx }}{{loop.index }}", stroke: schemeObservable10[{{ loop.index }}]}),
+            {%- endfor %}
+            ]
           }))
         }</div>
       {% endfor %}

--- a/example/onlyfieldstation.yaml
+++ b/example/onlyfieldstation.yaml
@@ -1,0 +1,11 @@
+apiVersion: www.hydrovu.com/v1
+kind: Combine
+name: test-data
+desc: Noyo harbor instrument collections
+spec:
+  scopes:
+  - name: FieldStation
+    series:
+    - pattern: /Derive/csvextract/SurfaceMeasurements/*
+    - pattern: /Derive/csvextract/BottomMeasurements/*
+    - pattern: /Derive/csvextract/VulinkMeasurements/*

--- a/example/reduce.yaml
+++ b/example/reduce.yaml
@@ -5,8 +5,8 @@ desc: Downsampled datasets
 spec:
   datasets:
   - name: single_instrument
-    in_pattern: "/Combine/xyz/*/combine"
+    in_pattern: "/Combine/test-data/*/combine"
     out_pattern: "reduce-$0"
     resolutions: [1h, 2h, 4h, 12h, 24h]
     queries:
-      "AT500_Bottom.DO.mg/L": [max, avg, min]
+      x: []

--- a/example/reduce.yaml
+++ b/example/reduce.yaml
@@ -1,0 +1,31 @@
+apiVersion: duckpond/v1
+kind: Reduce
+name: noyoharbor
+desc: Page datasets
+spec:
+  inputs:
+    # pattern matching each single instrument/site
+    # pattern matching combination of all sites
+  
+  dataset:
+    resolution: 1h # 720 timestamps/month per instrument
+    partition: [year, month]
+
+    # e.g. res=1h/year=2024/month=1
+
+  dataset:
+    resolution: 2h # 365 pts/month
+    partition: [year, month]
+    
+  dataset: 
+    resolution: 4h # 550 pts/quarter
+    partition: [year, quarter]
+
+  dataset: 
+    resolution: 12h # 182 pts/quarter
+    partition: [year, quarter]
+
+  datasety: 
+    resolution: 24h # 365 pts/year
+    partition: [year]
+  

--- a/example/reduce.yaml
+++ b/example/reduce.yaml
@@ -5,8 +5,8 @@ desc: Downsampled datasets
 spec:
   datasets:
   - name: single_instrument
-    in_pattern: "/Combine/test-data/*/combine"
+    in_pattern: "/Combine/noyodata/*/combine"
     out_pattern: "reduce-$0"
     resolutions: [1h, 2h, 4h, 12h, 24h]
     queries:
-      x: []
+      AT500_Surface.DO.mg/L: ["avg", "min", "max"]

--- a/example/reduce.yaml
+++ b/example/reduce.yaml
@@ -1,31 +1,12 @@
 apiVersion: duckpond/v1
 kind: Reduce
-name: noyoharbor
-desc: Page datasets
+name: downsampled
+desc: Downsampled datasets
 spec:
-  inputs:
-    # pattern matching each single instrument/site
-    # pattern matching combination of all sites
-  
-  dataset:
-    resolution: 1h # 720 timestamps/month per instrument
-    partition: [year, month]
-
-    # e.g. res=1h/year=2024/month=1
-
-  dataset:
-    resolution: 2h # 365 pts/month
-    partition: [year, month]
-    
-  dataset: 
-    resolution: 4h # 550 pts/quarter
-    partition: [year, quarter]
-
-  dataset: 
-    resolution: 12h # 182 pts/quarter
-    partition: [year, quarter]
-
-  datasety: 
-    resolution: 24h # 365 pts/year
-    partition: [year]
-  
+  datasets:
+  - name: single_instrument
+    in_pattern: "/Combine/xyz/*/combine"
+    out_pattern: "reduce-$0"
+    resolutions: [1h, 2h, 4h, 12h, 24h]
+    queries:
+      "AT500_Bottom.DO.mg/L": [max, avg, min]

--- a/src/hydrovu.rs
+++ b/src/hydrovu.rs
@@ -330,11 +330,10 @@ pub fn read(
                 }
             }
 
-	    std::thread::sleep(std::time::Duration::from_millis(10));
-
-            if num_points > MIN_POINTS_PER_READ {
-                break;
-            }
+	    //std::thread::sleep(std::time::Duration::from_millis(10));
+            // if num_points > MIN_POINTS_PER_READ {
+            //     break;
+            // }
         }
 
         if num_points == 0 {
@@ -362,6 +361,11 @@ pub fn read(
             ));
         }
 
+	// Add more information about this loop. It
+	// TODO: because it's not obvious why the same
+	// location ID can produce multiple updates for
+	// the same run. Why is it creating multiple
+	// Tables?
         for (_, mut inst) in insts {
             let mut builders: Vec<ArrayRef> = Vec::new();
             builders.push(Arc::new(inst.tsb.finish()));

--- a/src/hydrovu.rs
+++ b/src/hydrovu.rs
@@ -64,15 +64,15 @@ pub fn fetch_data(
     Client::fetch_json(client, constant::location_url(id, start, end))
 }
 
-fn write_units(d: &mut WD, mapping: BTreeMap<i16, String>) -> Result<()> {
+fn write_units(d: &mut WD, mapping: BTreeMap<String, String>) -> Result<()> {
     write_mapping(d, "units", mapping)
 }
 
-fn write_parameters(d: &mut WD, mapping: BTreeMap<i16, String>) -> Result<()> {
+fn write_parameters(d: &mut WD, mapping: BTreeMap<String, String>) -> Result<()> {
     write_mapping(d, "params", mapping)
 }
 
-fn write_mapping(d: &mut WD, name: &str, mapping: BTreeMap<i16, String>) -> Result<()> {
+fn write_mapping(d: &mut WD, name: &str, mapping: BTreeMap<String, String>) -> Result<()> {
     let result = mapping
         .into_iter()
         .map(|(x, y)| -> Mapping { Mapping { index: x, value: y } })
@@ -103,15 +103,6 @@ fn write_temporal(d: &mut WD, locations: &Vec<ScopedLocation>) -> Result<()> {
     d.write_whole_file("temporal", FileType::Table, &result)
 }
 
-fn ss2is(ss: (String, String)) -> Option<(i16, String)> {
-    if let Ok(i) = ss.0.parse::<i16>() {
-        Some((i, ss.1))
-    } else {
-        // HydroVu has some garbage data.
-        None
-    }
-}
-
 pub fn init_func(
     d: &mut WD,
     spec: &UniqueSpec<HydroVuSpec>,
@@ -129,7 +120,7 @@ pub fn init_func(
         .reduce(|x, y| x.into_iter().chain(y).collect())
         .context("no units defined")?
         .into_iter()
-        .filter_map(ss2is)
+        //.filter_map(ss2is)
         .collect();
 
     let params = plist
@@ -137,7 +128,7 @@ pub fn init_func(
         .reduce(|x, y| x.into_iter().chain(y).collect())
         .context("no parameters defined")?
         .into_iter()
-        .filter_map(ss2is)
+        //.filter_map(ss2is)
         .collect();
 
     let locs: Result<Vec<_>, _> = fetch_locations(client.clone()).collect();

--- a/src/hydrovu.rs
+++ b/src/hydrovu.rs
@@ -2,6 +2,7 @@ mod client;
 mod constant;
 mod load;
 mod model;
+mod submain;
 
 use crate::pond;
 use crate::pond::crd::HydroVuDevice;
@@ -39,19 +40,22 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-fn creds(spec: &HydroVuSpec) -> (String, String) {
+pub use submain::Commands as Commands;
+pub use submain::hydrovu_sub_main as hydrovu_sub_main;
+
+pub fn creds(spec: &HydroVuSpec) -> (String, String) {
     (spec.key.clone(), spec.secret.clone())
 }
 
-fn fetch_names(client: Rc<Client>) -> ClientCall<Names> {
+pub fn fetch_names(client: Rc<Client>) -> ClientCall<Names> {
     Client::fetch_json(client, constant::names_url())
 }
 
-fn fetch_locations(client: Rc<Client>) -> ClientCall<Vec<Location>> {
+pub fn fetch_locations(client: Rc<Client>) -> ClientCall<Vec<Location>> {
     Client::fetch_json(client, constant::locations_url())
 }
 
-fn fetch_data(
+pub fn fetch_data(
     client: Rc<Client>,
     id: i64,
     start: i64,

--- a/src/hydrovu.rs
+++ b/src/hydrovu.rs
@@ -39,8 +39,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub const MIN_POINTS_PER_READ: usize = 1000;
-
 fn creds(spec: &HydroVuSpec) -> (String, String) {
     (spec.key.clone(), spec.secret.clone())
 }
@@ -284,6 +282,7 @@ pub fn read(
                         .map(|_| Float64Builder::default())
                         .collect();
 
+		    eprintln!("  instrument {}", &schema_str[1..]);
                     insts.insert(
                         schema_str.clone(),
                         Instrument {
@@ -330,10 +329,8 @@ pub fn read(
                 }
             }
 
-	    //std::thread::sleep(std::time::Duration::from_millis(10));
-            // if num_points > MIN_POINTS_PER_READ {
-            //     break;
-            // }
+	    // TODO: Maybe handle rate limits. With a single thread it's
+	    // not a likely scenario.
         }
 
         if num_points == 0 {

--- a/src/hydrovu/client.rs
+++ b/src/hydrovu/client.rs
@@ -71,7 +71,11 @@ impl Client {
             }
             let resp = bldr.send().with_context(|| "api request failed")?;
             let next = next_header(&resp)?;
-	    
+
+	    resp.error_for_status_ref()?;
+	    // if !resp.status().is_success() {
+	    // 	return Err(anyhow!("api response status {}", resp.status()));
+	    // }
  
             let text = resp.text().with_context(|| "api response error")?;
             let one = serde_json::from_str(&text)

--- a/src/hydrovu/load.rs
+++ b/src/hydrovu/load.rs
@@ -7,11 +7,11 @@ use crate::pond::wd::WD;
 use anyhow::Result;
 use std::collections::BTreeMap;
 
-pub fn open_units(d: &mut WD) -> Result<BTreeMap<i16, String>> {
+pub fn open_units(d: &mut WD) -> Result<BTreeMap<String, String>> {
     open_mapping(d, "units")
 }
 
-pub fn open_parameters(d: &mut WD) -> Result<BTreeMap<i16, String>> {
+pub fn open_parameters(d: &mut WD) -> Result<BTreeMap<String, String>> {
     open_mapping(d, "params")
 }
 
@@ -19,7 +19,7 @@ pub fn open_locations(d: &mut WD) -> Result<Vec<ScopedLocation>> {
     d.read_file("locations")
 }
 
-fn open_mapping(d: &mut WD, name: &str) -> Result<BTreeMap<i16, String>> {
+fn open_mapping(d: &mut WD, name: &str) -> Result<BTreeMap<String, String>> {
     let items: Vec<Mapping> = d.read_file(name)?;
 
     return Ok(items.into_iter().map(|x| (x.index, x.value)).collect());

--- a/src/hydrovu/model.rs
+++ b/src/hydrovu/model.rs
@@ -88,14 +88,17 @@ pub struct Reading {
 // discarded the non-integer values and checked for i16 compatibility.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Mapping {
-    pub index: i16,
+    pub index: String,
+    // Note that the API docs say the indexes are always integers, but they're
+    // a string field and sometimes not integers; some of the instruments use
+    // e.g. "density" as an index mapping to "Density".
     pub value: String,
 }
 
 impl ForArrow for Mapping {
     fn for_arrow() -> Vec<FieldRef> {
         vec![
-            Arc::new(Field::new("index", DataType::Int16, false)),
+            Arc::new(Field::new("index", DataType::Utf8, false)),
             Arc::new(Field::new("value", DataType::Utf8, false)),
         ]
     }
@@ -104,8 +107,8 @@ impl ForArrow for Mapping {
 // Vu is the metadata of a hydrovu account.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Vu {
-    pub units: BTreeMap<i16, String>,
-    pub params: BTreeMap<i16, String>,
+    pub units: BTreeMap<String, String>,
+    pub params: BTreeMap<String, String>,
     pub locations: Vec<ScopedLocation>,
 }
 
@@ -135,11 +138,11 @@ impl Vu {
     pub fn lookup_param_unit(&self, p: &ParameterInfo) -> Result<(String, String), Error> {
         let param = self
             .params
-            .get(&p.parameter_id.parse::<i16>()?)
+            .get(&p.parameter_id)
             .ok_or(anyhow!("unknown parameter_id {}", p.parameter_id))?;
         let unit = self
             .units
-            .get(&p.unit_id.parse::<i16>()?)
+            .get(&p.unit_id)
             .ok_or(anyhow!("unknown unit_id {}", p.unit_id))?;
         Ok((param.to_string(), unit.to_string()))
     }

--- a/src/hydrovu/submain.rs
+++ b/src/hydrovu/submain.rs
@@ -1,0 +1,71 @@
+use crate::hydrovu::Client;
+use crate::hydrovu::utc2date;
+
+use crate::pond::Pond;
+use crate::pond::sub_main_cmd;
+use crate::pond::crd::HydroVuSpec;
+use crate::pond::UniqueSpec;
+
+use clap::Subcommand;
+
+use anyhow::Result;
+use std::rc::Rc;
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Scan prints raw timeseries data.
+    Scan {
+        #[arg(short, long)]
+        uuid: String,
+
+        #[arg(short, long)]
+	loc_id: i64,
+
+        #[arg(short, long)]
+	start_ts: i64,
+
+        #[arg(short, long)]
+	end_ts: i64,
+    },
+}
+
+pub fn hydrovu_sub_main(command: &Commands) -> Result<()> {
+    let mut pond = crate::pond::open()?;
+    match command {
+        Commands::Scan{uuid, loc_id, start_ts, end_ts} => {
+	    scan(&mut pond, uuid.as_str(), *loc_id, *start_ts, *end_ts)
+	},
+    }
+}
+
+fn scan(pond: &mut Pond, uuid: &str, loc_id: i64, start_ts: i64, end_ts: i64) -> Result<()> {
+    sub_main_cmd(pond, uuid, |_pond: &mut Pond, spec: &mut UniqueSpec<HydroVuSpec>| -> Result<()> {
+	let client = Rc::new(Client::new(crate::hydrovu::creds(spec.inner()))?);
+
+        for one_data in crate::hydrovu::fetch_data(client.clone(), loc_id, start_ts, Some(end_ts)) {
+	    let one = one_data?;
+
+	    let num_points = one
+                .parameters
+                .iter()
+                .fold(0, |acc, e| acc + e.readings.len());
+
+	    let min_one = one
+                .parameters
+                .iter()
+                .map(|x| &x.readings)
+                .flatten()
+                .fold(std::i64::MAX, |a, b| a.min(b.timestamp));
+
+	    let max_one = one
+                .parameters
+                .iter()
+                .map(|x| &x.readings)
+                .flatten()
+                .fold(std::i64::MIN, |a, b| a.max(b.timestamp));
+	    
+	    eprintln!("min/max {} {}: {} {}: {}", &min_one, &max_one, utc2date(min_one)?, utc2date(max_one)?, num_points);
+	}
+	Ok(())
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@
 #![feature(os_str_display)]
 #![feature(path_add_extension)]
 #![feature(trait_upcasting)]
+#![feature(duration_constants)]
+#![feature(duration_constructors)]
 
 mod hydrovu;
 pub mod pond;

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,10 @@ enum Commands {
         pattern: String,
 
 	#[arg(short, long)]
-	dir: PathBuf
+	dir: PathBuf,
+
+	#[arg(long)]
+	temporal: String,
     },
 }
 
@@ -129,6 +132,6 @@ fn main_result() -> Result<()> {
 
 	Commands::List { pattern } => pond::list(&pattern),
 
-	Commands::Export { pattern, dir } => pond::export(pattern, &dir),
+	Commands::Export { pattern, dir, temporal } => pond::export(pattern, &dir, &temporal),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,13 @@ enum Commands {
         command: backup::Commands,
     },
 
+    /// HydroVu has a sub-menu of commands for interacting with the
+    /// HydroVu API.
+    Hydrovu {
+	#[command(subcommand)]
+	command: hydrovu::Commands,
+    },
+
     /// Cat prints the contents of the file from the Pond.
     #[clap(visible_alias = "print")]
     Cat {
@@ -115,6 +122,8 @@ fn main_result() -> Result<()> {
         Commands::Check => pond::check(),
 
         Commands::Backup { command } => backup::sub_main(&command),
+
+	Commands::Hydrovu { command } => hydrovu::hydrovu_sub_main(&command),
 
         Commands::Cat { path } => pond::cat(path.clone()),
 

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -743,7 +743,11 @@ pub fn export(pattern: String, dir: &Path) -> Result<()> {
 	// TODO WIP NEW
 	let output = PathBuf::from(dir).join(format!("{}", name));
 	let qs = wd.sql_for(ent)?;
-	let hs = format!("COPY (SELECT *, year(epoch_ms(1000*Timestamp::BIGINT)) AS year, week(epoch_ms(1000*Timestamp::BIGINT)) AS week FROM ({})) TO '{}' (FORMAT PARQUET, PARTITION_BY (year, week), OVERWRITE)", qs, output.display());
+
+	// BIGINT??
+	//let hs = format!("COPY (SELECT *, year(epoch_ms(1000*Timestamp::BIGINT)) AS year, week(epoch_ms(1000*Timestamp::BIGINT)) AS week FROM ({})) TO '{}' (FORMAT PARQUET, PARTITION_BY (year, week), OVERWRITE)", qs, output.display());
+
+	let hs = format!("COPY (SELECT *, year(Timestamp) AS year, week(Timestamp) AS week FROM ({})) TO '{}' (FORMAT PARQUET, PARTITION_BY (year, week), OVERWRITE)", qs, output.display());
 
 	let conn = new_connection()?;
         conn.execute(&hs, [])

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -735,19 +735,20 @@ pub fn export(pattern: String, dir: &Path) -> Result<()> {
 	    fold("combined".to_string(), |a, b| format!("{}-{}", a, b.replace("/", ":")));
 
 	// TODO: OLD
-	let output = PathBuf::from(dir).join(format!("{}.parquet", name));
-	wd.copy_to(ent, &mut File::create(&output).with_context(|| format!("create {}", output.display()))?)?;
+	//let output = PathBuf::from(dir).join(format!("{}.parquet", name));
+	//wd.copy_to(ent, &mut File::create(&output).with_context(|| format!("create {}", output.display()))?)?;
 
 	// TODO it's weird to return vec; why is Default + Expand + IntoIterator really?
 
 	// TODO WIP NEW
-	//let output = PathBuf::from(dir).join(format!("{}", name));
-	// let qs = wd.sql_for(ent)?;
-	// let hs = format!("COPY (SELECT *, year(epoch_ms(1000*Timestamp::BIGINT)) AS year, week(epoch_ms(1000*Timestamp::BIGINT)) AS week FROM ({})) TO '{}' (FORMAT PARQUET, PARTITION_BY (year, week), OVERWRITE)", qs, output.display());
+	let output = PathBuf::from(dir).join(format!("{}", name));
+	let qs = wd.sql_for(ent)?;
+	let hs = format!("COPY (SELECT *, year(epoch_ms(1000*Timestamp::BIGINT)) AS year, week(epoch_ms(1000*Timestamp::BIGINT)) AS week FROM ({})) TO '{}' (FORMAT PARQUET, PARTITION_BY (year, week), OVERWRITE)", qs, output.display());
 
-	// let conn = new_connection()?;
-        // conn.execute(&hs, [])
-	//     .with_context(|| format!("can't prepare statement {}", &qs))?;
+	let conn = new_connection()?;
+        conn.execute(&hs, [])
+	    .with_context(|| format!("can't prepare statement {}", &qs))?;
+
 	Ok(vec![])
     })
 }

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -704,7 +704,15 @@ pub fn export(pattern: String, dir: &Path) -> Result<()> {
 	    fold("combined".to_string(), |a, b| format!("{}-{}", a, b.replace("/", ":")));
 
 	let output = PathBuf::from(dir).join(format!("{}.parquet", name));
+
+	
+	// TODO: OLD
 	wd.copy_to(ent, &mut File::create(&output).with_context(|| format!("create {}", output.display()))?)
+	// TODO WIP NEW
+	// let qs = wd.sql_for(ent)?;
+	// eprintln!("export query {} to {}", qs, output.display());
+
+	// Ok(())
     })
 }
 

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -159,7 +159,7 @@ impl<T: ForArrow> ForArrow for UniqueSpec<T> {
     }
 }
 
-pub trait Deriver: std::fmt::Debug {
+pub trait Deriver {
     fn open_derived(
         &self,
         pond: &mut Pond,
@@ -168,8 +168,6 @@ pub trait Deriver: std::fmt::Debug {
         entry: &DirEntry,
     ) -> Result<usize>;
 }
-
-#[derive(Debug)]
 
 pub struct Pond {
     /// nodes are working-directory handles corresponding with tree-like objects

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -600,25 +600,11 @@ impl Pond {
             if bn == "" {
                 return wd.in_path(bn, |wd| visit(wd, glob, Path::new(""), f));
             }
-            let mut ent = wd.lookup(&bn);
-	    loop {
-		match ent {
-		    None => { return Ok(()); },
-		    Some(ref found) => {
-			if let FileType::SymLink = found.ftype {
-			    let new_base = found.content.clone().map_or("".to_string(),
-									|x| String::from_utf8_lossy(&x).to_string());
-			    // TODO: eprintln!("resolved link {}", new_base);
-			    ent = wd.lookup(&new_base);
-
-			    continue;
-			}
-		    },
-		};
-		break;
-	    };
+            let ent = wd.lookup(&bn);
+	    if ent.is_none() {
+		return Ok(())
+	    }
 	    let ent = ent.unwrap();
-	    // TODO:
             match ent.ftype {
                 FileType::Tree | FileType::SynTree => {
                     // Prefix is a dir

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -734,6 +734,9 @@ pub fn export(pattern: String, dir: &Path, temporal: &String) -> Result<()> {
 
 	let pp = wd.pondpath(&ent.prefix);
 	let mp = CandidatePath::from(pp.as_path());
+
+	// TODO: This matched().expect() will fail when the pattern uses
+	// a symlink. Bogus!
 	let matched = glob.matched(&mp).expect("this already matched");
 	let cap_cnt = glob.captures().count();
 	let name = (1..=cap_cnt).

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -25,6 +25,7 @@ use duckdb::Connection;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use rand::prelude::thread_rng;
@@ -171,7 +172,11 @@ pub trait Deriver: std::fmt::Debug {
 #[derive(Debug)]
 
 pub struct Pond {
+    /// nodes are working-directory handles corresponding with tree-like objects
+    /// that have been initialized.
     nodes: Vec<Rc<RefCell<dyn TreeLike>>>,
+    /// syndat maps syn-tree objects to child-state callbacks.
+    syndat: HashMap<usize, usize>,
     ders: BTreeMap<String, BTreeMap<usize, Rc<RefCell<dyn Deriver>>>>,
 
     pub resources: Vec<PondResource>,
@@ -367,6 +372,7 @@ impl Pond {
         Pond {
             nodes: Vec::new(),
             ders: BTreeMap::new(),
+	    syndat: HashMap::new(),
             resources: Vec::new(),
             writer: MultiWriter::new(),
         }

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -31,7 +31,7 @@ use std::collections::BTreeSet;
 use rand::prelude::thread_rng;
 use rand::Rng;
 use std::env;
-use std::fs::File;
+//use std::fs::File;
 use std::io::Write;
 use std::iter::Iterator;
 use std::ops::Deref;
@@ -732,7 +732,7 @@ pub fn export(pattern: String, dir: &Path) -> Result<()> {
 	let cap_cnt = glob.captures().count();
 	let name = (1..=cap_cnt).
 	    map(|x| matched.get(x).unwrap().to_string()).
-	    fold("combined".to_string(), |a, b| format!("{}-{}", a, b.replace("/", ":")));
+	    fold("export".to_string(), |a, b| format!("{}-{}", a, b.replace("/", ":")));
 
 	// TODO: OLD
 	//let output = PathBuf::from(dir).join(format!("{}.parquet", name));
@@ -747,7 +747,7 @@ pub fn export(pattern: String, dir: &Path) -> Result<()> {
 	// BIGINT??
 	//let hs = format!("COPY (SELECT *, year(epoch_ms(1000*Timestamp::BIGINT)) AS year, week(epoch_ms(1000*Timestamp::BIGINT)) AS week FROM ({})) TO '{}' (FORMAT PARQUET, PARTITION_BY (year, week), OVERWRITE)", qs, output.display());
 
-	let hs = format!("COPY (SELECT *, year(Timestamp) AS year, week(Timestamp) AS week FROM ({})) TO '{}' (FORMAT PARQUET, PARTITION_BY (year, week), OVERWRITE)", qs, output.display());
+	let hs = format!("COPY (SELECT RTimestamp as Timestamp, * EXCLUDE RTimestamp, year(RTimestamp) AS year, week(RTimestamp) AS week FROM ({})) TO '{}' (FORMAT PARQUET, PARTITION_BY (year, week), OVERWRITE)", qs, output.display());
 
 	let conn = new_connection()?;
         conn.execute(&hs, [])

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -732,7 +732,10 @@ pub fn export(pattern: String, dir: &Path) -> Result<()> {
 	let cap_cnt = glob.captures().count();
 	let name = (1..=cap_cnt).
 	    map(|x| matched.get(x).unwrap().to_string()).
-	    fold("export".to_string(), |a, b| format!("{}-{}", a, b.replace("/", ":")));
+	    fold(".".to_string(), |a, b| format!("{}/{}", a, b));
+
+	let output = PathBuf::from(dir).join(format!("{}", &name));
+	std::fs::create_dir_all(&output)?;
 
 	// TODO: OLD
 	//let output = PathBuf::from(dir).join(format!("{}.parquet", name));
@@ -741,7 +744,6 @@ pub fn export(pattern: String, dir: &Path) -> Result<()> {
 	// TODO it's weird to return vec; why is Default + Expand + IntoIterator really?
 
 	// TODO WIP NEW
-	let output = PathBuf::from(dir).join(format!("{}", name));
 	let qs = wd.sql_for(ent)?;
 
 	// BIGINT??

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -615,6 +615,10 @@ impl Pond {
         glob: &Glob,
 	mut f: &mut impl FnMut(&mut WD, &DirEntry, &Vec<String>) -> Result<T>,
     ) -> Result<T> {
+	// @@@ TODO there is an easy way to go recursive here and not return.
+	// There was a typo, where "out_pattern" ("reduce-$0") was passed as
+	// the in_pattern. Since it has no slash, it was scanning the entire tree,
+	// recursing indefintely.
         let (dp, bn) = split_path(&path)?;
         self.in_path(&dp, &mut |wd: &mut WD| -> Result<T> {
             if bn == "" {

--- a/src/pond.rs
+++ b/src/pond.rs
@@ -710,15 +710,14 @@ pub fn export(pattern: String, dir: &Path) -> Result<()> {
 
 	
 	// TODO: OLD
-	wd.copy_to(ent, &mut File::create(&output).with_context(|| format!("create {}", output.display()))?)?;
+	//wd.copy_to(ent, &mut File::create(&output).with_context(|| format!("create {}", output.display()))?)?;
 
 	// TODO it's weird to return vec; why is Default + Expand + IntoIterator really?
 
 	// TODO WIP NEW
-	// let qs = wd.sql_for(ent)?;
-	// eprintln!("export query {} to {}", qs, output.display());
+	let qs = wd.sql_for(ent)?;
+	eprintln!("export query {} to {}", qs, output.display());
 
-	// Ok(())
 	Ok(vec![])
     })
 }

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -22,7 +22,7 @@ use crate::pond::tmpfile;
 use anyhow::{anyhow, Context, Result};
 //use arrow_schema::SchemaRef;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use sea_query::expr::SimpleExpr;
+//use sea_query::expr::SimpleExpr;
 use sea_query::{
     all, Alias, Asterisk, ColumnRef, CommonTableExpression, Expr, Func, Iden, Order, Query, SeaRc,
     SelectStatement, SqliteQueryBuilder, UnionType, WithClause,
@@ -50,7 +50,7 @@ pub struct Combine {
 #[derive(Iden)]
 enum DuckFunc {
     ReadParquet,
-    Coalesce,
+//  Coalesce,
 }
 
 fn table(x: usize) -> Alias {
@@ -285,21 +285,23 @@ impl TreeLike for Combine {
                 SeaRc::new(table(1)),
                 SeaRc::new(Alias::new("Timestamp")),
             ));
-	    // @@@ Q: Somehow Coalesce is not happening in any data
-	    // set. Hmmm. ???
+	    // Note that this Coalesce option does not happen with the
+	    // LT dataset because (I think) no instruments overlap in 
+	    
             for (cn, als) in fields_from {
                 if als.len() == 1 {
                     select.column(ColumnRef::Column(SeaRc::new(Alias::new(cn))));
                 } else {
-                    select.expr_as(
-                        Func::cust(DuckFunc::Coalesce).args(als.iter().map(|x| {
-                            SimpleExpr::Column(ColumnRef::TableColumn(
-                                SeaRc::new(x.clone()),
-                                SeaRc::new(Alias::new(cn.clone())),
-                            ))
-                        })),
-                        Alias::new(cn),
-                    );
+		    panic!("can't happen because UNION BY NAME")
+                    // select.expr_as(
+                    //     Func::cust(DuckFunc::Coalesce).args(als.iter().map(|x| {
+                    //         SimpleExpr::Column(ColumnRef::TableColumn(
+                    //             SeaRc::new(x.clone()),
+                    //             SeaRc::new(Alias::new(cn.clone())),
+                    //         ))
+                    //     })),
+                    //     Alias::new(cn),
+                    // );
                 }
             }
             &mut select

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -285,6 +285,8 @@ impl TreeLike for Combine {
                 SeaRc::new(table(1)),
                 SeaRc::new(Alias::new("Timestamp")),
             ));
+	    // @@@ Q: Somehow Coalesce is not happening in any data
+	    // set. Hmmm. ???
             for (cn, als) in fields_from {
                 if als.len() == 1 {
                     select.column(ColumnRef::Column(SeaRc::new(Alias::new(cn))));

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -20,7 +20,6 @@ use crate::pond::dir::Lookup;
 
 use anyhow::{anyhow, Context, Result};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-//use sea_query::expr::SimpleExpr;
 use sea_query::{
     all, Alias, Asterisk, ColumnRef, CommonTableExpression, Expr, Func, Iden, Order, Query, SeaRc,
     SelectStatement, SqliteQueryBuilder, UnionType, WithClause,
@@ -50,7 +49,7 @@ pub enum DuckFunc {
     ReadParquet,
     TimeBucket,
     EpochMs,
-//  Coalesce,
+    Avg,
 }
 
 fn table(x: usize) -> Alias {

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -18,10 +18,7 @@ use crate::pond::UniqueSpec;
 use crate::pond::tmpfile;
 use crate::pond::dir::Lookup;
 
-// use chrono::TimeZone;
-// use chrono::offset::Local;
 use anyhow::{anyhow, Context, Result};
-//use arrow_schema::SchemaRef;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 //use sea_query::expr::SimpleExpr;
 use sea_query::{
@@ -49,8 +46,10 @@ pub struct Combine {
 }
 
 #[derive(Iden)]
-enum DuckFunc {
+pub enum DuckFunc {
     ReadParquet,
+    TimeBucket,
+    EpochMs,
 //  Coalesce,
 }
 

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -16,6 +16,7 @@ use crate::pond::MultiWriter;
 use crate::pond::Pond;
 use crate::pond::UniqueSpec;
 use crate::pond::tmpfile;
+use crate::pond::dir::Lookup;
 
 // use chrono::TimeZone;
 // use chrono::offset::Local;
@@ -101,7 +102,7 @@ impl Deriver for Module {
 }
 
 impl TreeLike for Combine {
-    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _prefix: &str, _parent_node: usize) -> Result<WD<'a>> {
+    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _lookup: &Lookup) -> Result<WD<'a>> {
         Err(anyhow!("no subdirs"))
     }
 

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -50,6 +50,8 @@ pub enum DuckFunc {
     TimeBucket,
     EpochMs,
     Avg,
+    Min,
+    Max,
 }
 
 fn table(x: usize) -> Alias {

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -77,7 +77,7 @@ pub fn start(
     >,
 > {
     let instance = Rc::new(RefCell::new(Module {}));
-    pond.register_deriver(spec.dirpath(), instance);
+    pond.register_deriver(spec.kind(), 3, instance);
     start_noop(pond, spec)
 }
 
@@ -355,6 +355,9 @@ impl TreeLike for Combine {
 }
 
 fn materialize_inputs(wd: &mut WD, ent: &DirEntry, _: &Vec<String>) -> Result<Vec<PathBuf>> {
+    // @@@ TODO: Would be nice to push sql_for_version() through so that materialize
+    // is not needed, to use in-line MIN/MAX select statements for the time range,
+    // and so on?
     let mut fs = Vec::new();
     for item in wd.lookup_all(&ent.prefix) {
         match wd.realpath(&item) {

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -77,7 +77,7 @@ pub fn start(
     >,
 > {
     let instance = Rc::new(RefCell::new(Module {}));
-    pond.register_deriver(spec.kind(), 3, instance);
+    pond.register_deriver(spec.kind(), instance);
     start_noop(pond, spec)
 }
 
@@ -127,7 +127,7 @@ impl TreeLike for Combine {
         None
     }
 
-    fn entries_syn(&mut self, _pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<dyn Deriver>>>> {
+    fn entries_syn(&mut self, _pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<Box<dyn Deriver>>>>> {
         vec![DirEntry {
             prefix: "combine".to_string(),
             number: 0,
@@ -172,7 +172,7 @@ impl TreeLike for Combine {
             // First, for each series in the scope, match the glob.
             let tgt = parse_glob(&s.pattern).unwrap();
 
-            let fs = pond.visit_path(&tgt.path, &tgt.glob, &mut materialize_inputs)?;
+            let fs = pond.visit_path(&tgt.path, &tgt.glob, &mut materialize_all_inputs)?;
 	    
             let mut tree = BTreeMap::new();
             let mut allmax: i64 = 0;
@@ -355,7 +355,7 @@ impl TreeLike for Combine {
     }
 }
 
-fn materialize_inputs(wd: &mut WD, ent: &DirEntry, _: &Vec<String>) -> Result<Vec<PathBuf>> {
+fn materialize_all_inputs(wd: &mut WD, ent: &DirEntry, _: &Vec<String>) -> Result<Vec<PathBuf>> {
     // @@@ TODO: Would be nice to push sql_for_version() through so that materialize
     // is not needed, to use in-line MIN/MAX select statements for the time range,
     // and so on?

--- a/src/pond/combine.rs
+++ b/src/pond/combine.rs
@@ -127,7 +127,7 @@ impl TreeLike for Combine {
         None
     }
 
-    fn entries(&mut self, _pond: &mut Pond) -> BTreeSet<DirEntry> {
+    fn entries_syn(&mut self, _pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<dyn Deriver>>>> {
         vec![DirEntry {
             prefix: "combine".to_string(),
             number: 0,
@@ -136,8 +136,9 @@ impl TreeLike for Combine {
             size: 0,
             content: None,
         }]
-        .into_iter()
-        .collect()
+            .into_iter()
+            .map(|x| (x, None))
+            .collect()
     }
 
     fn copy_version_to<'a>(

--- a/src/pond/derive.rs
+++ b/src/pond/derive.rs
@@ -68,7 +68,7 @@ pub fn start(
     >,
 > {
     let instance = Rc::new(RefCell::new(Module {}));
-    pond.register_deriver(spec.kind(), 3, instance);
+    pond.register_deriver(spec.kind(), instance);
     start_noop(pond, spec)
 }
 
@@ -163,7 +163,7 @@ impl TreeLike for Collection {
         None
     }
 
-    fn entries_syn(&mut self, pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<dyn Deriver>>>> {
+    fn entries_syn(&mut self, pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<Box<dyn Deriver>>>>> {
         pond.visit_path(
             &self.target.deref().borrow().path,
             &self.target.deref().borrow().glob,

--- a/src/pond/derive.rs
+++ b/src/pond/derive.rs
@@ -163,11 +163,11 @@ impl TreeLike for Collection {
     }
 
     fn entries(&mut self, pond: &mut Pond) -> BTreeSet<DirEntry> {
-        let mut res = BTreeSet::new();
         pond.visit_path(
             &self.target.deref().borrow().path,
             &self.target.deref().borrow().glob,
             &mut |_wd: &mut WD, ent: &DirEntry, _: &Vec<String>| {
+		let mut res = BTreeSet::new();
                 res.insert(DirEntry {
                     prefix: ent.prefix.clone(),
                     size: 0,
@@ -180,11 +180,10 @@ impl TreeLike for Collection {
                     sha256: [0; 32],
                     content: None,
                 });
-                Ok(())
+                Ok(res)
             },
         )
-        .expect("otherwise nope");
-        res
+        .expect("otherwise nope")
     }
 
     fn copy_version_to<'a>(

--- a/src/pond/derive.rs
+++ b/src/pond/derive.rs
@@ -12,6 +12,7 @@ use crate::pond::InitContinuation;
 use crate::pond::Pond;
 use crate::pond::TreeLike;
 use crate::pond::UniqueSpec;
+use crate::pond::dir::Lookup;
 
 use anyhow::{anyhow, Context, Result};
 use duckdb::arrow::array::StructArray;
@@ -137,7 +138,7 @@ impl<'conn> Iterator for DuckArrow<'conn> {
 
 
 impl TreeLike for Collection {
-    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _prefix: &str, _parent_node: usize) -> Result<WD<'a>> {
+    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _lookup: &Lookup) -> Result<WD<'a>> {
         Err(anyhow!("no subdirs"))
     }
 

--- a/src/pond/dir.rs
+++ b/src/pond/dir.rs
@@ -59,6 +59,8 @@ pub trait TreeLike: std::fmt::Debug {
         ext: &str,
         mut to: Box<dyn Write + Send + 'a>,
     ) -> Result<()> {
+	// TODO: this could call sql_for_version for parquet files?
+	// Is the 'SELECT * FROM' needed?
         if numf == 0 {
             let files = self.realpath_all(pond, prefix);
             let qs = format!("SELECT * FROM read_parquet({:?})", files);

--- a/src/pond/dir.rs
+++ b/src/pond/dir.rs
@@ -73,6 +73,24 @@ pub trait TreeLike: std::fmt::Debug {
         }
     }
 
+    fn sql_for_version(
+        &mut self,
+        pond: &mut Pond,
+        prefix: &str,
+        numf: i32,
+        ext: &str,
+    ) -> Result<String> {
+        if numf == 0 {
+            let files = self.realpath_all(pond, prefix);
+            Ok(format!("SELECT * FROM read_parquet({:?})", files))
+        } else {
+            let path = self
+                .realpath_version(pond, prefix, numf, ext)
+                .ok_or(anyhow!("no real path {}", prefix))?;
+            Ok(format!("SELECT * FROM read_parquet({})", path.display()))
+        }
+    }
+    
     fn realpath_current(&mut self, pond: &mut Pond, prefix: &str) -> Result<Option<PathBuf>> {
         if let Some(cur) = self.lookup(pond, prefix) {
             Ok(self.realpath_version(pond, prefix, cur.number, cur.ftype.ext()))

--- a/src/pond/dir.rs
+++ b/src/pond/dir.rs
@@ -38,7 +38,7 @@ pub struct Lookup {
     pub deri: Option<Rc<RefCell<Box<dyn Deriver>>>>,
 }
 
-pub trait TreeLike: std::fmt::Debug {
+pub trait TreeLike {
     fn subdir<'a>(&mut self, pond: &'a mut Pond, lookup: &Lookup) -> Result<WD<'a>>;
 
     fn pondpath(&self, prefix: &str) -> PathBuf;

--- a/src/pond/inbox.rs
+++ b/src/pond/inbox.rs
@@ -77,7 +77,7 @@ fn inbox(wd: &mut WD, uspec: &UniqueSpec<InboxSpec>) -> Result<()> {
 
         wd.in_path(&reldir, |wd| {
             let exists = wd.lookup(&relbase);
-            if let Some(ent) = exists {
+            if let Some(ent) = exists.entry {
                 let realpath = wd
                     .realpath_version(&relbase, ent.number, ent.ftype.ext())
                     .expect("real file here");

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -1,43 +1,242 @@
-// 1 week @ 1hr = 168 points
-// 2 weeks = 336
-// 4 weeks = 672
-// 30 days = 720 = 360*2hr
-// 60 days =     = 360*4hr
-
-// select time_bucket('2 hours', epoch_ms(CAST("Timestamp"*1000 as BIGINT))) as twohours, avg("AT500_Bottom.DO.mg/L") from read_parquet('./tmp/combined-FieldStation.parquet') group by twohours order by twohours;
-
-// select "Timestamp", epoch_ms(CAST("Timestamp"*1000 as BIGINT)), "AT500_Bottom.DO.mg/L" from read_parquet('./tmp/combined-FieldStation.parquet') ;
-
-//resolution: 1h
-
 use crate::pond::UniqueSpec;
 use crate::pond::wd::WD;
 use crate::pond::Pond;
 use crate::pond::crd::ReduceSpec;
+use crate::pond::crd::ReduceDataset;
 use crate::pond::InitContinuation;
+use crate::pond::dir::FileType;
+use crate::pond::dir::DirEntry;
+use crate::pond::dir::TreeLike;
+use crate::pond::template::check_inout;
+use crate::pond::derive::copy_parquet_to;
+use crate::pond::start_noop;
+use crate::pond::MultiWriter;
+use crate::pond::Deriver;
+use crate::pond::file::read_file;
 
-use anyhow::{Result};
+use std::io::Write;
+use std::rc::Rc;
+use std::path::PathBuf;
+use std::cell::RefCell;
+use anyhow::{anyhow,Result};
+use std::collections::BTreeSet;
 
-static PARTITIONS: [&'static str; 5_] = ["year",
-			 "quarter",
-			 "month",
-			 "week",
-			 "day"
-			 ];
+#[derive(Debug)]
+pub struct ModuleByRes {}
+
+#[derive(Debug)]
+pub struct ModuleByQuery {}
+
+#[derive(Debug)]
+pub struct ReduceByRes {
+    dataset: ReduceDataset,
+    real: PathBuf,
+    relp: PathBuf,
+    entry: DirEntry,
+}
+
+#[derive(Debug)]
+pub struct ReduceByQuery {
+    dataset: ReduceDataset,
+    resolution: String,
+    real: PathBuf,
+    relp: PathBuf,
+    entry: DirEntry,
+}
+
+// static PARTITIONS: [&'static str; 5_] = ["year",
+// 			 "quarter",
+// 			 "month",
+// 			 "week",
+// 			 "day"
+// 			 ];
 
 pub fn init_func(wd: &mut WD, uspec: &UniqueSpec<ReduceSpec>, _former: Option<UniqueSpec<ReduceSpec>>) -> Result<Option<InitContinuation>> {
-    // for coll in &uspec.spec.datasets {
-    //     // _ = parse_glob(&coll.pattern)?;
-    //     // let cv = vec![coll.clone()];
-    //     // wd.write_whole_file(&coll.name, FileType::SynTree, &cv)?;
-    // }
+    for ds in &uspec.spec.datasets {
+	check_inout(&ds.in_pattern, &ds.out_pattern)?;
+
+	// @@@ Check resolutions, queries
+
+        let dv = vec![ds.clone()];
+        wd.write_whole_file(&ds.name, FileType::SynTree, &dv)?;
+    }
 
     Ok(None)
 }
 
 pub fn start(
-    _pond: &mut Pond,
-    _spec: &UniqueSpec<ReduceSpec>,
-) -> Result<()> {
-    return Ok(())
+    pond: &mut Pond,
+    spec: &UniqueSpec<ReduceSpec>,
+) -> Result<
+    Box<
+        dyn for<'a> FnOnce(&'a mut Pond) -> Result<Box<dyn FnOnce(&mut MultiWriter) -> Result<()>>>,
+    >,
+> {
+    pond.register_deriver(spec.kind(), 3, Rc::new(RefCell::new(ModuleByRes {})));
+    pond.register_deriver(spec.kind(), 4, Rc::new(RefCell::new(ModuleByQuery {})));
+    start_noop(pond, spec)
+}
+
+impl Deriver for ModuleByRes {
+    fn open_derived(
+        &self,
+        pond: &mut Pond,
+        real: &PathBuf,
+        relp: &PathBuf,
+        entry: &DirEntry,
+    ) -> Result<usize> {
+        let ds: ReduceDataset = read_file(real)?.remove(0);
+        Ok(pond.insert(Rc::new(RefCell::new(ReduceByRes {
+            dataset: ds,
+            relp: relp.clone(),
+            real: real.clone(),
+            entry: entry.clone(),
+        }))))
+    }
+}
+
+impl TreeLike for ReduceByRes {
+    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _prefix: &str, _parent_node: usize) -> Result<WD<'a>> {
+        Err(anyhow!("no subdirs"))
+    }
+
+    fn pondpath(&self, prefix: &str) -> PathBuf {
+        if prefix.is_empty() {
+            self.relp.clone()
+        } else {
+            self.relp.clone().join(prefix)
+        }
+    }
+
+    fn realpath_of(&self) -> PathBuf {
+        self.real.clone()
+    }
+
+    fn realpath_version(
+        &mut self,
+        _pond: &mut Pond,
+        _prefix: &str,
+        _numf: i32,
+        _ext: &str,
+    ) -> Option<PathBuf> {
+        None
+    }
+
+    fn entries(&mut self, _pond: &mut Pond) -> BTreeSet<DirEntry> {
+	self.dataset.resolutions.iter().map(|x| DirEntry {
+            prefix: format!("res={}", x),
+            number: 0,
+            ftype: FileType::SynTree,
+            sha256: [0; 32],
+            size: 0,
+            content: None,
+        }).collect()
+    }
+
+    fn sync(&mut self, _pond: &mut Pond) -> Result<(PathBuf, i32, usize, bool)> {
+        Ok((
+            self.real.clone(),
+            self.entry.number,
+            self.entry.size as usize, // Q@@@: ((why u64 vs usize happening?))
+            false,
+        ))
+    }
+
+    fn update(
+        &mut self,
+        _pond: &mut Pond,
+        _prefix: &str,
+        _newfile: &PathBuf,
+        _seq: i32,
+        _ftype: FileType,
+        _row_cnt: Option<usize>,
+    ) -> Result<()> {
+        Err(anyhow!("no update for synthetic trees"))
+    }
+}
+
+impl Deriver for ModuleByQuery {
+    fn open_derived(
+        &self,
+        pond: &mut Pond,
+        real: &PathBuf,
+        relp: &PathBuf,
+        entry: &DirEntry,
+    ) -> Result<usize> {
+        let ds: ReduceDataset = self.ds.clone();
+
+        Ok(pond.insert(Rc::new(RefCell::new(ReduceByQuery {
+            dataset: ds,
+	    resolution: 0, // @@@ Need to get the parent dir's
+	    // ReduceByRes object and extract res= from the path. Hmm.
+            relp: relp.clone(),
+            real: real.clone(),
+            entry: entry.clone(),
+        }))))
+    }
+}
+
+impl TreeLike for ReduceByQuery {
+    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _prefix: &str, _parent_node: usize) -> Result<WD<'a>> {
+        Err(anyhow!("no subdirs"))
+    }
+
+    fn pondpath(&self, prefix: &str) -> PathBuf {
+        if prefix.is_empty() {
+            self.relp.clone()
+        } else {
+            self.relp.clone().join(prefix)
+        }
+    }
+
+    fn realpath_of(&self) -> PathBuf {
+        self.real.clone()
+    }
+
+    fn realpath_version(
+        &mut self,
+        _pond: &mut Pond,
+        _prefix: &str,
+        _numf: i32,
+        _ext: &str,
+    ) -> Option<PathBuf> {
+        None
+    }
+
+    fn entries(&mut self, _pond: &mut Pond) -> BTreeSet<DirEntry> {
+	vec![DirEntry {
+            prefix: "reduce".to_string(),
+            number: 0,
+            ftype: FileType::SynTree,
+            sha256: [0; 32],
+            size: 0,
+            content: None,
+        }].into_iter().collect()
+    }
+
+    fn sync(&mut self, _pond: &mut Pond) -> Result<(PathBuf, i32, usize, bool)> {
+        Ok((
+            self.real.clone(),
+            self.entry.number,
+            self.entry.size as usize, // Q@@@: ((why u64 vs usize happening?))
+            false,
+        ))
+    }
+
+    fn update(
+        &mut self,
+        _pond: &mut Pond,
+        _prefix: &str,
+        _newfile: &PathBuf,
+        _seq: i32,
+        _ftype: FileType,
+        _row_cnt: Option<usize>,
+    ) -> Result<()> {
+        Err(anyhow!("no update for synthetic trees"))
+    }
+}
+
+
+pub fn run(_pond: &mut Pond, _uspec: &UniqueSpec<ReduceSpec>) -> Result<()> {
+    Ok(())
 }

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -107,8 +107,16 @@ impl Deriver for ModuleByRes {
 }
 
 impl TreeLike for ReduceByRes {
-    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _lookup: &Lookup) -> Result<WD<'a>> {
-        Err(anyhow!("no subdirs (A)"))
+    fn subdir<'a>(&mut self, pond: &'a mut Pond, lookup: &Lookup) -> Result<WD<'a>> {
+	let relp = self.pondpath(&lookup.prefix);
+	let real = PathBuf::new();
+	let entry = lookup.entry.clone().unwrap();
+	let node = lookup.deri.as_ref().unwrap().deref().borrow_mut()
+		   .open_derived(pond,
+				 &real,
+				 &relp,
+				 &entry)?;
+        Ok(WD::new(pond, node))
     }
 
     fn pondpath(&self, prefix: &str) -> PathBuf {
@@ -134,7 +142,7 @@ impl TreeLike for ReduceByRes {
     }
 
     fn entries_syn(&mut self, _pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<Box<dyn Deriver>>>>> {
-	let target = Rc::new(RefCell::new(parse_glob(&self.dataset.out_pattern).unwrap()));
+	let target = Rc::new(RefCell::new(parse_glob(&self.dataset.in_pattern).unwrap()));
 
 	self.dataset.resolutions.iter().map(|res| {
 	    let dbox: Box<dyn Deriver + 'static> = Box::new(ModuleByQuery{

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -320,7 +320,7 @@ impl TreeLike for ReduceByQuery {
 					 SeaRc::new(Alias::new("Timestamp")))),
 				 Alias::new("BIGINT")))
 			      .binary(BinOper::Mul, Expr::val(1000)))),
-		Alias::new("T"))
+		Alias::new("Timestamp"))
 	    .to_owned();
 
         for f in pf.schema().fields() {
@@ -356,8 +356,8 @@ impl TreeLike for ReduceByQuery {
                     .arg(Expr::val(format!("{}", path.display()))),
                 Alias::new("IN".to_string()),
 	    )
-                   .group_by_col(Alias::new("T"))
-            .order_by(Alias::new("T"), Order::Asc)
+                   .group_by_col(Alias::new("Timestamp"))
+            .order_by(Alias::new("Timestamp"), Order::Asc)
             .to_owned();
 
 	Ok(qs.to_string(SqliteQueryBuilder))

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -311,7 +311,23 @@ impl TreeLike for ReduceByQuery {
 	let mut qs = Query::select()
 	    .expr_as(
                 Func::cust(DuckFunc::TimeBucket)
-                    .arg(Expr::val(res_to_sql_interval(self.resolution)))
+                    .arg(Expr::custom_keyword(Alias::new(format!("INTERVAL {}", res_to_sql_interval(self.resolution)))))
+
+		// Note! Some of the commented sections may instead
+		// work for the Combine table, but the Reduce table
+		// has a Timestamp type for its Timestamp column.
+
+                    // .arg(SimpleExpr::Column(
+		    // 	ColumnRef::Column(
+		    // 	    SeaRc::new(Alias::new("Timestamp"))))),
+
+                    // .arg(Func::cust(DuckFunc::EpochMs)
+		    // 	 .arg(
+		    // 		 SimpleExpr::Column(
+		    // 		     ColumnRef::Column(
+		    // 			 SeaRc::new(Alias::new("Timestamp"))))
+		    // 	      .binary(BinOper::Mul, Expr::val(1000)))),
+
                     .arg(Func::cust(DuckFunc::EpochMs)
 			 .arg(SimpleExpr::FunctionCall(
 			     Func::cast_as(
@@ -320,6 +336,7 @@ impl TreeLike for ReduceByQuery {
 					 SeaRc::new(Alias::new("Timestamp")))),
 				 Alias::new("BIGINT")))
 			      .binary(BinOper::Mul, Expr::val(1000)))),
+
 		Alias::new("Timestamp"))
 	    .to_owned();
 

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -163,7 +163,8 @@ impl TreeLike for ReduceLevel1 {
             &mut |wd: &mut WD, ent: &DirEntry, captures: &Vec<String>| {
 
 		let name = glob_placeholder(captures, &self.dataset.out_pattern)?;
-	
+
+		// @@@ This is being called too often, need to cache it.
 		let path = materialize_one_input(wd, ent, captures)?.get(0).unwrap().clone();
 		let mut res = BTreeMap::new();
 

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -1,0 +1,43 @@
+// 1 week @ 1hr = 168 points
+// 2 weeks = 336
+// 4 weeks = 672
+// 30 days = 720 = 360*2hr
+// 60 days =     = 360*4hr
+
+// select time_bucket('2 hours', epoch_ms(CAST("Timestamp"*1000 as BIGINT))) as twohours, avg("AT500_Bottom.DO.mg/L") from read_parquet('./tmp/combined-FieldStation.parquet') group by twohours order by twohours;
+
+// select "Timestamp", epoch_ms(CAST("Timestamp"*1000 as BIGINT)), "AT500_Bottom.DO.mg/L" from read_parquet('./tmp/combined-FieldStation.parquet') ;
+
+//resolution: 1h
+
+use crate::pond::UniqueSpec;
+use crate::pond::wd::WD;
+use crate::pond::Pond;
+use crate::pond::crd::ReduceSpec;
+use crate::pond::InitContinuation;
+
+use anyhow::{Result};
+
+static PARTITIONS: [&'static str; 5_] = ["year",
+			 "quarter",
+			 "month",
+			 "week",
+			 "day"
+			 ];
+
+pub fn init_func(wd: &mut WD, uspec: &UniqueSpec<ReduceSpec>, _former: Option<UniqueSpec<ReduceSpec>>) -> Result<Option<InitContinuation>> {
+    // for coll in &uspec.spec.datasets {
+    //     // _ = parse_glob(&coll.pattern)?;
+    //     // let cv = vec![coll.clone()];
+    //     // wd.write_whole_file(&coll.name, FileType::SynTree, &cv)?;
+    // }
+
+    Ok(None)
+}
+
+pub fn start(
+    _pond: &mut Pond,
+    _spec: &UniqueSpec<ReduceSpec>,
+) -> Result<()> {
+    return Ok(())
+}

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -337,7 +337,7 @@ impl TreeLike for ReduceByQuery {
 				 Alias::new("BIGINT")))
 			      .binary(BinOper::Mul, Expr::val(1000)))),
 
-		Alias::new("Timestamp"))
+		Alias::new("RTimestamp"))
 	    .to_owned();
 
         for f in pf.schema().fields() {
@@ -373,8 +373,8 @@ impl TreeLike for ReduceByQuery {
                     .arg(Expr::val(format!("{}", path.display()))),
                 Alias::new("IN".to_string()),
 	    )
-                   .group_by_col(Alias::new("Timestamp"))
-            .order_by(Alias::new("Timestamp"), Order::Asc)
+                   .group_by_col(Alias::new("RTimestamp"))
+            .order_by(Alias::new("RTimestamp"), Order::Asc)
             .to_owned();
 
 	Ok(qs.to_string(SqliteQueryBuilder))

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -1,31 +1,30 @@
-use crate::pond::UniqueSpec;
-use crate::pond::wd::WD;
-use crate::pond::Pond;
-use crate::pond::crd::ReduceSpec;
-use crate::pond::crd::ReduceDataset;
-use crate::pond::InitContinuation;
-use crate::pond::dir::FileType;
-use crate::pond::dir::DirEntry;
-use crate::pond::dir::TreeLike;
-use crate::pond::template::check_inout;
-use crate::pond::derive::copy_parquet_to;
-use crate::pond::derive::Target;
-use crate::pond::derive::parse_glob;
-use crate::pond::template::glob_placeholder;
-use crate::pond::start_noop;
-use crate::pond::MultiWriter;
-use crate::pond::Deriver;
-use crate::pond::file::read_file;
-use crate::pond::tmpfile;
-use crate::pond::dir::Lookup;
 use crate::pond::combine::DuckFunc;
+use crate::pond::crd::ReduceDataset;
+use crate::pond::crd::ReduceSpec;
+use crate::pond::derive::copy_parquet_to;
+use crate::pond::derive::parse_glob;
+use crate::pond::dir::DirEntry;
+use crate::pond::dir::FileType;
+use crate::pond::dir::Lookup;
+use crate::pond::dir::TreeLike;
+use crate::pond::file::read_file;
+use crate::pond::split_path;
+use crate::pond::start_noop;
+use crate::pond::template::check_inout;
+use crate::pond::template::glob_placeholder;
+use crate::pond::tmpfile;
+use crate::pond::wd::WD;
+use crate::pond::Deriver;
+use crate::pond::InitContinuation;
+use crate::pond::MultiWriter;
+use crate::pond::Pond;
+use crate::pond::UniqueSpec;
 
-use anyhow::{anyhow,Result,Context};
-use parse_duration::parse;
+use anyhow::{anyhow, Context, Result};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parse_duration::parse;
 use sea_query::{
-    Alias, BinOper, ColumnRef, Expr, Func, Order,
-    Query, SeaRc, SimpleExpr, SqliteQueryBuilder,
+    Alias, BinOper, ColumnRef, Expr, Func, Order, Query, SeaRc, SimpleExpr, SqliteQueryBuilder,
 };
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -36,51 +35,65 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
 
-#[derive(Debug)]
+/// ModuleLevel1 synthesizes each top-level data set.  This SynTree
+/// contains an object for each in_pattern match.
 pub struct ModuleLevel1 {}
 
-#[derive(Debug)]
+/// ModuleLevel2 synthesizes a folder for every resolution.
 pub struct ModuleLevel2 {
-    path: PathBuf,
+    boxed: Rc<RefCell<LazyMaterialize>>,
     dataset: ReduceDataset,
 }
 
-#[derive(Debug)]
+/// LazyMaterialize defers materializing the input data until it is
+/// read.
+struct LazyMaterialize {
+    materialize: Option<Box<dyn FnOnce(&mut Pond) -> PathBuf>>,
+    path: Option<PathBuf>,
+}
+
+/// ReduceLevel1 corresponds with a single dataset.  Listing returns
+/// one entry per in_pattern match.
 pub struct ReduceLevel1 {
     dataset: ReduceDataset,
-    target: Rc<RefCell<Target>>,
+    ents: BTreeMap<String, Rc<RefCell<LazyMaterialize>>>,
     real: PathBuf,
     relp: PathBuf,
     entry: DirEntry,
 }
 
-#[derive(Debug)]
+/// ReduceLevel1 corresponds with a single match.  Listing returns one
+/// entry per resolution.
 pub struct ReduceLevel2 {
     dataset: ReduceDataset,
-    materialized: PathBuf,
+    lazy: Rc<RefCell<LazyMaterialize>>,
     real: PathBuf,
     relp: PathBuf,
     entry: DirEntry,
 }
 
-pub fn init_func(wd: &mut WD, uspec: &UniqueSpec<ReduceSpec>, _former: Option<UniqueSpec<ReduceSpec>>) -> Result<Option<InitContinuation>> {
+pub fn init_func(
+    wd: &mut WD,
+    uspec: &UniqueSpec<ReduceSpec>,
+    _former: Option<UniqueSpec<ReduceSpec>>,
+) -> Result<Option<InitContinuation>> {
     for ds in &uspec.spec.datasets {
-	check_inout(&ds.in_pattern, &ds.out_pattern)?;
+        check_inout(&ds.in_pattern, &ds.out_pattern)?;
 
-	for (_name, ops) in &ds.queries {
-	    for op in ops {
-		match op.as_str() {
-		    "avg"|"min"|"max" => {},
-		    _ => {
-			return Err(anyhow!("unrecognized operator {}", op));
-		    }
-		}
-	    }
-	}
+        for (_name, ops) in &ds.queries {
+            for op in ops {
+                match op.as_str() {
+                    "avg" | "min" | "max" => {}
+                    _ => {
+                        return Err(anyhow!("unrecognized operator {}", op));
+                    }
+                }
+            }
+        }
 
-	for res in &ds.resolutions {
-	    parse(res)?;
-	}
+        for res in &ds.resolutions {
+            parse(res)?;
+        }
 
         let dv = vec![ds.clone()];
         wd.write_whole_file(&ds.name, FileType::SynTree, &dv)?;
@@ -89,6 +102,7 @@ pub fn init_func(wd: &mut WD, uspec: &UniqueSpec<ReduceSpec>, _former: Option<Un
     Ok(None)
 }
 
+/// start registers a top-level deriver for Reduce resources.
 pub fn start(
     pond: &mut Pond,
     spec: &UniqueSpec<ReduceSpec>,
@@ -102,6 +116,7 @@ pub fn start(
 }
 
 impl Deriver for ModuleLevel1 {
+    /// At the top level,
     fn open_derived(
         &self,
         pond: &mut Pond,
@@ -110,10 +125,33 @@ impl Deriver for ModuleLevel1 {
         entry: &DirEntry,
     ) -> Result<usize> {
         let ds: ReduceDataset = read_file(real)?.remove(0);
-	let target = Rc::new(RefCell::new(parse_glob(&ds.in_pattern).unwrap()));
+        let target = parse_glob(&ds.in_pattern)?;
+
+        // Here evaluate the input pattern and form the matching output
+        // names.  Remember the full path (can't keep a `pond` reference)
+        // of the input, box a function to materialize that path lazily.
+        let ents = pond
+            .visit_path(
+                &target.path,
+                &target.glob,
+                &mut |wd: &mut WD, ent: &DirEntry, captures: &Vec<String>| {
+                    let name = glob_placeholder(captures, &ds.out_pattern)?;
+                    let fullp = wd.pondpath(&ent.prefix);
+
+                    let pbox: Box<dyn FnOnce(&mut Pond) -> PathBuf> =
+                        Box::new(|pond: &mut Pond| materialize_one_input(pond, fullp).unwrap());
+
+                    let mut res = BTreeMap::new();
+
+                    res.insert(name, Rc::new(RefCell::new(LazyMaterialize::new(pbox))));
+                    Ok(res)
+                },
+            )
+            .expect("otherwise nope");
+
         Ok(pond.insert(Rc::new(RefCell::new(ReduceLevel1 {
             dataset: ds,
-	    target: target.clone(),
+            ents: ents,
             relp: relp.clone(),
             real: real.clone(),
             entry: entry.clone(),
@@ -123,14 +161,18 @@ impl Deriver for ModuleLevel1 {
 
 impl TreeLike for ReduceLevel1 {
     fn subdir<'a>(&mut self, pond: &'a mut Pond, lookup: &Lookup) -> Result<WD<'a>> {
-	let relp = self.pondpath(&lookup.prefix);
-	let real = PathBuf::new();
-	let entry = lookup.entry.clone().unwrap();
-	let node = lookup.deri.as_ref().unwrap().deref().borrow_mut()
-		   .open_derived(pond,
-				 &real,
-				 &relp,
-				 &entry)?;
+        // Second-level lookup using the deriver returned from
+        // first-level entries.
+        let relp = self.pondpath(&lookup.prefix);
+        let real = PathBuf::new();
+        let entry = lookup.entry.clone().unwrap();
+        let node = lookup
+            .deri
+            .as_ref()
+            .unwrap()
+            .deref()
+            .borrow_mut()
+            .open_derived(pond, &real, &relp, &entry)?;
         Ok(WD::new(pond, node))
     }
 
@@ -156,44 +198,40 @@ impl TreeLike for ReduceLevel1 {
         None
     }
 
-    fn entries_syn(&mut self, pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<Box<dyn Deriver>>>>> {
-        pond.visit_path(
-            &self.target.deref().borrow().path,
-            &self.target.deref().borrow().glob,
-            &mut |wd: &mut WD, ent: &DirEntry, captures: &Vec<String>| {
+    fn entries_syn(
+        &mut self,
+        _pond: &mut Pond,
+    ) -> BTreeMap<DirEntry, Option<Rc<RefCell<Box<dyn Deriver>>>>> {
+        // For each entry, construct a deriver with a reference to the
+        // the lazy materialize function.
+        let mut res = BTreeMap::new();
+        for (name, boxed) in &self.ents {
+            let dbox: Box<dyn Deriver + 'static> = Box::new(ModuleLevel2 {
+                boxed: boxed.clone(),
+                dataset: self.dataset.clone(),
+            });
+            let dder: Rc<RefCell<Box<dyn Deriver>>> = Rc::new(RefCell::new(dbox));
 
-		let name = glob_placeholder(captures, &self.dataset.out_pattern)?;
-
-		// @@@ This is being called too often, need to cache it.
-		let path = materialize_one_input(wd, ent, captures)?.get(0).unwrap().clone();
-		let mut res = BTreeMap::new();
-
-		let dbox: Box<dyn Deriver + 'static> = Box::new(ModuleLevel2{
-		    path: path,
-		    dataset: self.dataset.clone(),
-		});
-		let dder: std::option::Option<Rc<RefCell<Box<dyn Deriver>>>> =
-		    Some(Rc::new(RefCell::new(dbox)));
-		
-                res.insert(DirEntry {
-                    prefix: name,
+            res.insert(
+                DirEntry {
+                    prefix: name.clone(),
                     size: 0,
                     number: 1,
                     ftype: FileType::SynTree,
                     sha256: [0; 32],
                     content: None,
-                }, dder);
-                Ok(res)
-            },
-        )
-            .expect("otherwise nope")
+                },
+                Some(dder),
+            );
+        }
+        res
     }
 
     fn sync(&mut self, _pond: &mut Pond) -> Result<(PathBuf, i32, usize, bool)> {
         Ok((
             self.real.clone(),
             self.entry.number,
-            self.entry.size as usize, // Q@@@: ((why u64 vs usize happening?))
+            self.entry.size as usize,
             false,
         ))
     }
@@ -221,7 +259,7 @@ impl Deriver for ModuleLevel2 {
     ) -> Result<usize> {
         Ok(pond.insert(Rc::new(RefCell::new(ReduceLevel2 {
             dataset: self.dataset.clone(),
-	    materialized: self.path.clone(),
+            lazy: self.boxed.clone(),
             relp: relp.clone(),
             real: real.clone(),
             entry: entry.clone(),
@@ -231,26 +269,26 @@ impl Deriver for ModuleLevel2 {
 
 fn res_to_sql_interval(dur: Duration) -> String {
     if dur >= Duration::from_days(365) {
-	return "1 year".to_string();
+        return "1 year".to_string();
     } else if dur >= Duration::from_days(90) {
-	return "1 quarter".to_string();
+        return "1 quarter".to_string();
     } else if dur >= Duration::from_days(30) {
-	return "1 month".to_string();
+        return "1 month".to_string();
     } else if dur >= Duration::from_days(7) {
-	return "1 week".to_string();
+        return "1 week".to_string();
     } else if dur >= Duration::from_days(1) {
-	return "1 day".to_string();
+        return "1 day".to_string();
     }
 
     let hrs = dur.as_secs() / 3600;
     if hrs >= 1 {
-	return format!("{} hours", hrs);
+        return format!("{} hours", hrs);
     }
     let mins = dur.as_secs() / 60;
     if mins >= 1 {
-	return format!("{} minutes", mins);
+        return format!("{} minutes", mins);
     }
-    return format!("{} seconds", dur.as_secs())
+    return format!("{} seconds", dur.as_secs());
 }
 
 impl TreeLike for ReduceLevel2 {
@@ -288,113 +326,132 @@ impl TreeLike for ReduceLevel2 {
         ext: &str,
         to: Box<dyn Write + Send + 'a>,
     ) -> Result<()> {
-	copy_parquet_to(self.sql_for_version(pond, prefix, numf, ext)?, to)
+        copy_parquet_to(self.sql_for_version(pond, prefix, numf, ext)?, to)
     }
 
     fn sql_for_version(
         &mut self,
-        _pond: &mut Pond,
+        pond: &mut Pond,
         prefix: &str,
         _numf: i32,
         _ext: &str,
     ) -> Result<String> {
-	let fh = File::open(&self.materialized)?;
-	let pf = ParquetRecordBatchReaderBuilder::try_new(fh)?;
+        // Note that we materialize in order to get the schema.
+        let fh = File::open(self.lazy.deref().borrow_mut().get(pond))?;
+        let pf = ParquetRecordBatchReaderBuilder::try_new(fh)?;
 
-	// Parse the prefix to recover res={} -- we avoid use of
-	// a deriver here but note it's a redundant parse operation.
-	let resolution = parse(&prefix[4..])?;
+        // Parse the prefix to recover res={} -- we avoid use of
+        // a deriver here but note it's a redundant parse operation.
+        let resolution = parse(&prefix[4..])?;
 
-	let mut qs = Query::select()
-	    .expr_as(
+        let mut qs = Query::select()
+            .expr_as(
                 Func::cust(DuckFunc::TimeBucket)
-                    .arg(Expr::custom_keyword(Alias::new(format!("INTERVAL {}", res_to_sql_interval(resolution)))))
-
-		// Note! Some of the commented sections may instead
-		// work for the Combine table, but the Reduce table
-		// has a Timestamp type for its Timestamp column.
-
+                    .arg(Expr::custom_keyword(Alias::new(format!(
+                        "INTERVAL {}",
+                        res_to_sql_interval(resolution)
+                    ))))
+                    // Note! Some of the commented sections may instead
+                    // work for the Combine table, but the Reduce table
+                    // has a Timestamp type for its Timestamp column.
                     // .arg(SimpleExpr::Column(
-		    // 	ColumnRef::Column(
-		    // 	    SeaRc::new(Alias::new("Timestamp"))))),
-
+                    // 	ColumnRef::Column(
+                    // 	    SeaRc::new(Alias::new("Timestamp"))))),
                     // .arg(Func::cust(DuckFunc::EpochMs)
-		    // 	 .arg(
-		    // 		 SimpleExpr::Column(
-		    // 		     ColumnRef::Column(
-		    // 			 SeaRc::new(Alias::new("Timestamp"))))
-		    // 	      .binary(BinOper::Mul, Expr::val(1000)))),
-
-                    .arg(Func::cust(DuckFunc::EpochMs)
-			 .arg(SimpleExpr::FunctionCall(
-			     Func::cast_as(
-				 SimpleExpr::Column(
-				     ColumnRef::Column(
-					 SeaRc::new(Alias::new("Timestamp")))),
-				 Alias::new("BIGINT")))
-			      .binary(BinOper::Mul, Expr::val(1000)))),
-
-		Alias::new("RTimestamp"))
-	    .to_owned();
+                    // 	 .arg(
+                    // 		 SimpleExpr::Column(
+                    // 		     ColumnRef::Column(
+                    // 			 SeaRc::new(Alias::new("Timestamp"))))
+                    // 	      .binary(BinOper::Mul, Expr::val(1000)))),
+                    .arg(
+                        Func::cust(DuckFunc::EpochMs).arg(
+                            SimpleExpr::FunctionCall(Func::cast_as(
+                                SimpleExpr::Column(ColumnRef::Column(SeaRc::new(Alias::new(
+                                    "Timestamp",
+                                )))),
+                                Alias::new("BIGINT"),
+                            ))
+                            .binary(BinOper::Mul, Expr::val(1000)),
+                        ),
+                    ),
+                Alias::new("RTimestamp"),
+            )
+            .to_owned();
 
         for f in pf.schema().fields() {
             if f.name().to_lowercase() == "timestamp" {
-		continue;
-	    }
+                continue;
+            }
 
-	    let ops = self.dataset.queries.get(f.name())
-		.cloned()
-		.or_else(|| Some(vec!["avg".to_string()])).unwrap();
+            let ops = self
+                .dataset
+                .queries
+                .get(f.name())
+                .cloned()
+                .or_else(|| Some(vec!["avg".to_string()]))
+                .unwrap();
 
-	    for op in &ops {
-		let opexpr = match op.as_str() {
-		    "avg" => Func::cust(DuckFunc::Avg),
-		    "min" => Func::cust(DuckFunc::Min),
-		    "max" => Func::cust(DuckFunc::Max),
-		    _ => panic!("unchecked function"),
-		};
-		qs = qs.expr_as(
-		    opexpr
-			.arg(
-			    SimpleExpr::Column(
-				ColumnRef::Column(
-				    SeaRc::new(Alias::new(f.name()))))),
-		    Alias::new(format!("{}.{}", f.name(), op)),
-		).to_owned();
-	    }
-	}
+            for op in &ops {
+                let opexpr = match op.as_str() {
+                    "avg" => Func::cust(DuckFunc::Avg),
+                    "min" => Func::cust(DuckFunc::Min),
+                    "max" => Func::cust(DuckFunc::Max),
+                    _ => panic!("unchecked function"),
+                };
+                qs = qs
+                    .expr_as(
+                        opexpr.arg(SimpleExpr::Column(ColumnRef::Column(SeaRc::new(
+                            Alias::new(f.name()),
+                        )))),
+                        Alias::new(format!("{}.{}", f.name(), op)),
+                    )
+                    .to_owned();
+            }
+        }
 
-	qs = qs
+        qs = qs
             .from_function(
-                Func::cust(DuckFunc::ReadParquet)
-                    .arg(Expr::val(format!("{}", self.materialized.display()))),
+                Func::cust(DuckFunc::ReadParquet).arg(Expr::val(format!(
+                    "{}",
+                    self.lazy.deref().borrow_mut().get(pond).display()
+                ))),
                 Alias::new("IN".to_string()),
-	    )
-                   .group_by_col(Alias::new("RTimestamp"))
+            )
+            .group_by_col(Alias::new("RTimestamp"))
             .order_by(Alias::new("RTimestamp"), Order::Asc)
             .to_owned();
 
-	Ok(qs.to_string(SqliteQueryBuilder))
+        Ok(qs.to_string(SqliteQueryBuilder))
     }
 
-    fn entries_syn(&mut self, _pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<Box<dyn Deriver>>>>> {
-	self.dataset.resolutions.iter().map(|res| {
-	    (DirEntry {
-		prefix: format!("res={}", *res),
-		number: 0,
-		ftype: FileType::Series,
-		sha256: [0; 32],
-		size: 0,
-		content: None,
-            }, None)
-	}).collect()
+    fn entries_syn(
+        &mut self,
+        _pond: &mut Pond,
+    ) -> BTreeMap<DirEntry, Option<Rc<RefCell<Box<dyn Deriver>>>>> {
+        self.dataset
+            .resolutions
+            .iter()
+            .map(|res| {
+                (
+                    DirEntry {
+                        prefix: format!("res={}", *res),
+                        number: 0,
+                        ftype: FileType::Series,
+                        sha256: [0; 32],
+                        size: 0,
+                        content: None,
+                    },
+                    None,
+                )
+            })
+            .collect()
     }
 
     fn sync(&mut self, _pond: &mut Pond) -> Result<(PathBuf, i32, usize, bool)> {
         Ok((
             self.real.clone(),
             self.entry.number,
-            self.entry.size as usize, // Q@@@: ((why u64 vs usize happening?))
+            self.entry.size as usize,
             false,
         ))
     }
@@ -412,29 +469,54 @@ impl TreeLike for ReduceLevel2 {
     }
 }
 
-
 pub fn run(_pond: &mut Pond, _uspec: &UniqueSpec<ReduceSpec>) -> Result<()> {
     Ok(())
 }
 
-fn materialize_one_input(wd: &mut WD, ent: &DirEntry, _: &Vec<String>) -> Result<Vec<PathBuf>> {
-    // @@@ Copied from combine::materialize_all_inputs
-    let mut fs = Vec::new();
-    if let Some(item) = wd.lookup(&ent.prefix).entry {
-        match wd.realpath(&item) {
-	    None => {
-                // Materialize the output.
-                let tfn = tmpfile("parquet");
-                let mut file = File::create(&tfn)
-		    .with_context(|| format!("open {}", tfn.display()))?;
-                wd.copy_to(&item, &mut file)?;
-                fs.push(tfn);
-	    }
-	    Some(path) => {
-                // Real file.
-                fs.push(path);
-	    }
+fn materialize_one_input(pond: &mut Pond, fullp: PathBuf) -> Result<PathBuf> {
+    // Note: Derived from combine::materialize_all_inputs
+    let (dn, bn) = split_path(&fullp)?;
+
+    pond.in_path(dn, |wd| {
+        if let Some(item) = wd.lookup(&bn).entry {
+            match wd.realpath(&item) {
+                None => {
+                    // Materialize the output.
+                    let tfn = tmpfile("parquet");
+                    let mut file =
+                        File::create(&tfn).with_context(|| format!("open {}", tfn.display()))?;
+                    wd.copy_to(&item, &mut file)?;
+                    Ok(tfn)
+                }
+                Some(path) => {
+                    // Real file.
+                    Ok(path)
+                }
+            }
+        } else {
+            Err(anyhow!(
+                "did not match materialize path {}",
+                fullp.display()
+            ))
         }
-    };
-    Ok(fs)
-}    
+    })
+}
+
+impl LazyMaterialize {
+    fn new(mf: Box<dyn FnOnce(&mut Pond) -> PathBuf>) -> Self {
+        LazyMaterialize {
+            materialize: Some(mf),
+            path: None,
+        }
+    }
+
+    fn get(&mut self, pond: &mut Pond) -> PathBuf {
+        if self.path.is_some() {
+            return self.path.clone().unwrap();
+        }
+
+        self.path = Some((self.materialize.take().unwrap())(pond));
+
+        self.path.as_ref().unwrap().clone()
+    }
+}

--- a/src/pond/reduce.rs
+++ b/src/pond/reduce.rs
@@ -17,6 +17,7 @@ use crate::pond::MultiWriter;
 use crate::pond::Deriver;
 use crate::pond::file::read_file;
 use crate::pond::tmpfile;
+use crate::pond::dir::Lookup;
 
 use parse_duration::parse;
 use std::io::Write;
@@ -106,8 +107,8 @@ impl Deriver for ModuleByRes {
 }
 
 impl TreeLike for ReduceByRes {
-    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _prefix: &str, _parent_node: usize) -> Result<WD<'a>> {
-        Err(anyhow!("no subdirs"))
+    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _lookup: &Lookup) -> Result<WD<'a>> {
+        Err(anyhow!("no subdirs (A)"))
     }
 
     fn pondpath(&self, prefix: &str) -> PathBuf {
@@ -197,8 +198,9 @@ impl Deriver for ModuleByQuery {
 }
 
 impl TreeLike for ReduceByQuery {
-    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _prefix: &str, _parent_node: usize) -> Result<WD<'a>> {
-        Err(anyhow!("no subdirs"))
+    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _lookup: &Lookup) -> Result<WD<'a>> {
+        Err(anyhow!("no subdirs (B)"))
+	//Ok(lookup.deri.unwrap().deref().borrow_mut().open_derived(pond))
     }
 
     fn pondpath(&self, prefix: &str) -> PathBuf {
@@ -318,7 +320,7 @@ pub fn run(_pond: &mut Pond, _uspec: &UniqueSpec<ReduceSpec>) -> Result<()> {
 fn materialize_one_input(wd: &mut WD, ent: &DirEntry, _: &Vec<String>) -> Result<Vec<PathBuf>> {
     // @@@ Copied from combine::materialize_all_inputs
     let mut fs = Vec::new();
-    if let Some(item) = wd.lookup(&ent.prefix) {
+    if let Some(item) = wd.lookup(&ent.prefix).entry {
         match wd.realpath(&item) {
 	    None => {
                 // Materialize the output.

--- a/src/pond/template.rs
+++ b/src/pond/template.rs
@@ -181,7 +181,6 @@ impl TreeLike for Collection {
     }
 
     fn entries(&mut self, pond: &mut Pond) -> BTreeSet<DirEntry> {
-        let mut res = BTreeSet::new();
         pond.visit_path(
             &self.target.deref().borrow().path,
             &self.target.deref().borrow().glob,
@@ -205,6 +204,7 @@ impl TreeLike for Collection {
 
 		name.push_str(&self.out_pattern[start..self.out_pattern.len()]);
 		
+		let mut res = BTreeSet::new();
                 res.insert(DirEntry {
                     prefix: name,
                     size: 0,
@@ -213,11 +213,10 @@ impl TreeLike for Collection {
                     sha256: [0; 32],
                     content: None,
                 });
-                Ok(())
+                Ok(res)
             },
         )
-            .expect("otherwise nope");
-        res
+            .expect("otherwise nope")
     }
 
     fn copy_version_to<'a>(

--- a/src/pond/template.rs
+++ b/src/pond/template.rs
@@ -15,6 +15,7 @@ use crate::pond::TreeLike;
 use crate::pond::UniqueSpec;
 use crate::pond::split_path;
 use crate::pond::tmpfile;
+use crate::pond::dir::Lookup;
 
 use anyhow::{anyhow, Context, Result};
 use std::cell::RefCell;
@@ -183,7 +184,7 @@ pub fn glob_placeholder(captures: &Vec<String>, pattern: &str) -> Result<String>
 }
 
 impl TreeLike for Collection {
-    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _prefix: &str, _parent_node: usize) -> Result<WD<'a>> {
+    fn subdir<'a>(&mut self, _pond: &'a mut Pond, _lookup: &Lookup) -> Result<WD<'a>> {
 	Err(anyhow!("no subdirs"))
     }
 
@@ -252,7 +253,7 @@ impl TreeLike for Collection {
 	// TODO: Note we're materializing files for which we could've stored
 	// the schema.  This is not efficient!
 	let mpath = pond.in_path(dp, |d| {
-	    let item = d.lookup(&bn).ok_or(anyhow!("reconstructed path not found {}", &rec))?;
+	    let item = d.lookup(&bn).entry.ok_or(anyhow!("reconstructed path not found {}", &rec))?;
             match d.realpath(&item) {
 		None => {
                     // Materialize the output.

--- a/src/pond/template.rs
+++ b/src/pond/template.rs
@@ -18,7 +18,7 @@ use crate::pond::tmpfile;
 
 use anyhow::{anyhow, Context, Result};
 use std::cell::RefCell;
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::io::Write;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -186,7 +186,7 @@ impl TreeLike for Collection {
         None
     }
 
-    fn entries(&mut self, pond: &mut Pond) -> BTreeSet<DirEntry> {
+    fn entries_syn(&mut self, pond: &mut Pond) -> BTreeMap<DirEntry, Option<Rc<RefCell<dyn Deriver>>>> {
         pond.visit_path(
             &self.target.deref().borrow().path,
             &self.target.deref().borrow().glob,
@@ -210,7 +210,7 @@ impl TreeLike for Collection {
 
 		name.push_str(&self.out_pattern[start..self.out_pattern.len()]);
 		
-		let mut res = BTreeSet::new();
+		let mut res = BTreeMap::new();
                 res.insert(DirEntry {
                     prefix: name,
                     size: 0,
@@ -218,7 +218,7 @@ impl TreeLike for Collection {
                     ftype: FileType::Data,
                     sha256: [0; 32],
                     content: None,
-                });
+                }, None);
                 Ok(res)
             },
         )

--- a/src/pond/wd.rs
+++ b/src/pond/wd.rs
@@ -72,7 +72,6 @@ impl<'a> WD<'a> {
     where
         F: FnOnce(&mut WD) -> Result<T>,
     {
-	eprintln!("in_path for {}", path.as_ref().display());
         let mut comp = path.as_ref().components();
         let mut first = comp.next();
 

--- a/src/pond/wd.rs
+++ b/src/pond/wd.rs
@@ -180,6 +180,22 @@ impl<'a> WD<'a> {
         }
     }
 
+    pub fn sql_for_version(
+        &mut self,
+        prefix: &str,
+        numf: i32,
+        ext: &str,
+    ) -> Result<String> {
+        self.d()
+            .deref()
+            .borrow_mut()
+            .sql_for_version(self.pond, prefix, numf, ext)
+    }
+
+    pub fn sql_for(&mut self, ent: &DirEntry) -> Result<String> {
+        self.sql_for_version(&ent.prefix, ent.number, ent.ftype.ext())
+    }
+
     /// check performs a consistency check on this working directory.
     pub fn check(&mut self) -> Result<()> {
 	// read the real entries in the file system.

--- a/src/pond/wd.rs
+++ b/src/pond/wd.rs
@@ -6,6 +6,7 @@ use crate::pond::file;
 use crate::pond::writer::MultiWriter;
 use crate::pond::ForArrow;
 use crate::pond::Pond;
+use crate::pond::Deriver;
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -143,6 +144,10 @@ impl<'a> WD<'a> {
         self.d().deref().borrow_mut().lookup(self.pond, prefix)
     }
 
+    pub fn lookup_syn(&mut self, prefix: &str) -> Option<(DirEntry, Option<Rc<RefCell<Box<dyn Deriver>>>>)> {
+        self.d().deref().borrow_mut().lookup_syn(self.pond, prefix)
+    }
+    
     pub fn realpath_version(&mut self, prefix: &str, num: i32, ext: &str) -> Option<PathBuf> {
         self.d()
             .deref()

--- a/src/pond/wd.rs
+++ b/src/pond/wd.rs
@@ -268,6 +268,11 @@ impl<'a> WD<'a> {
             if ent.ftype == FileType::Tree {
                 continue;
             }
+	    // @@@ Ignoring symlinks
+            if ent.ftype == FileType::SymLink {
+                continue;
+            }
+	    
             // Build the set of existing verions by prefix
             let pkey = (ent.prefix.clone(), ent.ftype.ext().to_string());
             match presuf_idxs.get_mut(&pkey) {

--- a/src/pond/wd.rs
+++ b/src/pond/wd.rs
@@ -22,7 +22,6 @@ use std::ops::Deref;
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
 
-#[derive(Debug)]
 pub struct WD<'a> {
     pond: &'a mut Pond,
     node: usize,

--- a/src/pond/wd.rs
+++ b/src/pond/wd.rs
@@ -146,6 +146,13 @@ impl<'a> WD<'a> {
             .realpath_version(self.pond, prefix, num, ext)
     }
 
+    pub fn create_symlink(&mut self, from: &str, to: &str) -> Result<()> {
+        self.d()
+            .deref()
+            .borrow_mut()
+            .create_symlink(self.pond, from, to)
+    }
+
     pub fn copy_version_to<T: Write + Send>(
         &mut self,
         prefix: &str,

--- a/src/pond/wd.rs
+++ b/src/pond/wd.rs
@@ -72,8 +72,13 @@ impl<'a> WD<'a> {
     where
         F: FnOnce(&mut WD) -> Result<T>,
     {
+	eprintln!("in_path for {}", path.as_ref().display());
         let mut comp = path.as_ref().components();
-        let first = comp.next();
+        let mut first = comp.next();
+
+	if let Some(Component::RootDir) = first {
+	    first = comp.next();
+	}
 
         match first {
             None => {


### PR DESCRIPTION
Adds symlink support esp for top-level resource names.
Adds HydroVu retry/reliability.
Files expose sql expressions, `export` yields temporal partitioned database.
Two-level synthetic directory support w/ propagated deriver.
New `Reduce` resource for downsampling timeseries.
