### PR TITLE
Make empty timeseries-join placeholder registration idempotent

### DIFF
--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -1421,6 +1421,28 @@ impl SqlDerivedFile {
 
         let ctx = &context.datafusion_session;
 
+        // The placeholder name is deterministic in (pattern, node_id), and the
+        // session context is shared across reads, so the same node re-evaluated
+        // within a build (e.g. one export per resolution) would otherwise try
+        // to register the same table twice.  Mirror the real-table path: if it
+        // already exists, just (re)record the mapping and return.
+        let node_id_hex = id.node_id().to_string().replace('-', "");
+        let table_name = format!("sql_derived_empty_{}_{}", pattern_name, node_id_hex);
+
+        let already_registered = matches!(
+            ctx.catalog("datafusion")
+                .expect("registered")
+                .schema("public")
+                .expect("defined")
+                .table(&table_name)
+                .await,
+            Ok(Some(_))
+        );
+        if already_registered {
+            _ = table_mappings.insert(pattern_name.to_string(), table_name);
+            return Ok(());
+        }
+
         let schema = match self
             .sibling_scope_schema(ctx, pattern_name, table_mappings)
             .await
@@ -1446,8 +1468,6 @@ impl SqlDerivedFile {
             }
         };
 
-        let node_id_hex = id.node_id().to_string().replace('-', "");
-        let table_name = format!("sql_derived_empty_{}_{}", pattern_name, node_id_hex);
         let empty = MemTable::try_new(schema, vec![vec![]]).map_other()?;
         _ = ctx
             .register_table(

--- a/crates/provider/src/factory/timeseries_join.rs
+++ b/crates/provider/src/factory/timeseries_join.rs
@@ -956,6 +956,22 @@ mod tests {
             .await
             .expect("zero-match input must not fail the join");
 
+        // Re-evaluate the SAME node through a different ProviderContext that
+        // shares the DataFusion session but has a fresh provider cache.  This
+        // is what happens when a derived node is read more than once within a
+        // single build (e.g. one sitegen export per resolution): the cache
+        // misses, so registration runs again against the shared session.  The
+        // empty placeholder must be registered idempotently and not fail with
+        // "table 'sql_derived_empty_...' already exists".
+        let provider_context2 = crate::ProviderContext::new(
+            provider_context.datafusion_session.clone(),
+            provider_context.persistence.clone(),
+        );
+        let _second = join_file
+            .as_table_provider(root_id, &provider_context2)
+            .await
+            .expect("re-registering the empty placeholder must be idempotent");
+
         let ctx = &provider_context.datafusion_session;
         let df_state = ctx.state();
         let plan = table_provider


### PR DESCRIPTION
The zero-match placeholder table (sql_derived_empty_<input>_<node_id>) is registered into the shared DataFusion session, which persists across reads. When the same derived node is re-evaluated within one build through a ProviderContext whose provider cache misses (e.g. one sitegen export per resolution), registration ran again and failed with "table 'sql_derived_empty_...' already exists", aborting the noyo /reduced/single_param/DO export.

Mirror the real-table path: check whether the deterministic placeholder name is already registered and, if so, just re-record the pattern->table mapping and return instead of re-registering.

Extends the zero-match unit test to re-evaluate the node through a second ProviderContext that shares the session but has a fresh cache, reproducing the "already exists" failure without the guard.