### PR TITLE
Tolerate zero-match inputs in timeseries-join

### DIFF
--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -1184,9 +1184,16 @@ impl SqlDerivedFile {
     /// Resolve a single pattern to its source files, build a source
     /// TableProvider, apply transforms and scope prefixes, and register it in
     /// the DataFusion session under a deterministic table name.  Records the
-    /// pattern -> table-name mapping in `table_mappings`.  Patterns matching no
-    /// files are skipped; tables already registered (shared source files) are
-    /// not rebuilt.
+    /// pattern -> table-name mapping in `table_mappings`.  Tables already
+    /// registered (shared source files) are not rebuilt.
+    ///
+    /// Returns `true` when a real source table was registered (and mapped), or
+    /// `false` when the pattern matched no files.  A zero-match pattern is NOT
+    /// an error: a glob is a set and an empty set is valid.  The caller is
+    /// responsible for registering an empty placeholder for the unmatched
+    /// pattern (see `register_empty_pattern_table`), because the generated SQL
+    /// still references every configured input by name and would otherwise fail
+    /// to plan with "table 'inputN' not found".
     async fn register_pattern_source(
         &self,
         id: FileID,
@@ -1194,7 +1201,7 @@ impl SqlDerivedFile {
         pattern_name: &str,
         pattern: &crate::Url,
         table_mappings: &mut HashMap<String, String>,
-    ) -> TinyFSResult<()> {
+    ) -> TinyFSResult<bool> {
         let ctx = &context.datafusion_session;
 
         // Source files can be created by factories (Dynamic) or direct uploads
@@ -1251,7 +1258,7 @@ impl SqlDerivedFile {
         }
 
         if queryable_files.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
         // Data-only table name: depends ONLY on the pattern URL and resolved
@@ -1295,7 +1302,7 @@ impl SqlDerivedFile {
                 "[GO] SQL-DERIVED: Data table '{}' already registered, skipping construction",
                 unique_table_name
             );
-            return Ok(());
+            return Ok(true);
         }
 
         let scheme = pattern.scheme();
@@ -1386,7 +1393,102 @@ impl SqlDerivedFile {
             unique_table_name, pattern_name
         );
 
+        Ok(true)
+    }
+
+    /// Register an empty placeholder table for a pattern that matched no files.
+    ///
+    /// The generated SQL (notably from `timeseries-join`) references every
+    /// configured input by its `inputN` alias, so an unmatched input must still
+    /// resolve to a table or planning fails with "table 'inputN' not found".
+    /// The placeholder contributes zero rows, so `UNION BY NAME` / `FULL JOIN`
+    /// simply ignore it.
+    ///
+    /// The placeholder schema is cloned from a sibling input that shares the
+    /// same scope (and therefore the same post-scope-prefix columns), so the
+    /// empty side is type- and name-compatible without any guessing.  When the
+    /// whole scope group is empty (no sibling resolved) we fall back to a lone
+    /// time column.
+    async fn register_empty_pattern_table(
+        &self,
+        id: FileID,
+        context: &tinyfs::ProviderContext,
+        pattern_name: &str,
+        table_mappings: &mut HashMap<String, String>,
+    ) -> TinyFSResult<()> {
+        use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+        use datafusion::datasource::MemTable;
+
+        let ctx = &context.datafusion_session;
+
+        let schema = match self
+            .sibling_scope_schema(ctx, pattern_name, table_mappings)
+            .await
+        {
+            Some(schema) => schema,
+            None => {
+                // Whole-scope-empty fallback: a single time column.  The time
+                // column name comes from the input's scope config; default
+                // "timestamp".  Microsecond UTC matches the canonical series
+                // timestamp normalization.
+                let time_col = self
+                    .config
+                    .scope_prefixes
+                    .as_ref()
+                    .and_then(|sp| sp.get(pattern_name))
+                    .map(|(_, tc)| tc.clone())
+                    .unwrap_or_else(|| "timestamp".to_string());
+                Arc::new(Schema::new(vec![Field::new(
+                    time_col,
+                    DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                    true,
+                )]))
+            }
+        };
+
+        let node_id_hex = id.node_id().to_string().replace('-', "");
+        let table_name = format!("sql_derived_empty_{}_{}", pattern_name, node_id_hex);
+        let empty = MemTable::try_new(schema, vec![vec![]]).map_other()?;
+        _ = ctx
+            .register_table(
+                datafusion::sql::TableReference::bare(table_name.as_str()),
+                Arc::new(empty),
+            )
+            .map_other()?;
+        _ = table_mappings.insert(pattern_name.to_string(), table_name);
+        debug!(
+            "[OK] SQL-DERIVED: Registered empty placeholder for zero-match pattern '{}'",
+            pattern_name
+        );
         Ok(())
+    }
+
+    /// Find the schema of an already-registered sibling input that shares the
+    /// same scope as `pattern_name`, used to build a compatible empty
+    /// placeholder.  Returns `None` when scopes are not configured or no
+    /// same-scope sibling has been registered yet.
+    async fn sibling_scope_schema(
+        &self,
+        ctx: &datafusion::prelude::SessionContext,
+        pattern_name: &str,
+        table_mappings: &HashMap<String, String>,
+    ) -> Option<arrow::datatypes::SchemaRef> {
+        let scope_prefixes = self.config.scope_prefixes.as_ref()?;
+        let (scope, _) = scope_prefixes.get(pattern_name)?;
+        let schema = ctx.catalog("datafusion")?.schema("public")?;
+
+        for (other_pattern, (other_scope, _)) in scope_prefixes.iter() {
+            if other_pattern == pattern_name || other_scope != scope {
+                continue;
+            }
+            let Some(table_name) = table_mappings.get(other_pattern) else {
+                continue;
+            };
+            if let Ok(Some(provider)) = schema.table(table_name).await {
+                return Some(provider.schema());
+            }
+        }
+        None
     }
 }
 
