### PR TITLE
Hydrovu archive restore

### DIFF
--- a/crates/hydrovu/src/lib.rs
+++ b/crates/hydrovu/src/lib.rs
@@ -609,12 +609,19 @@ impl HydroVuCollector {
             let table_name = format!("_archive_{}", i);
             let _ = ctx.register_table(&table_name, table).map_err(|e| {
                 steward::StewardError::Dyn(
-                    format!("Failed to register archive table for '{}': {}", file_path, e).into(),
+                    format!(
+                        "Failed to register archive table for '{}': {}",
+                        file_path, e
+                    )
+                    .into(),
                 )
             })?;
 
             let batches = ctx
-                .sql(&format!("SELECT max(timestamp) AS m FROM \"{}\"", table_name))
+                .sql(&format!(
+                    "SELECT max(timestamp) AS m FROM \"{}\"",
+                    table_name
+                ))
                 .await
                 .map_err(|e| {
                     steward::StewardError::Dyn(
@@ -625,14 +632,20 @@ impl HydroVuCollector {
                 .await
                 .map_err(|e| {
                     steward::StewardError::Dyn(
-                        format!("Failed to collect max(timestamp) for '{}': {}", file_path, e)
-                            .into(),
+                        format!(
+                            "Failed to collect max(timestamp) for '{}': {}",
+                            file_path, e
+                        )
+                        .into(),
                     )
                 })?;
             let _ = ctx.deregister_table(&table_name);
 
             if let Some(micros) = Self::scalar_timestamp_to_micros(&batches)? {
-                debug!("Archive '{}' max(timestamp) -> {} micros", file_path, micros);
+                debug!(
+                    "Archive '{}' max(timestamp) -> {} micros",
+                    file_path, micros
+                );
                 max_micros = Some(max_micros.map_or(micros, |cur| cur.max(micros)));
             }
         }
@@ -668,11 +681,14 @@ impl HydroVuCollector {
 
         let micros = match column.data_type() {
             DataType::Int64 => {
-                let arr = column.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
-                    steward::StewardError::Dyn(
-                        "max(timestamp) result claims Int64 but downcast failed".into(),
-                    )
-                })?;
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .ok_or_else(|| {
+                        steward::StewardError::Dyn(
+                            "max(timestamp) result claims Int64 but downcast failed".into(),
+                        )
+                    })?;
                 arr.value(0) * 1_000_000
             }
             DataType::Timestamp(TimeUnit::Second, _) => {
@@ -1225,7 +1241,10 @@ mod tests {
             HydroVuCollector::scalar_timestamp_to_micros(&b).unwrap(),
             None
         );
-        assert_eq!(HydroVuCollector::scalar_timestamp_to_micros(&[]).unwrap(), None);
+        assert_eq!(
+            HydroVuCollector::scalar_timestamp_to_micros(&[]).unwrap(),
+            None
+        );
 
         // Unsupported type hard-fails (no silent skip).
         let b = one_col(Arc::new(arrow_array::StringArray::from(vec!["x"])));

--- a/crates/hydrovu/src/lib.rs
+++ b/crates/hydrovu/src/lib.rs
@@ -541,7 +541,11 @@ impl HydroVuCollector {
     /// Query the read-only seed archives for a device's youngest timestamp,
     /// returned in microseconds (DuckPond canonical unit).  Reads every
     /// `{archive_path}/devices/{device_id}/*.series` file via a `series://`
-    /// cast (Parquet bytes -> MemTable) and takes `max(timestamp)` across all.
+    /// cast (the same Provider builtin path used by `timeseries-join`) and
+    /// takes `max(timestamp)` across all.  No new file-access mechanism: the
+    /// cast flows through the shared `read_pond_node_as_parquet` helper in the
+    /// provider crate.  TODO(perf): that helper currently materializes whole
+    /// files in memory; the right fix is in the provider cache, not here.
     ///
     /// Returns `Ok(None)` when no archive files exist for the device.
     async fn find_archive_youngest_micros(
@@ -590,7 +594,9 @@ impl HydroVuCollector {
         let mut max_micros: Option<i64> = None;
 
         for (i, file_path) in archive_files.iter().enumerate() {
-            // Cast the git-ingested data node as a queryable series (Parquet).
+            // Reuse the canonical builtin `+series` cast: same Provider entry
+            // point used by `timeseries-join` for git-ingested archives.  No
+            // separate file-access path lives in this crate.
             let url = format!("series://{}", file_path);
             let table = provider
                 .create_table_provider(&url, &ctx)
@@ -625,7 +631,7 @@ impl HydroVuCollector {
                 })?;
             let _ = ctx.deregister_table(&table_name);
 
-            if let Some(micros) = Self::scalar_timestamp_to_micros(&batches) {
+            if let Some(micros) = Self::scalar_timestamp_to_micros(&batches)? {
                 debug!("Archive '{}' max(timestamp) -> {} micros", file_path, micros);
                 max_micros = Some(max_micros.map_or(micros, |cur| cur.max(micros)));
             }
@@ -635,48 +641,101 @@ impl HydroVuCollector {
     }
 
     /// Extract a single `max(timestamp)` scalar from a query result and
-    /// normalize it to microseconds.  The seed archives store `timestamp` as a
-    /// plain INT64 in **seconds**; collector-written active series use
-    /// `Timestamp(Second)`.  Both normalize to micros here; logical Timestamp
-    /// types are scaled per their TimeUnit.
-    fn scalar_timestamp_to_micros(batches: &[RecordBatch]) -> Option<i64> {
+    /// normalize it to microseconds (DuckPond canonical unit).
+    ///
+    /// HydroVu archives are produced by the hydrovu factory itself, so the
+    /// timestamp column type is known.  Unsupported Arrow types hard-fail
+    /// rather than silently degrade -- a type mismatch indicates a real
+    /// regression that should not be hidden.  The seed archives in production
+    /// use INT64 seconds; collector-written active series use
+    /// `Timestamp(Second)`.  Other logical Timestamp units are accepted and
+    /// scaled per their TimeUnit.
+    fn scalar_timestamp_to_micros(
+        batches: &[RecordBatch],
+    ) -> Result<Option<i64>, Box<dyn std::error::Error + Send + Sync>> {
         use arrow_array::{
             Int64Array, TimestampMicrosecondArray, TimestampMillisecondArray,
             TimestampNanosecondArray, TimestampSecondArray,
         };
 
-        let batch = batches.iter().find(|b| b.num_rows() > 0)?;
+        let Some(batch) = batches.iter().find(|b| b.num_rows() > 0) else {
+            return Ok(None);
+        };
         let column = batch.column(0);
         if column.is_null(0) {
-            return None;
+            return Ok(None);
         }
 
-        match column.data_type() {
+        let micros = match column.data_type() {
             DataType::Int64 => {
-                let arr = column.as_any().downcast_ref::<Int64Array>()?;
-                Some(arr.value(0) * 1_000_000)
+                let arr = column.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
+                    steward::StewardError::Dyn(
+                        "max(timestamp) result claims Int64 but downcast failed".into(),
+                    )
+                })?;
+                arr.value(0) * 1_000_000
             }
             DataType::Timestamp(TimeUnit::Second, _) => {
-                let arr = column.as_any().downcast_ref::<TimestampSecondArray>()?;
-                Some(arr.value(0) * 1_000_000)
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<TimestampSecondArray>()
+                    .ok_or_else(|| {
+                        steward::StewardError::Dyn(
+                            "max(timestamp) result claims Timestamp(Second) but downcast failed"
+                                .into(),
+                        )
+                    })?;
+                arr.value(0) * 1_000_000
             }
             DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                let arr = column.as_any().downcast_ref::<TimestampMillisecondArray>()?;
-                Some(arr.value(0) * 1_000)
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .ok_or_else(|| {
+                        steward::StewardError::Dyn(
+                            "max(timestamp) result claims Timestamp(Millisecond) but downcast failed"
+                                .into(),
+                        )
+                    })?;
+                arr.value(0) * 1_000
             }
             DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                let arr = column.as_any().downcast_ref::<TimestampMicrosecondArray>()?;
-                Some(arr.value(0))
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<TimestampMicrosecondArray>()
+                    .ok_or_else(|| {
+                        steward::StewardError::Dyn(
+                            "max(timestamp) result claims Timestamp(Microsecond) but downcast failed"
+                                .into(),
+                        )
+                    })?;
+                arr.value(0)
             }
             DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                let arr = column.as_any().downcast_ref::<TimestampNanosecondArray>()?;
-                Some(arr.value(0) / 1_000)
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<TimestampNanosecondArray>()
+                    .ok_or_else(|| {
+                        steward::StewardError::Dyn(
+                            "max(timestamp) result claims Timestamp(Nanosecond) but downcast failed"
+                                .into(),
+                        )
+                    })?;
+                arr.value(0) / 1_000
             }
             other => {
-                debug!("Unexpected max(timestamp) type {:?}; ignoring archive", other);
-                None
+                return Err(steward::StewardError::Dyn(
+                    format!(
+                        "Unsupported archive max(timestamp) type {:?}; expected INT64 (seconds) or a logical Timestamp",
+                        other
+                    )
+                    .into(),
+                )
+                .into());
             }
-        }
+        };
+
+        Ok(Some(micros))
     }
 
     /// Core device data collection function - handles both counting and timestamp tracking
@@ -1116,11 +1175,10 @@ mod tests {
         Ok(())
     }
 
-    /// The seed archives store `timestamp` as a plain INT64 in seconds; the
-    /// resume logic must normalize that (and any logical Timestamp type) to
-    /// microseconds, the DuckPond canonical unit.
+    /// Archive timestamp normalization uses strict typing with hard failures on
+    /// unsupported types.
     #[test]
-    fn test_scalar_timestamp_to_micros_units() {
+    fn test_scalar_timestamp_to_micros_units_and_strictness() {
         use arrow_array::{
             Int64Array, TimestampMicrosecondArray, TimestampMillisecondArray,
             TimestampNanosecondArray, TimestampSecondArray,
@@ -1135,35 +1193,45 @@ mod tests {
         // INT64 seconds (the real archive layout) -> micros.
         let b = one_col(Arc::new(Int64Array::from(vec![1_770_000_000i64])));
         assert_eq!(
-            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            HydroVuCollector::scalar_timestamp_to_micros(&b).unwrap(),
             Some(1_770_000_000_000_000)
         );
 
         // Logical Timestamp types scale per their unit.
         let b = one_col(Arc::new(TimestampSecondArray::from(vec![1_700i64])));
         assert_eq!(
-            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            HydroVuCollector::scalar_timestamp_to_micros(&b).unwrap(),
             Some(1_700_000_000)
         );
         let b = one_col(Arc::new(TimestampMillisecondArray::from(vec![1_700i64])));
         assert_eq!(
-            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            HydroVuCollector::scalar_timestamp_to_micros(&b).unwrap(),
             Some(1_700_000)
         );
         let b = one_col(Arc::new(TimestampMicrosecondArray::from(vec![1_700i64])));
         assert_eq!(
-            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            HydroVuCollector::scalar_timestamp_to_micros(&b).unwrap(),
             Some(1_700)
         );
         let b = one_col(Arc::new(TimestampNanosecondArray::from(vec![1_700_000i64])));
         assert_eq!(
-            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            HydroVuCollector::scalar_timestamp_to_micros(&b).unwrap(),
             Some(1_700)
         );
 
-        // NULL / empty -> None (no archive temporal data).
+        // NULL / empty -> Ok(None): the SQL aggregate had no rows / a NULL max.
         let b = one_col(Arc::new(Int64Array::from(vec![None::<i64>])));
-        assert_eq!(HydroVuCollector::scalar_timestamp_to_micros(&b), None);
-        assert_eq!(HydroVuCollector::scalar_timestamp_to_micros(&[]), None);
+        assert_eq!(
+            HydroVuCollector::scalar_timestamp_to_micros(&b).unwrap(),
+            None
+        );
+        assert_eq!(HydroVuCollector::scalar_timestamp_to_micros(&[]).unwrap(), None);
+
+        // Unsupported type hard-fails (no silent skip).
+        let b = one_col(Arc::new(arrow_array::StringArray::from(vec!["x"])));
+        assert!(
+            HydroVuCollector::scalar_timestamp_to_micros(&b).is_err(),
+            "String timestamp column must hard-fail"
+        );
     }
 }

--- a/crates/hydrovu/src/lib.rs
+++ b/crates/hydrovu/src/lib.rs
@@ -379,22 +379,30 @@ impl HydroVuCollector {
         let client = self.client.clone();
         let names = self.names.clone();
         let hydrovu_path = self.config.hydrovu_path.clone();
+        let archive_path = self.config.archive_path.clone();
         let max_points = self.config.max_points_per_run;
 
         // Call internal collection function directly - no sub-transaction needed
         // We're already running within the caller's single transaction
         // Only one fetch per run (max_points_per_run enforced per run)
-        let result =
-            Self::collect_device_data_internal(fs, hydrovu_path, client, names, device, max_points)
-                .await
-                .map_err(|e| {
-                    anyhow!(
-                        "Failed to collect data for device '{}' (ID: {}): {}",
-                        device_name,
-                        device_id,
-                        e
-                    )
-                })?;
+        let result = Self::collect_device_data_internal(
+            fs,
+            hydrovu_path,
+            archive_path,
+            client,
+            names,
+            device,
+            max_points,
+        )
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "Failed to collect data for device '{}' (ID: {}): {}",
+                device_name,
+                device_id,
+                e
+            )
+        })?;
 
         let total_records = result.0;
         let start_timestamp = result.1;
@@ -425,13 +433,21 @@ impl HydroVuCollector {
         Ok(())
     }
 
-    /// Find the youngest (most recent) timestamp for a device by scanning
-    /// ALL *.series files in the device directory. This includes both the
-    /// active file and any archive files, so that pre-loaded archive data
-    /// seamlessly sets the start point for the next API fetch.
+    /// Find the youngest (most recent) timestamp (in microseconds, the DuckPond
+    /// canonical unit) for a device by scanning ALL *.series files in the
+    /// writeable device directory via the oplog temporal metadata.
+    ///
+    /// When the writeable directory has no temporal data (a freshly reset pond)
+    /// and an `archive_path` is configured, fall back to the read-only seed
+    /// archives at `{archive_path}/devices/{device_id}/*.series`.  Those are
+    /// git-ingested `FileDynamic` Parquet snapshots with no oplog metadata, so
+    /// they are queried directly with a `series://` cast + `SELECT max(timestamp)`.
+    /// This lets live collection resume from the archive's youngest point instead
+    /// of crawling from epoch, without copying the archives into the oplog.
     async fn find_youngest_timestamp(
         fs: &FS,
         hydrovu_path: &str,
+        archive_path: Option<&str>,
         device_id: i64,
         device_name: &str,
     ) -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
@@ -443,85 +459,222 @@ impl HydroVuCollector {
             .await
             .map_err(|e| steward::StewardError::DataInit(tlogfs::TLogFSError::TinyFS(e)))?;
 
-        // Navigate to device directory
-        let device_dir = match root_wd.open_dir_path(&device_dir_path).await {
-            Ok(dir) => dir,
-            Err(_) => {
-                debug!("Device directory not found for device {device_id}, starting from epoch");
-                return Ok(0);
-            }
-        };
+        // Scan the writeable device directory's oplog metadata for max timestamp.
+        let mut max_timestamp: Option<i64> = None;
+        if let Ok(device_dir) = root_wd.open_dir_path(&device_dir_path).await {
+            use futures::StreamExt;
+            let mut entries_stream = device_dir
+                .entries()
+                .await
+                .map_err(|e| steward::StewardError::DataInit(tlogfs::TLogFSError::TinyFS(e)))?;
 
-        // List all entries and find *.series files
+            let mut series_paths = Vec::new();
+            while let Some(entry) = entries_stream.next().await {
+                let entry = entry
+                    .map_err(|e| steward::StewardError::DataInit(tlogfs::TLogFSError::TinyFS(e)))?;
+                if entry.name.ends_with(".series") && entry.entry_type.is_file() {
+                    series_paths.push(format!("{}/{}", device_dir_path, entry.name));
+                }
+            }
+
+            debug!(
+                "Found {} writeable .series files for device {device_id}: {:?}",
+                series_paths.len(),
+                series_paths
+            );
+
+            for series_path in &series_paths {
+                let version_infos = root_wd.list_file_versions(series_path).await.map_err(|e| {
+                    steward::StewardError::Dyn(
+                        format!("Failed to query file versions for {}: {}", series_path, e).into(),
+                    )
+                })?;
+
+                for (i, version_info) in version_infos.iter().enumerate() {
+                    if let Some(metadata) = &version_info.extended_metadata
+                        && let (Some(min_str), Some(max_str)) = (
+                            metadata.get("min_event_time"),
+                            metadata.get("max_event_time"),
+                        )
+                        && let (Ok(min_time), Ok(max_time)) =
+                            (min_str.parse::<i64>(), max_str.parse::<i64>())
+                    {
+                        debug!(
+                            "{} version {i}: temporal range {min_time}..{max_time}",
+                            series_path
+                        );
+                        max_timestamp =
+                            Some(max_timestamp.map_or(max_time, |current| current.max(max_time)));
+                    }
+                }
+            }
+        } else {
+            debug!("Writeable device directory not found for device {device_id}");
+        }
+
+        // Writeable data present: resume from its youngest timestamp.
+        if let Some(timestamp) = max_timestamp {
+            // Add 1 second (1M microseconds) to avoid duplicate when API uses second resolution
+            let next_timestamp = timestamp + 1_000_000;
+            debug!(
+                "Found youngest timestamp {timestamp} across writeable series for device {device_id}, will continue from {next_timestamp}"
+            );
+            return Ok(next_timestamp);
+        }
+
+        // Writeable directory empty: fall back to the read-only seed archives.
+        if let Some(archive_path) = archive_path
+            && let Some(archive_micros) =
+                Self::find_archive_youngest_micros(fs, archive_path, device_id).await?
+        {
+            let next_timestamp = archive_micros + 1_000_000;
+            debug!(
+                "Device {device_id}: no writeable data; resuming from archive youngest {archive_micros}, will continue from {next_timestamp}"
+            );
+            return Ok(next_timestamp);
+        }
+
+        debug!("Device {device_id}: no writeable data and no archive, starting from epoch");
+        Ok(0)
+    }
+
+    /// Query the read-only seed archives for a device's youngest timestamp,
+    /// returned in microseconds (DuckPond canonical unit).  Reads every
+    /// `{archive_path}/devices/{device_id}/*.series` file via a `series://`
+    /// cast (Parquet bytes -> MemTable) and takes `max(timestamp)` across all.
+    ///
+    /// Returns `Ok(None)` when no archive files exist for the device.
+    async fn find_archive_youngest_micros(
+        fs: &FS,
+        archive_path: &str,
+        device_id: i64,
+    ) -> Result<Option<i64>, Box<dyn std::error::Error + Send + Sync>> {
+        use datafusion::prelude::SessionContext;
         use futures::StreamExt;
-        let mut entries_stream = device_dir
-            .entries()
+
+        let archive_dir_path = format!("{}/devices/{}", archive_path, device_id);
+
+        let root_wd = fs
+            .root()
             .await
             .map_err(|e| steward::StewardError::DataInit(tlogfs::TLogFSError::TinyFS(e)))?;
 
-        let mut series_paths = Vec::new();
+        let archive_dir = match root_wd.open_dir_path(&archive_dir_path).await {
+            Ok(dir) => dir,
+            Err(_) => {
+                debug!("No archive directory '{archive_dir_path}' for device {device_id}");
+                return Ok(None);
+            }
+        };
+
+        let mut archive_files = Vec::new();
+        let mut entries_stream = archive_dir
+            .entries()
+            .await
+            .map_err(|e| steward::StewardError::DataInit(tlogfs::TLogFSError::TinyFS(e)))?;
         while let Some(entry) = entries_stream.next().await {
             let entry = entry
                 .map_err(|e| steward::StewardError::DataInit(tlogfs::TLogFSError::TinyFS(e)))?;
             if entry.name.ends_with(".series") && entry.entry_type.is_file() {
-                series_paths.push(format!("{}/{}", device_dir_path, entry.name));
+                archive_files.push(format!("{}/{}", archive_dir_path, entry.name));
             }
         }
 
-        if series_paths.is_empty() {
-            debug!("No .series files found for device {device_id}, starting from epoch");
-            return Ok(0);
+        if archive_files.is_empty() {
+            debug!("No archive .series files for device {device_id} in '{archive_dir_path}'");
+            return Ok(None);
         }
 
-        debug!(
-            "Found {} .series files for device {device_id}: {:?}",
-            series_paths.len(),
-            series_paths
-        );
+        let provider = provider::Provider::new(Arc::new(fs.clone()));
+        let ctx = SessionContext::new();
+        let mut max_micros: Option<i64> = None;
 
-        // Scan all versions of all series files for max timestamp
-        let mut max_timestamp: Option<i64> = None;
-
-        for series_path in &series_paths {
-            let version_infos = root_wd.list_file_versions(series_path).await.map_err(|e| {
+        for (i, file_path) in archive_files.iter().enumerate() {
+            // Cast the git-ingested data node as a queryable series (Parquet).
+            let url = format!("series://{}", file_path);
+            let table = provider
+                .create_table_provider(&url, &ctx)
+                .await
+                .map_err(|e| {
+                    steward::StewardError::Dyn(
+                        format!("Failed to open archive '{}' as series: {}", file_path, e).into(),
+                    )
+                })?;
+            let table_name = format!("_archive_{}", i);
+            let _ = ctx.register_table(&table_name, table).map_err(|e| {
                 steward::StewardError::Dyn(
-                    format!("Failed to query file versions for {}: {}", series_path, e).into(),
+                    format!("Failed to register archive table for '{}': {}", file_path, e).into(),
                 )
             })?;
 
-            for (i, version_info) in version_infos.iter().enumerate() {
-                if let Some(metadata) = &version_info.extended_metadata
-                    && let (Some(min_str), Some(max_str)) = (
-                        metadata.get("min_event_time"),
-                        metadata.get("max_event_time"),
+            let batches = ctx
+                .sql(&format!("SELECT max(timestamp) AS m FROM \"{}\"", table_name))
+                .await
+                .map_err(|e| {
+                    steward::StewardError::Dyn(
+                        format!("Failed to query max(timestamp) for '{}': {}", file_path, e).into(),
                     )
-                    && let (Ok(min_time), Ok(max_time)) =
-                        (min_str.parse::<i64>(), max_str.parse::<i64>())
-                {
-                    debug!(
-                        "{} version {i}: temporal range {min_time}..{max_time}",
-                        series_path
-                    );
-                    max_timestamp =
-                        Some(max_timestamp.map_or(max_time, |current| current.max(max_time)));
-                }
+                })?
+                .collect()
+                .await
+                .map_err(|e| {
+                    steward::StewardError::Dyn(
+                        format!("Failed to collect max(timestamp) for '{}': {}", file_path, e)
+                            .into(),
+                    )
+                })?;
+            let _ = ctx.deregister_table(&table_name);
+
+            if let Some(micros) = Self::scalar_timestamp_to_micros(&batches) {
+                debug!("Archive '{}' max(timestamp) -> {} micros", file_path, micros);
+                max_micros = Some(max_micros.map_or(micros, |cur| cur.max(micros)));
             }
         }
 
-        match max_timestamp {
-            Some(timestamp) => {
-                // Add 1 second (1M microseconds) to avoid duplicate when API uses second resolution
-                let next_timestamp = timestamp + 1_000_000;
-                debug!(
-                    "Found youngest timestamp {timestamp} across all series for device {device_id}, will continue from {next_timestamp}"
-                );
-                Ok(next_timestamp)
+        Ok(max_micros)
+    }
+
+    /// Extract a single `max(timestamp)` scalar from a query result and
+    /// normalize it to microseconds.  The seed archives store `timestamp` as a
+    /// plain INT64 in **seconds**; collector-written active series use
+    /// `Timestamp(Second)`.  Both normalize to micros here; logical Timestamp
+    /// types are scaled per their TimeUnit.
+    fn scalar_timestamp_to_micros(batches: &[RecordBatch]) -> Option<i64> {
+        use arrow_array::{
+            Int64Array, TimestampMicrosecondArray, TimestampMillisecondArray,
+            TimestampNanosecondArray, TimestampSecondArray,
+        };
+
+        let batch = batches.iter().find(|b| b.num_rows() > 0)?;
+        let column = batch.column(0);
+        if column.is_null(0) {
+            return None;
+        }
+
+        match column.data_type() {
+            DataType::Int64 => {
+                let arr = column.as_any().downcast_ref::<Int64Array>()?;
+                Some(arr.value(0) * 1_000_000)
             }
-            None => {
-                debug!(
-                    "Device {device_id}: series files exist but no temporal data found, starting fresh"
-                );
-                Ok(0)
+            DataType::Timestamp(TimeUnit::Second, _) => {
+                let arr = column.as_any().downcast_ref::<TimestampSecondArray>()?;
+                Some(arr.value(0) * 1_000_000)
+            }
+            DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                let arr = column.as_any().downcast_ref::<TimestampMillisecondArray>()?;
+                Some(arr.value(0) * 1_000)
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                let arr = column.as_any().downcast_ref::<TimestampMicrosecondArray>()?;
+                Some(arr.value(0))
+            }
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+                let arr = column.as_any().downcast_ref::<TimestampNanosecondArray>()?;
+                Some(arr.value(0) / 1_000)
+            }
+            other => {
+                debug!("Unexpected max(timestamp) type {:?}; ignoring archive", other);
+                None
             }
         }
     }
@@ -532,6 +685,7 @@ impl HydroVuCollector {
     async fn collect_device_data_internal(
         fs: &FS,
         hydrovu_path: String,
+        archive_path: Option<String>,
         client: Client,
         names: Names,
         device: HydroVuDevice,
@@ -541,8 +695,14 @@ impl HydroVuCollector {
         debug!("Starting data collection for device {device_id}");
 
         // Step 1: Find the youngest timestamp using TinyFS metadata API
-        let youngest_timestamp =
-            Self::find_youngest_timestamp(fs, &hydrovu_path, device_id, &device.name).await?;
+        let youngest_timestamp = Self::find_youngest_timestamp(
+            fs,
+            &hydrovu_path,
+            archive_path.as_deref(),
+            device_id,
+            &device.name,
+        )
+        .await?;
 
         let start_date =
             utc2date(youngest_timestamp).unwrap_or_else(|_| "invalid date".to_string());
@@ -954,5 +1114,56 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    /// The seed archives store `timestamp` as a plain INT64 in seconds; the
+    /// resume logic must normalize that (and any logical Timestamp type) to
+    /// microseconds, the DuckPond canonical unit.
+    #[test]
+    fn test_scalar_timestamp_to_micros_units() {
+        use arrow_array::{
+            Int64Array, TimestampMicrosecondArray, TimestampMillisecondArray,
+            TimestampNanosecondArray, TimestampSecondArray,
+        };
+
+        fn one_col(array: Arc<dyn Array>) -> Vec<RecordBatch> {
+            let field = Field::new("m", array.data_type().clone(), true);
+            let schema = Arc::new(Schema::new(vec![field]));
+            vec![RecordBatch::try_new(schema, vec![array]).unwrap()]
+        }
+
+        // INT64 seconds (the real archive layout) -> micros.
+        let b = one_col(Arc::new(Int64Array::from(vec![1_770_000_000i64])));
+        assert_eq!(
+            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            Some(1_770_000_000_000_000)
+        );
+
+        // Logical Timestamp types scale per their unit.
+        let b = one_col(Arc::new(TimestampSecondArray::from(vec![1_700i64])));
+        assert_eq!(
+            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            Some(1_700_000_000)
+        );
+        let b = one_col(Arc::new(TimestampMillisecondArray::from(vec![1_700i64])));
+        assert_eq!(
+            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            Some(1_700_000)
+        );
+        let b = one_col(Arc::new(TimestampMicrosecondArray::from(vec![1_700i64])));
+        assert_eq!(
+            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            Some(1_700)
+        );
+        let b = one_col(Arc::new(TimestampNanosecondArray::from(vec![1_700_000i64])));
+        assert_eq!(
+            HydroVuCollector::scalar_timestamp_to_micros(&b),
+            Some(1_700)
+        );
+
+        // NULL / empty -> None (no archive temporal data).
+        let b = one_col(Arc::new(Int64Array::from(vec![None::<i64>])));
+        assert_eq!(HydroVuCollector::scalar_timestamp_to_micros(&b), None);
+        assert_eq!(HydroVuCollector::scalar_timestamp_to_micros(&[]), None);
     }
 }

--- a/crates/hydrovu/src/models.rs
+++ b/crates/hydrovu/src/models.rs
@@ -22,6 +22,16 @@ pub struct HydroVuConfig {
     /// Path within pond for hydrovu data (e.g., "/hydrovu")
     pub hydrovu_path: String,
 
+    /// Optional path within pond holding read-only seed archives (e.g.
+    /// "/hydrovu-archive"), typically git-ingested `FileDynamic` Parquet
+    /// `.series` snapshots laid out as `{archive_path}/devices/{id}/*.series`.
+    /// Consulted by `find_youngest_timestamp` ONLY when the writeable device
+    /// directory has no temporal data (a freshly reset pond), so live
+    /// collection resumes from the archive's youngest timestamp instead of
+    /// crawling from epoch.  These archives are NOT written to.
+    #[serde(default)]
+    pub archive_path: Option<String>,
+
     /// Device list
     pub devices: Vec<HydroVuDevice>,
 }

--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -455,6 +455,24 @@ impl SqlDerivedFile {
                 EntryType::TablePhysicalVersion => vec![EntryType::FilePhysicalVersion],
                 _ => vec![entry_type],
             }
+        } else if url.entry_type().is_some()
+            && matches!(
+                entry_type,
+                EntryType::TablePhysicalSeries
+                    | EntryType::TableDynamic
+                    | EntryType::TablePhysicalVersion
+            )
+        {
+            // Explicit `+series`/`+table` cast: a data-archetype node that holds
+            // Parquet bytes can be reinterpreted as a series/table. Accept data
+            // files as candidates in addition to the requested series/table type;
+            // the table-provider layer performs the actual cast.
+            // See docs/url-entry-type-casting.md.
+            vec![
+                entry_type,
+                EntryType::FileDynamic,
+                EntryType::FilePhysicalVersion,
+            ]
         } else {
             vec![entry_type]
         };

--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -1357,11 +1357,9 @@ impl tinyfs::QueryableFile for SqlDerivedFile {
                             let schema = batches.first().map(|b| b.schema()).ok_or_else(|| {
                                 tinyfs::Error::Other("No batches in union".to_string())
                             })?;
-                            let mem_table = datafusion::datasource::MemTable::try_new(
-                                schema,
-                                vec![batches],
-                            )
-                            .map_err(|e| tinyfs::Error::Other(e.to_string()))?;
+                            let mem_table =
+                                datafusion::datasource::MemTable::try_new(schema, vec![batches])
+                                    .map_err(|e| tinyfs::Error::Other(e.to_string()))?;
                             Arc::new(mem_table)
                         };
 

--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -823,6 +823,70 @@ impl SqlDerivedFile {
         let hash_value = hasher.finish();
         format!("sql_derived_data_{:016x}", hash_value).to_lowercase()
     }
+
+    /// Cast a non-queryable data-archetype node (e.g. a git-ingested
+    /// `FileDynamic` Parquet archive) into a TableProvider by reading its
+    /// bytes and decoding them as Parquet.
+    ///
+    /// This is the pond analogue of `create_host_parquet_table_provider`:
+    /// reached only when a `+series`/`+table` URL cast matched a data file
+    /// (see step 1 in `docs/url-entry-type-casting.md`).  A data file cast as
+    /// a series/table yields a single Parquet version read fully into a
+    /// `MemTable`.  A non-Parquet file produces a clear "not a valid Parquet
+    /// file" error rather than the opaque "not queryable" error.
+    async fn cast_data_node_to_parquet_provider(
+        node_path: &tinyfs::NodePath,
+    ) -> TinyFSResult<Arc<dyn TableProvider>> {
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        use tokio::io::AsyncReadExt;
+
+        let file_handle = node_path.as_file().await.map_err(|e| {
+            tinyfs::Error::Other(format!("Failed to get file handle for cast: {}", e))
+        })?;
+        let mut reader = file_handle.handle.async_reader().await.map_err(|e| {
+            tinyfs::Error::Other(format!("Failed to open reader for cast: {}", e))
+        })?;
+        let mut buf = Vec::new();
+        let _ = reader.read_to_end(&mut buf).await.map_err(|e| {
+            tinyfs::Error::Other(format!(
+                "Failed to read '{}' for Parquet cast: {}",
+                node_path.path().display(),
+                e
+            ))
+        })?;
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(buf))
+            .map_err(|e| {
+                tinyfs::Error::Other(format!(
+                    "File '{}' is not a valid Parquet file: {}",
+                    node_path.path().display(),
+                    e
+                ))
+            })?;
+        let schema = builder.schema().clone();
+        let batch_reader = builder.build().map_err(|e| {
+            tinyfs::Error::Other(format!(
+                "Failed to read Parquet from '{}': {}",
+                node_path.path().display(),
+                e
+            ))
+        })?;
+
+        let mut batches = Vec::new();
+        for batch in batch_reader {
+            batches.push(batch.map_err(|e| {
+                tinyfs::Error::Other(format!(
+                    "Failed to decode Parquet batch from '{}': {}",
+                    node_path.path().display(),
+                    e
+                ))
+            })?);
+        }
+
+        let table = datafusion::datasource::MemTable::try_new(schema, vec![batches])
+            .map_err(|e| tinyfs::Error::Other(e.to_string()))?;
+        Ok(Arc::new(table))
+    }
 }
 
 // QueryableFile trait implementation - follows anti-duplication principles
@@ -907,6 +971,17 @@ impl tinyfs::QueryableFile for SqlDerivedFile {
                 pattern,
                 queryable_files.len()
             );
+
+            // Dedup across entry types by FileID.  Normally a node has exactly
+            // one stored type so the per-entry-type searches are disjoint, but a
+            // data-archetype node matched under a +series/+table cast is
+            // accepted by every series/table entry-type search (see
+            // docs/url-entry-type-casting.md), so it can appear more than once.
+            {
+                use std::collections::HashSet;
+                let mut seen = HashSet::new();
+                queryable_files.retain(|np| seen.insert(np.id()));
+            }
 
             if !queryable_files.is_empty() {
                 // Generate data-only table name for the source ListingTable.
@@ -1194,28 +1269,48 @@ impl tinyfs::QueryableFile for SqlDerivedFile {
                                 }
                             }
                         } else {
-                            log::error!(
-                                "[ERR] SQL-DERIVED: File for pattern '{}' does not implement QueryableFile trait",
+                            // Not natively queryable.  Under a +series/+table
+                            // URL cast (step 1 in docs/url-entry-type-casting.md)
+                            // a data-archetype node (e.g. a git-ingested
+                            // FileDynamic Parquet archive) reached here; cast it
+                            // by reading its bytes as Parquet.
+                            drop(file_guard);
+                            debug!(
+                                "[CAST] SQL-DERIVED: Single data file under cast for pattern '{}', reading as Parquet",
                                 pattern_name
                             );
-                            return Err(tinyfs::Error::Other(format!(
-                                "File for pattern '{}' does not implement QueryableFile trait",
-                                pattern_name
-                            )));
+                            let provider =
+                                Self::cast_data_node_to_parquet_provider(node_path).await?;
+                            if let Some(wrapper) = &self.config.provider_wrapper {
+                                wrapper(provider)
+                                    .map_err(|e| tinyfs::Error::Other(e.to_string()))?
+                            } else {
+                                provider
+                            }
                         }
                     } else {
                         // Multiple files: use multi-URL ListingTable approach (maintains ownership chain)
                         // Following anti-duplication: use existing create_table_provider_for_multiple_urls pattern
                         let mut urls = Vec::new();
                         let mut file_ids = Vec::new();
+                        // Data-archetype nodes matched under a +series/+table URL
+                        // cast (e.g. git-ingested FileDynamic Parquet archives)
+                        // are not natively queryable and cannot be enumerated
+                        // through the tinyfs:/// version ListingTable; they are
+                        // read directly as Parquet (see
+                        // docs/url-entry-type-casting.md).
+                        let mut data_cast_files: Vec<tinyfs::NodePath> = Vec::new();
                         for node_path in queryable_files {
                             let file_id = node_path.id();
                             let file_handle = node_path.as_file().await.map_err(|e| {
                                 tinyfs::Error::Other(format!("Failed to get file handle: {}", e))
                             })?;
                             let file_arc = file_handle.handle.get_file().await;
-                            let file_guard = file_arc.lock().await;
-                            if let Some(_queryable_file) = file_guard.as_queryable() {
+                            let is_queryable = {
+                                let file_guard = file_arc.lock().await;
+                                file_guard.as_queryable().is_some()
+                            };
+                            if is_queryable {
                                 // For files that implement QueryableFile, we need to get their URL pattern
                                 // This maintains the ownership chain: FS Root -> State -> Cache -> Single TableProvider
 
@@ -1230,42 +1325,91 @@ impl tinyfs::QueryableFile for SqlDerivedFile {
                                 urls.push(url_pattern);
                                 file_ids.push(file_id);
                             } else {
-                                return Err(tinyfs::Error::Other(format!(
-                                    "File for pattern '{}' does not implement QueryableFile trait",
-                                    pattern_name
-                                )));
+                                data_cast_files.push(node_path.clone());
                             }
                         }
 
-                        // Use existing create_table_provider_for_multiple_urls to maintain ownership chain
-                        if urls.is_empty() {
+                        if urls.is_empty() && data_cast_files.is_empty() {
                             return Err(tinyfs::Error::Other(format!(
                                 "No valid URLs found for pattern '{}'",
                                 pattern_name
                             )));
                         }
 
-                        // Create table provider options for multi-file query
-                        // Note: Temporal bounds (from pond set-temporal-bounds) should be enforced
-                        // at the Parquet reader level, not here at the factory level
-                        let options = crate::TableProviderOptions {
-                            additional_urls: urls.clone(),
-                            ..Default::default()
-                        };
+                        // Build one provider per source: a single multi-URL
+                        // ListingTable for the queryable files, plus one
+                        // Parquet MemTable per data-cast file.
+                        let mut providers: Vec<Arc<dyn TableProvider>> = Vec::new();
 
-                        log::debug!(
-                            "[LIST] CREATING multi-URL TableProvider for pattern '{}': {} URLs",
-                            pattern_name,
-                            urls.len()
-                        );
+                        if !urls.is_empty() {
+                            // Create table provider options for multi-file query
+                            // Note: Temporal bounds (from pond set-temporal-bounds) should be enforced
+                            // at the Parquet reader level, not here at the factory level
+                            let options = crate::TableProviderOptions {
+                                additional_urls: urls.clone(),
+                                ..Default::default()
+                            };
 
-                        // Use first file_id for logging (temporal bounds are explicit, so file_id not used for lookup)
-                        let representative_file_id =
-                            file_ids.first().copied().unwrap_or(FileID::root());
-                        let provider =
-                            crate::create_table_provider(representative_file_id, context, options)
+                            log::debug!(
+                                "[LIST] CREATING multi-URL TableProvider for pattern '{}': {} URLs",
+                                pattern_name,
+                                urls.len()
+                            );
+
+                            // Use first file_id for logging (temporal bounds are explicit, so file_id not used for lookup)
+                            let representative_file_id =
+                                file_ids.first().copied().unwrap_or(FileID::root());
+                            providers.push(
+                                crate::create_table_provider(
+                                    representative_file_id,
+                                    context,
+                                    options,
+                                )
+                                .await
+                                .map_err(|e| tinyfs::Error::Other(e.to_string()))?,
+                            );
+                        }
+
+                        for np in &data_cast_files {
+                            providers.push(Self::cast_data_node_to_parquet_provider(np).await?);
+                        }
+
+                        let combined: Arc<dyn TableProvider> = if providers.len() == 1 {
+                            providers
+                                .into_iter()
+                                .next()
+                                .expect("providers has exactly one element")
+                        } else {
+                            // Union the sources via SQL into a single MemTable
+                            // (mirrors the format-provider multi-file path).
+                            let temp_ctx = datafusion::prelude::SessionContext::new();
+                            for (i, tp) in providers.iter().enumerate() {
+                                _ = temp_ctx
+                                    .register_table(format!("t{}", i), tp.clone())
+                                    .map_err(|e| tinyfs::Error::Other(e.to_string()))?;
+                            }
+                            let union_sql = (0..providers.len())
+                                .map(|i| format!("SELECT * FROM t{}", i))
+                                .collect::<Vec<_>>()
+                                .join(" UNION ALL BY NAME ");
+                            let df = temp_ctx
+                                .sql(&union_sql)
                                 .await
                                 .map_err(|e| tinyfs::Error::Other(e.to_string()))?;
+                            let batches = df
+                                .collect()
+                                .await
+                                .map_err(|e| tinyfs::Error::Other(e.to_string()))?;
+                            let schema = batches.first().map(|b| b.schema()).ok_or_else(|| {
+                                tinyfs::Error::Other("No batches in union".to_string())
+                            })?;
+                            let mem_table = datafusion::datasource::MemTable::try_new(
+                                schema,
+                                vec![batches],
+                            )
+                            .map_err(|e| tinyfs::Error::Other(e.to_string()))?;
+                            Arc::new(mem_table)
+                        };
 
                         // Apply optional provider wrapper (e.g., null_padding_table)
                         if let Some(wrapper) = &self.config.provider_wrapper {
@@ -1273,9 +1417,9 @@ impl tinyfs::QueryableFile for SqlDerivedFile {
                                 "Applying provider wrapper to multi-file table '{}'",
                                 pattern_name
                             );
-                            wrapper(provider).map_err(|e| tinyfs::Error::Other(e.to_string()))?
+                            wrapper(combined).map_err(|e| tinyfs::Error::Other(e.to_string()))?
                         } else {
-                            provider
+                            combined
                         }
                     };
                     // Register the source data table
@@ -3591,6 +3735,124 @@ query: ""
             total_rows, 6,
             "Should find multiple Physical files with pattern matching - got {} rows, expected 6",
             total_rows
+        );
+    }
+
+    /// A data-archetype Parquet node (e.g. a git-ingested FileDynamic archive)
+    /// is not natively queryable, but a `series:///` URL cast must read it as a
+    /// single-version series.  See docs/url-entry-type-casting.md.
+    #[tokio::test]
+    async fn test_series_cast_over_single_data_parquet_file() {
+        let (fs, provider_context) = create_test_environment().await;
+        let root = fs.root().await.unwrap();
+
+        _ = root.create_dir_path("/archive").await.unwrap();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("value", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![1000, 2000, 3000])),
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+            ],
+        )
+        .unwrap();
+
+        // Store as a plain data file (FilePhysicalVersion): not queryable on its
+        // own, mirroring a git-ingested Parquet archive.
+        _ = create_parquet_from_batch(
+            &fs,
+            "/archive/readings.parquet",
+            &batch,
+            EntryType::FilePhysicalVersion,
+        )
+        .await
+        .unwrap();
+
+        let context = test_context(&provider_context, FileID::root());
+        let config = SqlDerivedConfig {
+            patterns: test_patterns(&[("series", "series:///archive/readings.parquet")]),
+            query: Some("SELECT * FROM series ORDER BY timestamp".to_string()),
+            ..Default::default()
+        };
+        let sql_derived_file =
+            SqlDerivedFile::new(config, context, SqlDerivedMode::Series).unwrap();
+
+        let result_batches = execute_sql_derived_direct(&sql_derived_file, &provider_context)
+            .await
+            .unwrap();
+
+        let total_rows: usize = result_batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(
+            total_rows, 3,
+            "series:// cast should read the data Parquet file as a series (3 rows)"
+        );
+    }
+
+    /// A `series:///*.parquet` cast matching multiple data-archetype nodes
+    /// unions them into a single series.
+    #[tokio::test]
+    async fn test_series_cast_over_multiple_data_parquet_files() {
+        let (fs, provider_context) = create_test_environment().await;
+        let root = fs.root().await.unwrap();
+
+        _ = root.create_dir_path("/archive").await.unwrap();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        for (name, tss, vals) in [
+            ("a.parquet", vec![1000, 2000], vec![10, 20]),
+            ("b.parquet", vec![3000, 4000, 5000], vec![30, 40, 50]),
+        ] {
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(TimestampMillisecondArray::from(tss)),
+                    Arc::new(Int32Array::from(vals)),
+                ],
+            )
+            .unwrap();
+            _ = create_parquet_from_batch(
+                &fs,
+                &format!("/archive/{}", name),
+                &batch,
+                EntryType::FilePhysicalVersion,
+            )
+            .await
+            .unwrap();
+        }
+
+        let context = test_context(&provider_context, FileID::root());
+        let config = SqlDerivedConfig {
+            patterns: test_patterns(&[("series", "series:///archive/*.parquet")]),
+            query: Some("SELECT * FROM series ORDER BY timestamp".to_string()),
+            ..Default::default()
+        };
+        let sql_derived_file =
+            SqlDerivedFile::new(config, context, SqlDerivedMode::Series).unwrap();
+
+        let result_batches = execute_sql_derived_direct(&sql_derived_file, &provider_context)
+            .await
+            .unwrap();
+
+        let total_rows: usize = result_batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(
+            total_rows, 5,
+            "series:// cast should union both data Parquet files (2 + 3 = 5 rows)"
         );
     }
 

--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -837,55 +837,9 @@ impl SqlDerivedFile {
     async fn cast_data_node_to_parquet_provider(
         node_path: &tinyfs::NodePath,
     ) -> TinyFSResult<Arc<dyn TableProvider>> {
-        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-        use tokio::io::AsyncReadExt;
-
-        let file_handle = node_path.as_file().await.map_err(|e| {
-            tinyfs::Error::Other(format!("Failed to get file handle for cast: {}", e))
-        })?;
-        let mut reader = file_handle.handle.async_reader().await.map_err(|e| {
-            tinyfs::Error::Other(format!("Failed to open reader for cast: {}", e))
-        })?;
-        let mut buf = Vec::new();
-        let _ = reader.read_to_end(&mut buf).await.map_err(|e| {
-            tinyfs::Error::Other(format!(
-                "Failed to read '{}' for Parquet cast: {}",
-                node_path.path().display(),
-                e
-            ))
-        })?;
-
-        let builder = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(buf))
-            .map_err(|e| {
-                tinyfs::Error::Other(format!(
-                    "File '{}' is not a valid Parquet file: {}",
-                    node_path.path().display(),
-                    e
-                ))
-            })?;
-        let schema = builder.schema().clone();
-        let batch_reader = builder.build().map_err(|e| {
-            tinyfs::Error::Other(format!(
-                "Failed to read Parquet from '{}': {}",
-                node_path.path().display(),
-                e
-            ))
-        })?;
-
-        let mut batches = Vec::new();
-        for batch in batch_reader {
-            batches.push(batch.map_err(|e| {
-                tinyfs::Error::Other(format!(
-                    "Failed to decode Parquet batch from '{}': {}",
-                    node_path.path().display(),
-                    e
-                ))
-            })?);
-        }
-
-        let table = datafusion::datasource::MemTable::try_new(schema, vec![batches])
-            .map_err(|e| tinyfs::Error::Other(e.to_string()))?;
-        Ok(Arc::new(table))
+        crate::provider_api::read_pond_node_as_parquet(node_path)
+            .await
+            .map_err(|e| tinyfs::Error::Other(e.to_string()))
     }
 }
 

--- a/crates/provider/src/provider_api.rs
+++ b/crates/provider/src/provider_api.rs
@@ -1181,7 +1181,11 @@ mod tests {
             w.shutdown().await.unwrap();
         }
 
-        let node_path = match root.resolve_path("/hydrovu-archive/dev.series").await.unwrap() {
+        let node_path = match root
+            .resolve_path("/hydrovu-archive/dev.series")
+            .await
+            .unwrap()
+        {
             (_, Lookup::Found(np)) => np,
             _ => panic!("archive node not found"),
         };

--- a/crates/provider/src/provider_api.rs
+++ b/crates/provider/src/provider_api.rs
@@ -243,8 +243,16 @@ impl Provider {
     /// If `url` resolves to a node that is not natively queryable (a data
     /// archetype such as a git-ingested `FileDynamic` Parquet file), read its
     /// bytes and decode them as a Parquet `MemTable` (the `+series`/`+table`
-    /// cast).  Returns `Ok(None)` when the node *is* natively queryable, so the
-    /// caller falls through to the normal `as_queryable()` path.
+    /// cast).
+    ///
+    /// Returns `Ok(None)` **only** when the node is natively queryable, so
+    /// the caller can fall through to the normal `as_queryable()` path.
+    /// Every other condition -- resolve error, missing node, file-handle
+    /// error, parquet decode error -- propagates as `Err`.  Silent
+    /// fallthrough on "missing path" was hiding real lookup errors as a
+    /// misleading "requires ProviderContext" downstream (the next handler
+    /// requires a `ProviderContext`, which the contextless cast caller --
+    /// e.g. hydrovu resume -- does not have).
     ///
     /// Requires no `ProviderContext`: the cast reads bytes via the node's
     /// `async_reader()`, exactly like the host cast.
@@ -254,20 +262,35 @@ impl Provider {
     ) -> Result<Option<Arc<dyn datafusion::catalog::TableProvider>>> {
         use tinyfs::Lookup;
 
+        // Wildcards are already rejected upstream by `create_table_provider`
+        // (the only caller); this is dead-code-defensive.
         let path = url.path();
-        if path.contains('*') || path.contains('?') {
-            return Ok(None);
-        }
 
         let root = self.root().await?;
-        let node_path = match root.resolve_path(path).await {
-            Ok((_, Lookup::Found(np))) => np,
-            _ => return Ok(None),
+        let (_, lookup_result) = root.resolve_path(path).await.map_err(|e| {
+            Error::InvalidUrl(format!(
+                "Failed to resolve path '{}' for {}://  cast: {}",
+                path,
+                url.scheme(),
+                e
+            ))
+        })?;
+        let node_path = match lookup_result {
+            Lookup::Found(np) => np,
+            _ => {
+                return Err(Error::InvalidUrl(format!(
+                    "File not found for {}:// cast: {}",
+                    url.scheme(),
+                    path
+                )));
+            }
         };
 
-        // Capability-based gate: cast only nodes that cannot serve themselves as
-        // a TableProvider (data archetype).  Natively queryable series/table
-        // nodes fall through to the normal path.
+        // Capability-based gate: cast only nodes that cannot serve themselves
+        // as a TableProvider (data archetype).  Natively queryable
+        // series/table nodes are returned as `Ok(None)` so the caller falls
+        // through to the standard `as_queryable()` path -- this is the
+        // *only* legitimate fallthrough.
         let is_queryable = {
             let file_handle = node_path
                 .as_file()
@@ -1184,5 +1207,31 @@ mod tests {
             .unwrap()
             .value(0);
         assert_eq!(m, 1_770_000_000);
+    }
+
+    /// A `series://`/`table://` cast over a path that does not exist must
+    /// hard-fail with a clear "File not found" error, NOT silently fall
+    /// through to the next handler (which, in the contextless cast caller --
+    /// e.g. hydrovu resume -- would emit a misleading "requires
+    /// ProviderContext" message and hide the real bug).
+    #[tokio::test]
+    async fn test_series_cast_over_missing_path_hard_fails() {
+        let fs = create_test_fs().await;
+        let provider = Provider::new(fs);
+        let ctx = SessionContext::new();
+
+        let err = provider
+            .create_table_provider("series:///does/not/exist.series", &ctx)
+            .await
+            .expect_err("missing path under series:// cast must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("File not found") || msg.contains("Failed to resolve path"),
+            "missing-path error should name the lookup failure, got: {msg}"
+        );
+        assert!(
+            !msg.contains("requires ProviderContext"),
+            "missing-path error must not be masked as 'requires ProviderContext', got: {msg}"
+        );
     }
 }

--- a/crates/provider/src/provider_api.rs
+++ b/crates/provider/src/provider_api.rs
@@ -137,6 +137,17 @@ impl Provider {
 
         // Check if this is a builtin TinyFS type (file, series, table, data)
         if matches!(scheme, "file" | "series" | "table" | "data") {
+            // Explicit `+series`/`+table` cast over a node that is not natively
+            // queryable (a data archetype, e.g. a git-ingested FileDynamic
+            // Parquet file) reinterprets its bytes as Parquet.  This is the pond
+            // analogue of the host cast above and requires no ProviderContext.
+            // See docs/url-entry-type-casting.md.
+            if matches!(url.entry_type(), Some("table") | Some("series"))
+                && let Some(provider) = self.try_cast_data_node_to_parquet(&url).await?
+            {
+                return Ok(provider);
+            }
+
             let provider_context = self.provider_context.as_ref().ok_or_else(|| {
                 Error::InvalidUrl(format!(
                     "Builtin type '{}' requires ProviderContext. Use Provider::with_context()",
@@ -227,6 +238,51 @@ impl Provider {
 
         let table = MemTable::try_new(schema, vec![batches])?;
         Ok(Arc::new(table))
+    }
+
+    /// If `url` resolves to a node that is not natively queryable (a data
+    /// archetype such as a git-ingested `FileDynamic` Parquet file), read its
+    /// bytes and decode them as a Parquet `MemTable` (the `+series`/`+table`
+    /// cast).  Returns `Ok(None)` when the node *is* natively queryable, so the
+    /// caller falls through to the normal `as_queryable()` path.
+    ///
+    /// Requires no `ProviderContext`: the cast reads bytes via the node's
+    /// `async_reader()`, exactly like the host cast.
+    async fn try_cast_data_node_to_parquet(
+        &self,
+        url: &Url,
+    ) -> Result<Option<Arc<dyn datafusion::catalog::TableProvider>>> {
+        use tinyfs::Lookup;
+
+        let path = url.path();
+        if path.contains('*') || path.contains('?') {
+            return Ok(None);
+        }
+
+        let root = self.root().await?;
+        let node_path = match root.resolve_path(path).await {
+            Ok((_, Lookup::Found(np))) => np,
+            _ => return Ok(None),
+        };
+
+        // Capability-based gate: cast only nodes that cannot serve themselves as
+        // a TableProvider (data archetype).  Natively queryable series/table
+        // nodes fall through to the normal path.
+        let is_queryable = {
+            let file_handle = node_path
+                .as_file()
+                .await
+                .map_err(|e| Error::InvalidUrl(format!("Failed to get file handle: {}", e)))?;
+            let file_arc = file_handle.handle.get_file().await;
+            let file_guard = file_arc.lock().await;
+            file_guard.as_queryable().is_some()
+        };
+        if is_queryable {
+            return Ok(None);
+        }
+
+        let provider = read_pond_node_as_parquet(&node_path).await?;
+        Ok(Some(provider))
     }
 
     /// Create TableProvider from builtin TinyFS file using QueryableFile trait
@@ -671,6 +727,68 @@ impl Provider {
     }
 }
 
+/// Read a non-queryable data-archetype node (e.g. a git-ingested `FileDynamic`
+/// Parquet archive) by streaming its bytes and decoding them as a Parquet
+/// `MemTable`.  This is the shared implementation behind both the pond
+/// `+series`/`+table` cast (`Provider::try_cast_data_node_to_parquet`) and the
+/// timeseries-join builtin path (`SqlDerivedFile::cast_data_node_to_parquet_provider`).
+/// Requires no `ProviderContext`.  See `docs/url-entry-type-casting.md`.
+pub(crate) async fn read_pond_node_as_parquet(
+    node_path: &tinyfs::NodePath,
+) -> Result<Arc<dyn datafusion::catalog::TableProvider>> {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use tokio::io::AsyncReadExt;
+
+    let file_handle = node_path
+        .as_file()
+        .await
+        .map_err(|e| Error::InvalidUrl(format!("Failed to get file handle for cast: {}", e)))?;
+    let mut reader = file_handle
+        .handle
+        .async_reader()
+        .await
+        .map_err(|e| Error::InvalidUrl(format!("Failed to open reader for cast: {}", e)))?;
+    let mut buf = Vec::new();
+    let _ = reader.read_to_end(&mut buf).await.map_err(|e| {
+        Error::InvalidUrl(format!(
+            "Failed to read '{}' for Parquet cast: {}",
+            node_path.path().display(),
+            e
+        ))
+    })?;
+
+    let builder =
+        ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(buf)).map_err(|e| {
+            Error::InvalidUrl(format!(
+                "File '{}' is not a valid Parquet file: {}",
+                node_path.path().display(),
+                e
+            ))
+        })?;
+    let schema = builder.schema().clone();
+    let batch_reader = builder.build().map_err(|e| {
+        Error::InvalidUrl(format!(
+            "Failed to read Parquet from '{}': {}",
+            node_path.path().display(),
+            e
+        ))
+    })?;
+
+    let mut batches = Vec::new();
+    for batch in batch_reader {
+        batches.push(batch.map_err(|e| {
+            Error::InvalidUrl(format!(
+                "Failed to decode Parquet batch from '{}': {}",
+                node_path.path().display(),
+                e
+            ))
+        })?);
+    }
+
+    let table = MemTable::try_new(schema, vec![batches])?;
+    Ok(Arc::new(table))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -989,5 +1107,82 @@ mod tests {
             "host+csv+series must not take the Parquet path, got: {}",
             err
         );
+    }
+
+    /// `read_pond_node_as_parquet` decodes a pond node's raw bytes as Parquet
+    /// with NO ProviderContext.  This is the byte path behind the
+    /// `series://`/`table://` cast over a git-ingested data archetype, used by
+    /// hydrovu find_youngest to read archive max(timestamp).
+    #[tokio::test]
+    async fn test_read_pond_node_as_parquet_contextless() {
+        use arrow::array::Int64Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+        use parquet::arrow::ArrowWriter;
+        use tinyfs::Lookup;
+        use tokio::io::AsyncWriteExt;
+
+        // Build real Parquet bytes (timestamp in seconds, like the archives).
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "timestamp",
+            DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![100i64, 200, 1_770_000_000]))],
+        )
+        .unwrap();
+        let mut parquet_bytes = Vec::new();
+        {
+            let mut writer = ArrowWriter::try_new(&mut parquet_bytes, schema, None).unwrap();
+            writer.write(&batch).unwrap();
+            let _ = writer.close().unwrap();
+        }
+
+        // Write those bytes into a pond node as a FileDynamic, mirroring
+        // git-ingest archives.
+        let fs = create_test_fs().await;
+        let root = fs.root().await.unwrap();
+        let _ = root.create_dir_path("/hydrovu-archive").await;
+        {
+            let mut w = root
+                .async_writer_path_with_type(
+                    "/hydrovu-archive/dev.series",
+                    tinyfs::EntryType::FileDynamic,
+                )
+                .await
+                .unwrap();
+            w.write_all(&parquet_bytes).await.unwrap();
+            w.flush().await.unwrap();
+            w.shutdown().await.unwrap();
+        }
+
+        let node_path = match root.resolve_path("/hydrovu-archive/dev.series").await.unwrap() {
+            (_, Lookup::Found(np)) => np,
+            _ => panic!("archive node not found"),
+        };
+
+        // No ProviderContext is involved -- bytes are read directly.
+        let table = read_pond_node_as_parquet(&node_path)
+            .await
+            .expect("data node bytes must decode as Parquet");
+
+        let ctx = SessionContext::new();
+        let _ = ctx.register_table("arch", table).unwrap();
+        let results = ctx
+            .sql("SELECT max(timestamp) AS m FROM arch")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let m = results[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0);
+        assert_eq!(m, 1_770_000_000);
     }
 }

--- a/crates/provider/src/url_pattern_matcher.rs
+++ b/crates/provider/src/url_pattern_matcher.rs
@@ -129,6 +129,18 @@ impl UrlPatternMatcher {
             }
         };
 
+        // Explicit `+series`/`+table` cast also accepts data-archetype Parquet
+        // files; the table-provider layer reinterprets them. The cast signal is an
+        // explicit entry_type() suffix. See docs/url-entry-type-casting.md.
+        let mut entry_types = entry_types;
+        if url.entry_type().is_some() && matches!(type_key, "series" | "table") {
+            for t in [EntryType::FileDynamic, EntryType::FilePhysicalVersion] {
+                if !entry_types.contains(&t) {
+                    entry_types.push(t);
+                }
+            }
+        }
+
         // Get TinyFS root and expand pattern
         let fs = context.filesystem();
         let root = fs.root().await?;

--- a/docs/url-entry-type-casting.md
+++ b/docs/url-entry-type-casting.md
@@ -1,0 +1,250 @@
+# URL Entry-Type Casting (read/access-time archetype reinterpretation)
+
+Status: Design / implementation plan (not yet implemented)
+Author: design notes for jmacd
+Related: `hostmount-design.md`, `format-cache-design.md`, `remote-redesign.md`
+
+## Motivation
+
+The caspar.water "noyo-harbor" sub-site lost its historical HydroVu data after the
+post-D6 staging reset. The history exists as committed Parquet `.series` archive files in
+the `noyo-blue-econ` git repo and is exposed into the pond via the `git-ingest` factory.
+However, those archive files are **invisible to the `timeseries-join` (combine) factory**,
+so the dashboards only show data that live API collection has slowly back-filled from epoch.
+
+Root cause: `git-ingest` exposes every blob as `EntryType::FileDynamic` (a *data/dynamic*
+file). The combine join resolves its input patterns to *series* nodes and filters out
+everything else by the node's **stored** entry type. The archive Parquet files are real
+series data, but because they are stored as the *data* archetype they are excluded.
+
+The general fix — and the feature this document specifies — is to make the **URL
+entry-type suffix a read-time cast** that reinterprets a node's archetype, rather than a
+filter on the node's stored archetype. This already works for host files
+(`host+series:///x.parquet`); we are extending the same, already-intended semantics to
+pond paths uniformly.
+
+## Background: the entry-type system
+
+A non-directory, non-symlink entry has one of **six** types, formed by an
+**archetype × embodiment** product:
+
+| archetype | physical embodiment      | dynamic embodiment |
+| --------- | ------------------------ | ------------------ |
+| data      | `FilePhysicalVersion`    | `FileDynamic`      |
+| table     | `TablePhysicalVersion`   | `TableDynamic` (table-shaped dynamic) |
+| series    | `FilePhysicalSeries` / `TablePhysicalSeries` | `TableDynamic` (series-shaped dynamic) |
+
+Helpers (`crates/tinyfs/src/entry_type.rs`):
+- `base_format()` (`:66-78`) collapses embodiment, returning `file:data` / `file:table` /
+  `file:series` — this is the **archetype**.
+- `is_dynamic()` (`:16`), `is_physical()` (`:25`) — the **embodiment**.
+- `is_data_file()` (`:31`), `is_table_file()` (`:40`), `is_series_file()` (`:46`),
+  `is_parquet_file()` (`:55`).
+
+Archetype semantics:
+- **data** — opaque byte content. One logical value per access; versions are independent
+  byte blobs.
+- **table** — a single Parquet table; the meaningful value is the **latest version**.
+- **series** — a multi-version Parquet time series; the meaningful value is **all
+  versions concatenated** (oldest first), with temporal metadata for time-travel.
+
+## The casting model (read/access-time only)
+
+There are **no write-path URLs**. A URL always *reads/accesses* an existing path or
+pattern. The entry-type suffix in the URL declares the archetype the caller wants to
+**interpret the bytes as**. Embodiment (physical/dynamic) is irrelevant to the cast — it
+only affects how bytes are produced, not how they are interpreted.
+
+All Parquet-backed archetypes share the same byte format, so casts are defined by how
+bytes are read or produced:
+
+| from \\ to | data | table | series |
+| ---------- | ---- | ----- | ------ |
+| **data**   | identity (bytes) | read the bytes as one Parquet table | read the bytes as a one-version Parquet series |
+| **table**  | produce Parquet bytes of the latest version | identity | reinterpret latest version as a one-version series |
+| **series** | produce Parquet bytes of **all** versions concatenated | reinterpret as latest version only | identity |
+
+Notes:
+- A *data* file cast to *table*/*series* must contain valid Parquet bytes; otherwise the
+  read errors. (Symmetric to `host+series:///x.parquet` asserting a host file is Parquet.)
+- *table → data* yields the **last** version's Parquet bytes; *series → data* yields **all**
+  versions' Parquet bytes (this is already how physical series concatenate on byte-read —
+  `FilePhysicalSeries` uses a `ChainedReader`, see `entry_type.rs:26-27`,
+  `crates/tlogfs/src/file.rs:220`).
+- The cast is independent of physical/dynamic: a git-ingested `FileDynamic` Parquet blob
+  cast to *series* reads exactly like a physical *data* file cast to *series*.
+
+### URL syntax (already supported by the `Url` type)
+
+Canonical form (`crates/provider/src/lib.rs:122`):
+`[host+]scheme[+compression][+entrytype]:///path[?query]`
+
+- `series:///path` parses as `scheme="file"`, `entry_type()=Some("series")`
+  (`lib.rs:217`, `url_pattern_matcher.rs:82-83`).
+- `file+series:///path`, `csv+series:///path`, `host+series:///path` likewise carry
+  `entry_type()=Some("series")`.
+- The **target archetype** is `url.entry_type()`, falling back to the scheme name for the
+  bare builtins (`series`/`table`/`data`/`file`).
+
+## Current behavior and the gaps
+
+1. **Resolution filters by stored archetype (the central gap).**
+   - `url_pattern_matcher.rs::match_builtin_type` (`:96-158`): builds an `entry_types`
+     set per requested key (`series => [TablePhysicalSeries, TableDynamic]`, `data =>
+     [FilePhysicalVersion, FileDynamic]`, etc.) and keeps a match only if the node's
+     **stored** `file_id.entry_type()` is in that set (`:150`).
+   - `sql_derived.rs::resolve_pattern_to_queryable_files` (`:417-592`) + the caller at
+     `:840-852`: Series mode searches `[TablePhysicalSeries, TableDynamic]` and matches on
+     `actual_entry_type` (`:557`).
+   - Effect: a `series://` pattern over git-ingested `FileDynamic` Parquet matches **zero**
+     files.
+
+2. **`as_queryable()` gate rejects data nodes before any cast.**
+   - `provider_api.rs::create_builtin_table_provider` (`:233-276`) resolves the node then
+     calls `file_guard.as_queryable()` (`:261`), which is `None` for a *data* file
+     (default impl `crates/tinyfs/src/file.rs:55`; only `OpLogFile` series/table implement
+     it, `crates/tlogfs/src/file.rs:212`). Result: `"File ... is not queryable"`.
+
+3. **`create_table_provider` keys the read strategy off the stored type, not a requested
+   archetype.**
+   - `crates/provider/src/table_creation.rs:53-189` already builds a Parquet `ListingTable`
+     and selects versions via `TableProviderOptions.version_selection`
+     (`AllVersions` ⇒ series, `LatestVersion` ⇒ table; `:200-217`). The conversion
+     machinery exists — but there is **no parameter carrying the requested target
+     archetype**; callers pick options based on the stored type.
+
+4. **The host path already implements the cast (precedent / proof of intent).**
+   - `provider_api.rs:131-136` short-circuits `host+table`/`host+series` (scheme `file`)
+     to `create_host_parquet_table_provider` (`:183`), reading raw host bytes directly as
+     Parquet because "the URL asserts they are queryable Parquet." Pond paths should do the
+     same for *data* nodes.
+
+## Design specification
+
+Make the requested archetype (`url.entry_type()` or builtin scheme) drive interpretation
+end-to-end, applying the casting matrix when it differs from the node's stored archetype.
+
+### 1. Resolution: match by path, interpret by archetype
+
+`match_builtin_type` and `resolve_pattern_to_queryable_files` must treat the requested
+archetype as the **interpretation**, not an exclusion predicate:
+- Expand the path/glob to candidate nodes (skip directories and symlinks).
+- Do **not** drop a node because its stored archetype differs from the requested one. Any
+  of the three file archetypes is castable to any other (per the matrix), so all file
+  entry types are candidates.
+- Carry the requested target archetype forward on each match (e.g. on `MatchedFile` /
+  the reconstructed file URL) so the provider layer can apply the cast.
+- The bare `file:///` form (no `entry_type()`) keeps "wildcard / interpret as stored type"
+  behaviour.
+
+Open refinement: decide whether a glob like `series:///dir/*` should match *non-Parquet*
+data files and then error at read, or pre-skip by extension. Recommended: match by path,
+error clearly at read if bytes are not Parquet (consistent with the host-cast behaviour
+and with the "assert via URL" model). Globs in practice target specific suffixes
+(`*.series`).
+
+### 2. Thread the target archetype into `create_table_provider`
+
+Add a target-archetype field to `TableProviderOptions`
+(`crates/provider/src/table_provider_options.rs`), e.g.
+`interpret_as: Archetype` (Data/Table/Series), defaulting to "derive from stored type"
+for backward compatibility.
+
+`create_table_provider` (`table_creation.rs`) maps the **requested** archetype to the
+read strategy:
+- requested **series** ⇒ `VersionSelection::AllVersions` + Parquet `ListingTable`.
+- requested **table** ⇒ `VersionSelection::LatestVersion` + Parquet `ListingTable`.
+- requested **data** (when reading as bytes, not a table) ⇒ byte path, not a TableProvider
+  (see §4).
+
+Because the underlying `ListingTable` reads Parquet via the tinyfs ObjectStore regardless
+of stored type, a *data/dynamic* (git) node requested as *series* will read correctly once
+it reaches this function. Verify version enumeration (`VersionSelection::to_url_pattern`)
+works for dynamic git nodes (single logical version); if not, route single-version data
+nodes through a direct single-file `ListingTable` (mirroring
+`create_host_parquet_table_provider`).
+
+### 3. Bypass the `as_queryable()` gate for cast reads
+
+In `create_builtin_table_provider`, when `url.entry_type()` requests table/series and the
+resolved node is a *data* archetype (or otherwise returns `None` from `as_queryable()`),
+do **not** error. Instead build the provider from the node's bytes as Parquet — a pond
+analogue of `create_host_parquet_table_provider`, reading via the node's
+`async_reader()`. For nodes that *are* natively queryable, keep delegating to
+`as_table_provider` but pass the requested archetype through.
+
+### 4. The reverse cast (series/table → data) on byte reads
+
+Reading a series/table node through a `data://` (or byte) access must yield Parquet bytes:
+- series ⇒ all versions concatenated (already the `FilePhysicalSeries` `ChainedReader`
+  behaviour).
+- table ⇒ last version's bytes.
+This is the byte-read path (`async_reader`/`read_file_version`), not the TableProvider
+path. Confirm the access layer chooses versions per requested archetype. (Lower priority
+for the noyo use-case, which only needs data→series, but specified here for completeness.)
+
+### 5. Propagate the cast through `timeseries-join` / `sql-derived`
+
+The join builds input table providers by reconstructing a per-file URL and calling
+`provider_api.create_table_provider` (`sql_derived.rs:~964, ~1078`) or
+`queryable_file.as_table_provider` (`:~1151`). Ensure the reconstructed URL preserves the
+`+series`/`+table` suffix (the requested archetype) so the provider layer applies the cast.
+This is the path the noyo combine config exercises.
+
+## Affected read surfaces
+
+- `timeseries-join` (combine) and `sql-derived(-series/-table)` factories — primary.
+- Direct builtin reads via `provider_api::create_table_provider` (e.g. `pond cat`, sitegen
+  queries) — benefit automatically once §2/§3 land.
+- Caching: `TableProviderKey` (`table_creation.rs:68`) **must include the requested
+  archetype**, so `series://X` and `table://X` over the same node cache distinctly.
+
+## Edge cases
+
+- **Compression suffix**: `series+gzip://` etc. must compose with the cast (decompress,
+  then interpret as Parquet).
+- **Schema inference / 0-byte versions**: existing `infer_schema` already skips 0-byte
+  override versions (`table_creation.rs:117-124`); unchanged.
+- **Non-Parquet data cast to table/series**: clear error, naming the path and requested
+  archetype.
+- **Temporal bounds**: `get_temporal_bounds` (`table_creation.rs:144`) returns unbounded
+  for nodes lacking metadata (git nodes) — acceptable; data-quality filtering simply does
+  not apply.
+- **Format-provider schemes** (`csv+series://`, `excelhtml://`): unchanged — those route
+  through their format provider, which already maps to the *data* lookup; casting concerns
+  the **builtin/Parquet** path only.
+
+## Testing plan
+
+- Unit: `Url` parsing of `series://`, `file+series://`, `table://`, `data://` → correct
+  `entry_type()`/scheme (extend existing `lib.rs` tests).
+- Resolution: a glob over a directory containing `FileDynamic` Parquet files matches under
+  `series://` (regression for the current exclusion).
+- Provider: `create_table_provider` over a *data/dynamic* node requested as *series*
+  returns a queryable provider with the expected rows; over a *table* request returns the
+  latest version only.
+- Join: a `timeseries-join` with one `series:///…/*.series` input pointing at git-ingested
+  Parquet yields the archive rows; combined with a live series input, the union spans the
+  full range.
+- Cache: `series://X` and `table://X` over the same node produce distinct providers.
+
+## First consumer: caspar.water noyo archives
+
+Once the cast lands in duckpond:
+1. `config/noyo.yaml`: add a `git-ingest` `mknod` exposing the `noyo-blue-econ` HydroVu
+   archives at a read-only path (e.g. `/system/archive/hydrovu`, `prefix: hydrovu`).
+2. Add `timeseries-join` inputs casting those Parquet files as series, e.g.
+   `series:///system/archive/hydrovu/devices/**/NoyoCenterVulink_2*.series` with the
+   matching `scope`, alongside the existing live `/hydrovu/devices/**/…` inputs.
+3. Rebuild the duckpond image, deploy staging, `pond apply`, rebuild the site; verify the
+   noyo DO/Temperature/Salinity pages show history back to the archive range (Feb 2026).
+
+## Out of scope (tracked separately)
+
+- **HydroVu resume seeding.** `find_youngest_timestamp`
+  (`crates/hydrovu/src/lib.rs:430-526`) reads temporal metadata from
+  `list_file_versions` (the oplog), which git dynamic nodes lack. Making live API
+  collection resume from the archive max (instead of epoch) requires either footer-derived
+  bounds in `find_youngest` or seeding `/hydrovu/devices` directly. Display (this doc) is
+  independent: the combine union surfaces archive history immediately while live
+  collection back-fills the recent tail.

--- a/docs/url-entry-type-casting.md
+++ b/docs/url-entry-type-casting.md
@@ -1,6 +1,6 @@
 # URL Entry-Type Casting (read/access-time archetype reinterpretation)
 
-Status: Design / implementation plan (not yet implemented)
+Status: Display cast + HydroVu resume implemented; reverse cast (§4) deferred
 Author: design notes for jmacd
 Related: `hostmount-design.md`, `format-cache-design.md`, `remote-redesign.md`
 
@@ -239,15 +239,28 @@ Once the cast lands in duckpond:
 3. Rebuild the duckpond image, deploy staging, `pond apply`, rebuild the site; verify the
    noyo DO/Temperature/Salinity pages show history back to the archive range (Feb 2026).
 
-## Out of scope (tracked separately)
+## Resume (implemented): HydroVu live collection from archive max
 
-- **HydroVu resume seeding.** `find_youngest_timestamp`
-  (`crates/hydrovu/src/lib.rs:430-526`) reads temporal metadata from
-  `list_file_versions` (the oplog), which git dynamic nodes lack. Making live API
-  collection resume from the archive max (instead of epoch) requires either footer-derived
-  bounds in `find_youngest` or seeding `/hydrovu/devices` directly. Display (this doc) is
-  independent: the combine union surfaces archive history immediately while live
-  collection back-fills the recent tail.
+`find_youngest_timestamp` (`crates/hydrovu/src/lib.rs`) reads temporal metadata
+from `list_file_versions` (the oplog) for the **writeable** device directory.
+git-ingested archive nodes are `FileDynamic` and carry no oplog metadata, so on
+a freshly reset pond the writeable directory is empty and resume would otherwise
+start from epoch.
+
+The resume path now uses the `provider_api` byte-cast (below): `HydroVuConfig`
+gained an optional `archive_path`. When the writeable directory has no temporal
+data and `archive_path` is set, `find_archive_youngest_micros` enumerates
+`{archive_path}/devices/{device_id}/*.series`, opens each via a contextless
+`series://` cast, runs `SELECT max(timestamp)`, normalizes the scalar to
+microseconds (`scalar_timestamp_to_micros`: the seed archives store `timestamp`
+as INT64 **seconds**; logical `Timestamp` types scale per their unit), and
+resumes from `archive_max + 1s`. The archive is consulted ONLY on the first run
+(empty writeable dir); subsequent runs use the oplog max as before. No archives
+are written — they are read-only git seeds.
+
+caspar.water `config/noyo.yaml` mounts the archives at `/hydrovu-archive`
+(git-ingest, prefix `hydrovu`) and sets `archive_path: /hydrovu-archive` on the
+hydrovu factory.
 
 ## Implementation status
 
@@ -267,10 +280,16 @@ Once the cast lands in duckpond:
   data→series case the noyo combine config needs. Tests:
   `test_series_cast_over_single_data_parquet_file`,
   `test_series_cast_over_multiple_data_parquet_files`.
-  - The `TableProviderOptions`/`provider_api` archetype threading (§2/§3 as originally
-    written) is **not** implemented; direct `provider_api::create_table_provider` byte-cast
-    reads (e.g. `pond cat series://<data-node>`) are not yet wired and remain follow-up if
-    needed. The join path — the noyo consumer — is fully covered.
+- **provider_api byte-cast (done)** — `provider_api::create_table_provider` now
+  honors a `+series`/`+table` cast over a non-queryable pond node WITHOUT a
+  `ProviderContext`: `Provider::try_cast_data_node_to_parquet` resolves the node
+  and, when `as_queryable().is_none()` (the capability gate — not `is_data_file()`,
+  which includes `FilePhysicalSeries`), reads its bytes as Parquet. The
+  parquet-bytes→`MemTable` logic is extracted into the shared module-level
+  `read_pond_node_as_parquet`, reused by both `provider_api` and the
+  `timeseries-join` helper. This is the route HydroVu resume uses
+  (`series://{archive}/devices/<id>/<file>.series` + `SELECT max(timestamp)`).
+  Test: `test_read_pond_node_as_parquet_contextless`.
 - **Step 4 (reverse cast, series/table → data)** — not implemented (lower priority).
 - **Caching note** — the join's data-cast path builds a fresh `MemTable` per resolution and
   does not key on archetype; the `TableProviderKey` archetype concern applies only to the

--- a/docs/url-entry-type-casting.md
+++ b/docs/url-entry-type-casting.md
@@ -248,3 +248,30 @@ Once the cast lands in duckpond:
   bounds in `find_youngest` or seeding `/hydrovu/devices` directly. Display (this doc) is
   independent: the combine union surfaces archive history immediately while live
   collection back-fills the recent tail.
+
+## Implementation status
+
+- **Step 1 (done, `d0d205a0`)** — Resolution accepts data-archetype nodes under an
+  explicit `+series`/`+table` cast. `resolve_pattern_to_queryable_files`
+  (`sql_derived.rs`) and `match_builtin_type` (`url_pattern_matcher.rs`) add
+  `FileDynamic`/`FilePhysicalVersion` to the lookup set when `url.entry_type().is_some()`.
+- **Steps 2–3 (done, `b612fc43`)** — Realized pragmatically inside the `timeseries-join`
+  builtin path rather than by threading an archetype field through `TableProviderOptions`
+  → `create_table_provider` → `create_builtin_table_provider`. New helper
+  `SqlDerivedFile::cast_data_node_to_parquet_provider` reads a non-queryable data node's
+  bytes and decodes them into a Parquet `MemTable` — the pond analogue of
+  `create_host_parquet_table_provider`. The single-file branch uses it directly; the
+  multiple-file branch unions queryable `ListingTable` sources with per-file data-cast
+  `MemTable`s (`UNION ALL BY NAME`). `queryable_files` is deduped by `FileID` because a
+  cast data node is accepted by every series/table entry-type search. This covers the
+  data→series case the noyo combine config needs. Tests:
+  `test_series_cast_over_single_data_parquet_file`,
+  `test_series_cast_over_multiple_data_parquet_files`.
+  - The `TableProviderOptions`/`provider_api` archetype threading (§2/§3 as originally
+    written) is **not** implemented; direct `provider_api::create_table_provider` byte-cast
+    reads (e.g. `pond cat series://<data-node>`) are not yet wired and remain follow-up if
+    needed. The join path — the noyo consumer — is fully covered.
+- **Step 4 (reverse cast, series/table → data)** — not implemented (lower priority).
+- **Caching note** — the join's data-cast path builds a fresh `MemTable` per resolution and
+  does not key on archetype; the `TableProviderKey` archetype concern applies only to the
+  unimplemented `provider_api`/`create_table_provider` route.

--- a/testsuite/tests/027-data-node-entry-type-cast.sh
+++ b/testsuite/tests/027-data-node-entry-type-cast.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# EXPERIMENT: URL entry-type cast of a data file to Parquet (series + table)
+# DESCRIPTION: A data-archetype node that holds raw Parquet bytes but is not
+#   natively queryable (Format: "Raw data") can be reinterpreted as a queryable
+#   series/table via a `series://` / `table://` URL cast (the pond analogue of
+#   the host parquet cast). This covers BOTH archetypes:
+#     - FilePhysicalVersion: a parquet file copied in raw via host:// .
+#     - FileDynamic:         a parquet file exposed by git-ingest.
+#   Cross BOTH cast entry types (series and table) = 4 combinations.
+#   See docs/url-entry-type-casting.md. The same byte-cast powers HydroVu
+#   resume (find_youngest reading archive max(timestamp) over series://).
+# EXPECTED: All 4 casts query cleanly; a non-Parquet data file casts to a clear
+#   Parquet error rather than an opaque "not queryable" error.
+set -e
+source check.sh
+
+echo "=== Experiment: data-file -> series/table entry-type cast ==="
+
+pond init
+
+# ---- Setup: produce a real Parquet file (no external tooling) ----
+# A synthetic-timeseries node is queryable; copy it OUT to the host to obtain
+# valid Parquet bytes (7 rows), which we then re-ingest as raw data nodes.
+cat > /tmp/synth.yaml << 'YAML'
+start: "2024-01-01T00:00:00Z"
+end: "2024-01-01T06:00:00Z"
+interval: "1h"
+time_column: "timestamp"
+points:
+  - name: "temperature"
+    components:
+      - type: line
+        slope: 0.0
+        offset: 20.0
+YAML
+
+pond mkdir /sensors
+pond mknod synthetic-timeseries /sensors/weather --config-path /tmp/synth.yaml
+
+mkdir -p /tmp/cast-export
+pond copy /sensors/weather "host:///tmp/cast-export"
+cp /tmp/cast-export/sensors/weather /tmp/weather.parquet
+check '[ "$(head -c4 /tmp/weather.parquet | od -A n -t x1 | tr -d " ")" = "50415231" ]' \
+    "exported file has PAR1 magic (valid parquet)"
+
+# ---- Archetype 1: FilePhysicalVersion (raw parquet copied into the pond) ----
+# host:// (no +table/+series) stores the bytes verbatim as a physical data file.
+pond copy "host:///tmp/weather.parquet" /phys.parquet
+pond describe /phys.parquet > /tmp/desc-phys.txt 2>&1
+check_contains /tmp/desc-phys.txt "physical node is FilePhysicalVersion" 'FilePhysicalVersion'
+check_contains /tmp/desc-phys.txt "physical node is raw data (needs cast)" 'Raw data'
+
+# ---- Archetype 2: FileDynamic (parquet exposed via git-ingest) ----
+REPO_DIR=/tmp/cast-repo
+rm -rf "$REPO_DIR"
+mkdir -p "$REPO_DIR/archive"
+cp /tmp/weather.parquet "$REPO_DIR/archive/weather.parquet"
+( cd "$REPO_DIR" && git init -b main >/dev/null && \
+  git config user.email test@example.com && git config user.name "Test User" && \
+  git add -A && git commit -m "parquet archive" >/dev/null )
+
+cat > /tmp/git-arch.yaml << EOF
+url: file://${REPO_DIR}
+ref: main
+prefix: archive
+EOF
+pond mknod git-ingest /gitarch --config-path /tmp/git-arch.yaml
+pond run /gitarch pull
+pond describe /gitarch/weather.parquet > /tmp/desc-dyn.txt 2>&1
+check_contains /tmp/desc-dyn.txt "dynamic node is FileDynamic" 'FileDynamic'
+check_contains /tmp/desc-dyn.txt "dynamic node is raw data (needs cast)" 'Raw data'
+
+echo ""
+echo "--- Verification: 4 cast combinations all query cleanly ---"
+
+# Physical + series
+pond cat --sql "SELECT count(*) AS n FROM source" --format table \
+    "series:///phys.parquet" > /tmp/q-phys-series.txt 2>&1
+check_contains /tmp/q-phys-series.txt "physical + series:// casts and counts 7 rows" '| 7'
+
+# Physical + table
+pond cat --sql "SELECT count(*) AS n FROM source" --format table \
+    "table:///phys.parquet" > /tmp/q-phys-table.txt 2>&1
+check_contains /tmp/q-phys-table.txt "physical + table:// casts and counts 7 rows" '| 7'
+
+# Dynamic + series
+pond cat --sql "SELECT count(*) AS n FROM source" --format table \
+    "series:///gitarch/weather.parquet" > /tmp/q-dyn-series.txt 2>&1
+check_contains /tmp/q-dyn-series.txt "dynamic + series:// casts and counts 7 rows" '| 7'
+
+# Dynamic + table
+pond cat --sql "SELECT count(*) AS n FROM source" --format table \
+    "table:///gitarch/weather.parquet" > /tmp/q-dyn-table.txt 2>&1
+check_contains /tmp/q-dyn-table.txt "dynamic + table:// casts and counts 7 rows" '| 7'
+
+# The cast must decode the real schema, not just succeed: a typed column reads.
+pond cat --sql "SELECT temperature FROM source LIMIT 1" --format table \
+    "series:///gitarch/weather.parquet" > /tmp/q-schema.txt 2>&1
+check_contains /tmp/q-schema.txt "cast preserves column schema (temperature)" 'temperature'
+check_contains /tmp/q-schema.txt "cast preserves column type (Float64)" 'Float64'
+
+echo ""
+echo "--- Verification: non-Parquet data file gives a clear Parquet error ---"
+echo "this is not parquet" > /tmp/plain.txt
+pond copy "host:///tmp/plain.txt" /plain.txt
+pond cat --sql "SELECT 1 FROM source" --format table \
+    "series:///plain.txt" > /tmp/q-bad.txt 2>&1 || true
+check 'grep -qiE "parquet" /tmp/q-bad.txt' "non-parquet cast yields a Parquet error (not 'not queryable')"
+check '! grep -qi "not queryable" /tmp/q-bad.txt' "error is not the opaque 'not queryable' message"
+
+check_finish


### PR DESCRIPTION
This fixes an incorrectly interpreted design: the use of series:// and table:// URLs are meant to support reintrepreting a file type e.g., to allow data files in Parquet to be interpreted as series files.