### PR TITLE
Fix SLSA provenance .deb artifact path

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           mkdir -p artifacts
           cp target/release/pond artifacts/pond
-          cp crates/cmd/target/debian/*.deb artifacts/
+          cp target/debian/*.deb artifacts/
       
       - name: Generate hashes
         id: hash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmd"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2501,7 +2501,7 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hydrovu"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "provider"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4129,7 +4129,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "remote"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4606,7 +4606,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sitegen"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "chrono",
  "clap",
@@ -4709,7 +4709,7 @@ dependencies = [
 
 [[package]]
 name = "steward"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "tinyfs"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -5020,7 +5020,7 @@ checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
 
 [[package]]
 name = "tlogfs"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -5375,7 +5375,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utilities"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.37.0"
+version = "0.38.0"
 edition = "2024"
 authors = ["DuckPond Contributors"]
 homepage = "https://github.com/duckpond"


### PR DESCRIPTION
cargo deb outputs to workspace `target/debian/`, not `crates/cmd/target/debian/`.

The SLSA provenance workflow was failing because it looked for the .deb in the wrong directory.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>