@@ -1419,9 +1521,23 @@ impl tinyfs::QueryableFile for SqlDerivedFile {
         // Create mapping from user pattern names to unique internal table names
         let mut table_mappings = HashMap::new();
 
-        // Register each pattern as a table in the session context
+        // Register each pattern as a table in the session context.  Patterns
+        // that match no files are collected and handled in a second pass: the
+        // generated SQL references every input by name, so an unmatched input
+        // must still resolve to an (empty) table or planning fails.  The second
+        // pass runs after all real tables are registered so empty placeholders
+        // can borrow a same-scope sibling's schema.
+        let mut empty_patterns = Vec::new();
         for (pattern_name, pattern) in &self.get_config().patterns {
-            self.register_pattern_source(id, context, pattern_name, pattern, &mut table_mappings)
+            let registered = self
+                .register_pattern_source(id, context, pattern_name, pattern, &mut table_mappings)
+                .await?;
+            if !registered {
+                empty_patterns.push(pattern_name.clone());
+            }
+        }
+        for pattern_name in &empty_patterns {
+            self.register_empty_pattern_table(id, context, pattern_name, &mut table_mappings)
                 .await?;
         }
 

--- a/crates/provider/src/factory/timeseries_join.rs
+++ b/crates/provider/src/factory/timeseries_join.rs
@@ -857,6 +857,141 @@ mod tests {
         );
     }
 
+    // Regression: a timeseries-join input whose glob matches zero nodes must
+    // not break the whole query.  The generated SQL references every input by
+    // its `inputN` alias, so before the empty-placeholder fix an unmatched
+    // input produced "table 'inputN' not found" and aborted the build.  This
+    // mirrors the noyo combine, where a decommissioned instrument has archive
+    // data but no live `/hydrovu/...` series, leaving the live input empty.
+    #[tokio::test]
+    async fn test_timeseries_join_zero_match_input_is_empty_set() {
+        let (fs, provider_context) = create_test_environment().await;
+
+        // Helper to write a single-column series at `path`.
+        async fn write_series(
+            fs: &tinyfs::FS,
+            path: &str,
+            col: &str,
+            ts: Vec<i64>,
+            vals: Vec<f64>,
+        ) {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new(
+                    "timestamp",
+                    DataType::Timestamp(TimeUnit::Second, None),
+                    false,
+                ),
+                Field::new(col, DataType::Float64, false),
+            ]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(TimestampSecondArray::from(ts)),
+                    Arc::new(Float64Array::from(vals)),
+                ],
+            )
+            .unwrap();
+            let mut buf = Vec::new();
+            {
+                let cursor = Cursor::new(&mut buf);
+                let mut writer = ArrowWriter::try_new(cursor, schema, None).unwrap();
+                writer.write(&batch).unwrap();
+                _ = writer.close().unwrap();
+            }
+            _ = create_parquet_file(fs, path, buf, EntryType::TablePhysicalSeries)
+                .await
+                .unwrap();
+        }
+
+        // "archive" (resolves) and a same-scope "live" input that matches
+        // nothing, plus a second scope that resolves so we exercise the join.
+        write_series(
+            &fs,
+            "/silver_archive.series",
+            "temp",
+            vec![1, 2, 3],
+            vec![10.0, 20.0, 30.0],
+        )
+        .await;
+        write_series(
+            &fs,
+            "/field_live.series",
+            "pressure",
+            vec![2, 3, 4],
+            vec![100.0, 101.0, 102.0],
+        )
+        .await;
+
+        let root_id = FileID::root();
+        let context = test_context(&provider_context, root_id);
+
+        let config = TimeseriesJoinConfig {
+            time_column: "timestamp".to_string(),
+            inputs: vec![
+                TimeseriesInput {
+                    pattern: crate::Url::parse("series:///silver_archive.series").unwrap(),
+                    scope: Some("Silver".to_string()),
+                    range: None,
+                    transforms: None,
+                },
+                // Decommissioned-instrument live counterpart: matches no node.
+                TimeseriesInput {
+                    pattern: crate::Url::parse("series:///does_not_exist_*.series").unwrap(),
+                    scope: Some("Silver".to_string()),
+                    range: None,
+                    transforms: None,
+                },
+                TimeseriesInput {
+                    pattern: crate::Url::parse("series:///field_live.series").unwrap(),
+                    scope: Some("Field".to_string()),
+                    range: None,
+                    transforms: None,
+                },
+            ],
+        };
+
+        let join_file = TimeseriesJoinFile::new(config, context).unwrap();
+        let table_provider = join_file
+            .as_table_provider(root_id, &provider_context)
+            .await
+            .expect("zero-match input must not fail the join");
+
+        let ctx = &provider_context.datafusion_session;
+        let df_state = ctx.state();
+        let plan = table_provider
+            .scan(&df_state, None, &[], None)
+            .await
+            .unwrap();
+        let task_ctx = ctx.task_ctx();
+        let stream = plan.execute(0, task_ctx).unwrap();
+
+        use futures::StreamExt;
+        let batches: Vec<_> = stream
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert!(!batches.is_empty(), "join should still produce rows");
+        let column_names: Vec<String> = batches[0]
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert!(
+            column_names.iter().any(|n| n == "Silver.temp"),
+            "resolved Silver input data must survive the empty same-scope sibling, got {column_names:?}"
+        );
+        assert!(
+            column_names.iter().any(|n| n == "Field.pressure"),
+            "second scope must be present, got {column_names:?}"
+        );
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 4, "union of timestamps 1,2,3,4 = 4 rows");
+    }
+
     #[tokio::test]
     async fn test_timeseries_join_same_scope_non_overlapping_ranges() {
         // Test the Silver case: two Vulink devices with same scope but non-overlapping time ranges

--- a/testsuite/tests/104-timeseries-join-empty-input.sh
+++ b/testsuite/tests/104-timeseries-join-empty-input.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# EXPERIMENT: Timeseries join where one input glob matches zero nodes
+# EXPECTED: A timeseries-join input whose pattern resolves to no nodes is
+#           treated as an empty set (contributes no rows) instead of aborting
+#           the query with "table 'inputN' not found".  This mirrors the noyo
+#           combine, where a decommissioned instrument has archive data but no
+#           live `/hydrovu/...` series, leaving the live input empty.
+set -e
+
+echo "=== Experiment: Timeseries Join with a Zero-Match Input ==="
+
+pond init
+
+# --- Dynamic directory config ------------------------------------------------
+# station_a (scope StationA) and station_b (scope StationB) both exist.
+# The `combined` join also lists a SAME-SCOPE-as-StationA input whose glob
+# (/sensors/missing_station_*) matches NO node.  Before the empty-placeholder
+# fix this produced "table 'input1' not found" and failed the whole join.
+cat > /tmp/sensors.yaml << 'YAML'
+entries:
+  - name: "station_a"
+    factory: "synthetic-timeseries"
+    config:
+      start: "2024-01-01T00:00:00Z"
+      end:   "2024-01-10T00:00:00Z"
+      interval: "1h"
+      points:
+        - name: "temperature"
+          components:
+            - type: sine
+              amplitude: 5.0
+              period: "24h"
+              offset: 20.0
+
+  - name: "station_b"
+    factory: "synthetic-timeseries"
+    config:
+      start: "2024-01-05T00:00:00Z"
+      end:   "2024-01-15T00:00:00Z"
+      interval: "1h"
+      points:
+        - name: "temperature"
+          components:
+            - type: triangle
+              amplitude: 8.0
+              period: "24h"
+              offset: 30.0
+
+  - name: "combined"
+    factory: "timeseries-join"
+    config:
+      inputs:
+        - pattern: "/sensors/station_a"
+          scope: StationA
+        # Zero-match input, SAME scope as station_a (decommissioned-instrument
+        # live counterpart that never produced a node).
+        - pattern: "/sensors/missing_station_*"
+          scope: StationA
+        - pattern: "/sensors/station_b"
+          scope: StationB
+YAML
+
+pond mknod dynamic-dir /sensors --config-path /tmp/sensors.yaml
+echo "[OK] mknod dynamic-dir succeeded"
+
+echo ""
+echo "=== Directory listing ==="
+pond list /sensors/
+
+# --- The combined join must build despite the zero-match input ---------------
+echo ""
+echo "=== Combined: row count & full time range (must NOT error) ==="
+pond cat /sensors/combined --format=table --sql "
+  SELECT
+    COUNT(*)       AS rows,
+    MIN(timestamp) AS first_ts,
+    MAX(timestamp) AS last_ts
+  FROM source
+"
+
+# --- Both real scopes' data survive the empty same-scope sibling -------------
+echo ""
+echo "=== Combined: both scopes present ==="
+pond cat /sensors/combined --format=table --sql "
+  SELECT
+    COUNT(\"StationA.temperature\") AS a_present,
+    COUNT(\"StationB.temperature\") AS b_present
+  FROM source
+"
+
+# --- Verification ------------------------------------------------------------
+# The core regression is simply that `pond cat /sensors/combined` plans at all
+# (before the fix it errored "table 'input1' not found").  Beyond that, we
+# assert the resolved StationA data was NOT wiped by the empty same-scope
+# sibling, and that StationB (the other scope) is present.  We grep the ASCII
+# table output rather than parse it, and rely on `set -e` so any query error
+# fails the test.
+echo ""
+echo "=== VERIFICATION: StationA data survived the empty same-scope sibling ==="
+A_OUT=$(pond cat /sensors/combined --format=table --sql "
+  SELECT timestamp, \"StationA.temperature\" AS a
+  FROM source
+  WHERE \"StationA.temperature\" IS NOT NULL
+  ORDER BY timestamp
+  LIMIT 1
+")
+echo "${A_OUT}"
+if echo "${A_OUT}" | grep -q "No data found"; then
+  echo "FAIL: resolved StationA input was wiped by the empty same-scope sibling"
+  exit 1
+fi
+echo "${A_OUT}" | grep -q "2024-01-01" || {
+  echo "FAIL: StationA earliest row missing"
+  exit 1
+}
+
+echo ""
+echo "=== VERIFICATION: StationB scope present ==="
+B_OUT=$(pond cat /sensors/combined --format=table --sql "
+  SELECT timestamp, \"StationB.temperature\" AS b
+  FROM source
+  WHERE \"StationB.temperature\" IS NOT NULL
+  ORDER BY timestamp
+  LIMIT 1
+")
+echo "${B_OUT}"
+if echo "${B_OUT}" | grep -q "No data found"; then
+  echo "FAIL: StationB scope missing"
+  exit 1
+fi
+
+echo ""
+echo "[OK] Zero-match input tolerated; both resolved scopes intact."
+echo "=== Experiment Complete ==="


### PR DESCRIPTION
A timeseries-join input whose glob matches no nodes previously aborted the entire query: register_pattern_source returned Ok(()) without mapping the pattern, while the generated SQL still referenced every input by its `inputN` alias, so DataFusion failed to plan with "table 'inputN' not found".

This broke the noyo combine after an archive-resume reset: decommissioned HydroVu instruments have archive `.series` data but will never have a live `/hydrovu/...` series, leaving their live input permanently empty and the whole site build failing on /reduced/single_param/DO.

A glob is a set and an empty set is valid, so an unmatched input should simply contribute no rows. register_pattern_source now reports whether it registered a real table; as_table_provider collects zero-match patterns and, in a second pass, registers an empty placeholder table for each so the SQL still plans. The placeholder schema is cloned from a same-scope sibling (type/name compatible for UNION BY NAME / FULL JOIN), falling back to a lone time column when the whole scope group is empty.

Tests:
- unit: timeseries_join zero-match input is treated as an empty set
- testsuite: 104-timeseries-join-empty-input.sh (end-to-end via pond cat)