### PR TITLE
Fix temporal-reduce rollup for columns absent in older input versions

### DIFF
--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -627,7 +627,18 @@ impl TemporalReduceSqlFile {
             parquet_path.display()
         ))?;
 
-        let partial_sql = pieces.partial_sql(finest_interval, &self.config.time_column, table);
+        let available: std::collections::HashSet<String> = ctx
+            .table(table)
+            .await
+            .map_other_context("read cached version schema")?
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+
+        let partial_sql =
+            pieces.partial_sql(finest_interval, &self.config.time_column, table, &available);
         let stream = ctx
             .sql(&partial_sql)
             .await
@@ -991,6 +1002,30 @@ impl PartialKind {
         }
     }
 
+    /// Like [`raw_expr`], but emits a typed placeholder when the source column
+    /// is absent from this input version. An oteljson source builds a per-file
+    /// wide schema from the metric names present in that file, so a metric that
+    /// appears or is renamed over history is missing from older versions. The
+    /// single-pass query never sees this because it reads the unioned glob where
+    /// the absent column reads as NULL, but a per-version partial query plans
+    /// against one version's schema and would fail on `SUM("missing")`. The
+    /// placeholder keeps the partial output schema identical across versions,
+    /// which the cross-version merge listing table requires, and contributes
+    /// nothing on merge: NULL sums/mins/maxes are ignored and a zero count adds
+    /// nothing.
+    fn raw_expr_or_absent(self, column: &str, alias: &str, present: bool) -> String {
+        if present || matches!(self, PartialKind::CountStar) {
+            return self.raw_expr(column, alias);
+        }
+        match self {
+            PartialKind::Sum | PartialKind::Min | PartialKind::Max => {
+                format!("CAST(NULL AS DOUBLE) AS \"{alias}\"")
+            }
+            PartialKind::Count => format!("CAST(0 AS BIGINT) AS \"{alias}\""),
+            PartialKind::CountStar => format!("COUNT(*) AS \"{alias}\""),
+        }
+    }
+
     /// SQL expression merging an already-computed partial across partitions
     /// (input versions, cascaded levels), grouped by `time_bucket`. The merge
     /// is associative: sums and counts add, mins/maxes extend. The result keeps
@@ -1135,6 +1170,18 @@ impl AggSqlPieces {
             .collect()
     }
 
+    /// Partial expressions for one input version, substituting typed
+    /// placeholders for source columns absent from that version's schema.
+    fn raw_partial_exprs_for(&self, available: &std::collections::HashSet<String>) -> Vec<String> {
+        self.partials
+            .iter()
+            .map(|p| {
+                let present = p.column == "*" || available.contains(&p.column);
+                p.kind.raw_expr_or_absent(&p.column, &p.alias, present)
+            })
+            .collect()
+    }
+
     /// Partial expressions merging cached partials across partitions.
     fn merge_partial_exprs(&self) -> Vec<String> {
         self.partials
@@ -1204,7 +1251,13 @@ impl AggSqlPieces {
     /// buckets and emit `time_bucket` plus the partial columns. The output is
     /// cached once per version; it carries no reconstruction so the partials
     /// stay mergeable across versions.
-    fn partial_sql(&self, interval: Duration, ts: &str, version_table: &str) -> String {
+    fn partial_sql(
+        &self,
+        interval: Duration,
+        ts: &str,
+        version_table: &str,
+        available: &std::collections::HashSet<String>,
+    ) -> String {
         let interval = duration_to_sql_interval(interval);
         let bin = date_bin_expr(&interval, ts);
         format!(
@@ -1216,7 +1269,7 @@ impl AggSqlPieces {
         WHERE {ts} IS NOT NULL
         GROUP BY {bin}
         "#,
-            partial_exprs = self.raw_partial_exprs().join(",\n          "),
+            partial_exprs = self.raw_partial_exprs_for(available).join(",\n          "),
         )
     }
 
@@ -1890,7 +1943,11 @@ mod tests {
         let full = ctx.sql(&full_sql).await.unwrap().collect().await.unwrap();
 
         // Per-version partials -> register -> merge.
-        let partial_sql = pieces.partial_sql(interval, "timestamp", "src");
+        let available: std::collections::HashSet<String> =
+            ["temperature".to_string(), "salinity".to_string()]
+                .into_iter()
+                .collect();
+        let partial_sql = pieces.partial_sql(interval, "timestamp", "src", &available);
         let partials = ctx
             .sql(&partial_sql)
             .await
@@ -1926,8 +1983,129 @@ mod tests {
         }
     }
 
-    ///
-    /// Creates multiple series files with different names (site1, site2, site3),
+    /// A source column that is absent from an older input version must not break
+    /// the per-version partial query: an oteljson source builds a per-file wide
+    /// schema from the metric names present in that file, so a metric that is
+    /// added or renamed over history is missing from earlier versions. The
+    /// partial query for such a version emits typed placeholders for the absent
+    /// column, keeping the partial schema identical across versions so the merge
+    /// can union them, and the merged output matches a single-pass query over
+    /// the union of both versions.
+    #[tokio::test]
+    async fn test_partial_tolerates_column_absent_in_older_version() {
+        use arrow::array::{Float64Array, TimestampMillisecondArray};
+        use datafusion::datasource::MemTable;
+        use datafusion::prelude::SessionContext;
+
+        let day = 86_400_000i64;
+
+        // Older version: only "temperature" exists; "salinity" had not yet
+        // appeared in the source.
+        let v0_schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("temperature", DataType::Float64, true),
+        ]));
+        let v0 = RecordBatch::try_new(
+            v0_schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![0, day / 4])),
+                Arc::new(Float64Array::from(vec![20.0, 22.0])),
+            ],
+        )
+        .unwrap();
+
+        // Newer version: both columns present.
+        let v1_schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("temperature", DataType::Float64, true),
+            Field::new("salinity", DataType::Float64, true),
+        ]));
+        let v1 = RecordBatch::try_new(
+            v1_schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![day, day + day / 4])),
+                Arc::new(Float64Array::from(vec![25.0, 24.0])),
+                Arc::new(Float64Array::from(vec![33.0, 34.0])),
+            ],
+        )
+        .unwrap();
+
+        let config = cfg_with_aggs(vec![
+            agg(AggregationType::Avg, &["temperature"]),
+            agg(AggregationType::Sum, &["salinity"]),
+            agg(AggregationType::Min, &["salinity"]),
+            agg(AggregationType::Max, &["salinity"]),
+            agg(AggregationType::Count, &["*"]),
+        ]);
+        let pieces = AggSqlPieces::build(&config).unwrap();
+        let interval = Duration::from_secs(86_400);
+        let ctx = SessionContext::new();
+
+        // Per-version partials, each planned against that version's own schema.
+        let mut all_partials = Vec::new();
+        for (i, (batch, schema)) in [(v0, v0_schema), (v1, v1_schema)].into_iter().enumerate() {
+            let table = format!("v{i}");
+            let available: std::collections::HashSet<String> =
+                schema.fields().iter().map(|f| f.name().clone()).collect();
+            let mem = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+            _ = ctx.register_table(table.as_str(), Arc::new(mem)).unwrap();
+            let partial_sql = pieces.partial_sql(interval, "timestamp", &table, &available);
+            let mut part = ctx
+                .sql(&partial_sql)
+                .await
+                .unwrap()
+                .collect()
+                .await
+                .unwrap();
+            all_partials.append(&mut part);
+        }
+
+        // All partial batches must share one schema so the merge can union them.
+        let partials_schema = all_partials[0].schema();
+        for p in &all_partials {
+            assert_eq!(
+                p.schema(),
+                partials_schema,
+                "per-version partial schemas must be identical across versions"
+            );
+        }
+        let partials_table = MemTable::try_new(partials_schema, vec![all_partials]).unwrap();
+        _ = ctx
+            .register_table("partials", Arc::new(partials_table))
+            .unwrap();
+        let merge_sql = pieces.merge_sql(interval, "timestamp", "partials");
+        let merged = ctx.sql(&merge_sql).await.unwrap().collect().await.unwrap();
+        let merged = arrow::compute::concat_batches(&merged[0].schema(), &merged).unwrap();
+
+        // Two daily buckets: day 0 (temperature only) and day 1 (both columns).
+        assert_eq!(merged.num_rows(), 2);
+
+        let merged_schema = merged.schema();
+        let names: Vec<&str> = merged_schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        let sal_sum_idx = names.iter().position(|n| *n == "salinity.sum").unwrap();
+        let sal_sum = merged
+            .column(sal_sum_idx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        use arrow::array::Array;
+        // Day 0 had no salinity column at all -> NULL; day 1 -> 33 + 34 = 67.
+        assert!(sal_sum.is_null(0), "day-0 salinity sum must be NULL");
+        assert_eq!(sal_sum.value(1), 67.0);
+    }
+
     /// each with 3 days of hourly data, then validates that temporal-reduce correctly:
     /// - Discovers all source files matching the pattern
     /// - Creates site subdirectories for each matched file

--- a/testsuite/tests/046-rollup-oteljson-schema-evolution.sh
+++ b/testsuite/tests/046-rollup-oteljson-schema-evolution.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# EXPERIMENT: temporal-reduce incremental rollup over oteljson sources whose
+#   schema evolves across files (a metric is renamed/added over history).
+# DESCRIPTION: Reproduces the watershop site-staging regression. An oteljson
+#   source builds a per-file wide schema from the metric names present in that
+#   file, so a metric added or renamed over history is MISSING from older files.
+#
+#   When several glob-matched files share ONE fixed out_pattern partition (as in
+#   the real water.yaml: out_pattern "data"), schema discovery unions the columns
+#   across files and finds the newer column (concrete_tank_level_value). The
+#   incremental rollup then computes a per-FILE partial; the older file lacks the
+#   column, so the partial SQL planned "SUM(concrete_tank_level_value)" against a
+#   file that has no such field and failed:
+#
+#     rollup partial SQL planning failed: Schema error:
+#     No field named concrete_tank_level_value.
+#
+#   The single-pass union path never hit this (an absent column reads as NULL),
+#   so test 039/040 (which use out_pattern "$0", a 1:1 source->output mapping)
+#   did not catch it. This test uses a FIXED out_pattern so multiple files feed
+#   one partition, exercising the per-version partial path that regressed.
+#
+# EXPECTED: Reading the reduced series succeeds. It carries the newer column with
+#   real values for buckets from the newer file and NULLs for buckets from the
+#   older file that predates the column. Reading drives the same per-version
+#   rollup partial path that the sitegen export originally failed on.
+set -e
+source check.sh
+
+echo "=== Experiment: Rollup over oteljson schema evolution ==="
+
+pond init
+
+# ---- Setup: two oteljson files with evolving schemas ----
+#
+# OLDER file (2024): well_depth_value only. Predates the tank-level metric.
+# NEWER file (2025): well_depth_value + concrete_tank_level_value.
+#
+# Two hourly buckets per file, two samples per bucket, so avg/min/max are
+# non-trivial.
+
+mkdir -p /tmp/otel-evo
+
+cat > /tmp/otel-evo/metrics-2024.json << 'OTELJSON'
+{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1704067200000000000","asDouble":42.5}]}}]}]}]}
+{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1704068100000000000","asDouble":42.3}]}}]}]}]}
+{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1704070800000000000","asDouble":41.0}]}}]}]}]}
+{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1704071700000000000","asDouble":41.2}]}}]}]}]}
+OTELJSON
+
+cat > /tmp/otel-evo/metrics-2025.json << 'OTELJSON'
+{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1735689600000000000","asDouble":44.0}]}},{"name":"concrete_tank_level_value","gauge":{"dataPoints":[{"timeUnixNano":"1735689600000000000","asDouble":10.0}]}}]}]}]}
+{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1735690500000000000","asDouble":44.1}]}},{"name":"concrete_tank_level_value","gauge":{"dataPoints":[{"timeUnixNano":"1735690500000000000","asDouble":10.2}]}}]}]}]}
+{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1735693200000000000","asDouble":43.0}]}},{"name":"concrete_tank_level_value","gauge":{"dataPoints":[{"timeUnixNano":"1735693200000000000","asDouble":11.0}]}}]}]}]}
+{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1735694100000000000","asDouble":43.5}]}},{"name":"concrete_tank_level_value","gauge":{"dataPoints":[{"timeUnixNano":"1735694100000000000","asDouble":11.5}]}}]}]}]}
+OTELJSON
+
+echo "--- Ingest both files ---"
+pond mkdir -p /ingest
+pond copy "host:///tmp/otel-evo/metrics-2024.json" /ingest/metrics-2024.json
+pond copy "host:///tmp/otel-evo/metrics-2025.json" /ingest/metrics-2025.json
+pond list '/ingest/*'
+
+# ---- temporal-reduce with a FIXED out_pattern (all files -> one partition) ----
+#
+# This mirrors water.yaml exactly: in_pattern is a multi-file oteljson glob and
+# out_pattern is the constant "data", so both files feed the single "data"
+# partition. The aggregations explicitly reference concrete_tank_level_value,
+# which only the 2025 file provides.
+
+cat > /tmp/reduce.yaml << 'YAML'
+in_pattern: "oteljson:///ingest/metrics-*.json"
+out_pattern: "data"
+time_column: "timestamp"
+resolutions: ["1h"]
+aggregations:
+  - type: "avg"
+    columns: ["concrete_tank_level_value", "well_depth_value"]
+  - type: "min"
+    columns: ["concrete_tank_level_value", "well_depth_value"]
+  - type: "max"
+    columns: ["concrete_tank_level_value", "well_depth_value"]
+YAML
+
+pond mknod temporal-reduce /reduced --config-path /tmp/reduce.yaml
+
+echo ""
+echo "--- Reduced tree ---"
+pond list '/reduced/**/*'
+
+# ---- Execute: read + export, both of which drive the rollup partial path ----
+
+echo ""
+echo "--- pond cat (drives per-file rollup partials) ---"
+CAT_OUT=$(pond cat /reduced/data/res=1h.series --format=table --sql "
+  SELECT
+    \"well_depth_value.avg\",
+    \"concrete_tank_level_value.avg\",
+    \"concrete_tank_level_value.min\",
+    \"concrete_tank_level_value.max\"
+  FROM source ORDER BY timestamp" 2>&1 || true)
+echo "$CAT_OUT"
+
+# Count buckets where the late-appearing column is non-null. Only the two 2025
+# buckets have it; the two 2024 buckets must be NULL (the column did not exist).
+TANK_NONNULL=$(pond cat /reduced/data/res=1h.series --format=table --sql "
+  SELECT COUNT(*) AS cnt FROM source
+  WHERE \"concrete_tank_level_value.avg\" IS NOT NULL" 2>&1 \
+  | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+
+TOTAL_BUCKETS=$(pond cat /reduced/data/res=1h.series --format=table --sql "
+  SELECT COUNT(*) AS cnt FROM source" 2>&1 \
+  | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+
+WD_NONNULL=$(pond cat /reduced/data/res=1h.series --format=table --sql "
+  SELECT COUNT(*) AS cnt FROM source
+  WHERE \"well_depth_value.avg\" IS NOT NULL" 2>&1 \
+  | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+
+# Exact reconstructed value for the first newer-file bucket: avg(10.0, 10.2).
+TANK_AVG_2025=$(pond cat /reduced/data/res=1h.series --format=table --sql "
+  SELECT \"concrete_tank_level_value.avg\" AS v FROM source
+  WHERE \"concrete_tank_level_value.avg\" IS NOT NULL ORDER BY timestamp LIMIT 1" 2>&1 \
+  | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+
+# ---- Verify ----
+#
+# pond cat builds the temporal-reduce table provider, which runs the same
+# incremental rollup per-version partial path that the sitegen export
+# (export_series_to_parquet) drove when it regressed on watershop. The regression
+# was in partial SQL planning, before any export/COPY step, so reading the series
+# exercises it directly.
+
+echo ""
+echo "--- Verification ---"
+
+check '! echo "$CAT_OUT" | grep -qi "error"' \
+  "reading the reduced series does not raise a schema error"
+
+check '! echo "$CAT_OUT" | grep -q "No field named concrete_tank_level_value"' \
+  "no missing-column schema error from the per-version partial path"
+
+check '[ "${TOTAL_BUCKETS}" = "4" ]' \
+  "four hourly buckets produced (two per file), got ${TOTAL_BUCKETS}"
+
+check '[ "${WD_NONNULL}" = "4" ]' \
+  "well_depth (present in all files) non-null in all 4 buckets, got ${WD_NONNULL}"
+
+check '[ "${TANK_NONNULL}" = "2" ]' \
+  "concrete_tank_level non-null only in the 2 newer-file buckets, got ${TANK_NONNULL}"
+
+check '[ "${TANK_AVG_2025}" = "10.1" ]' \
+  "newer-file bucket reconstructs avg(10.0,10.2)=10.1, got ${TANK_AVG_2025}"
+
+check_finish


### PR DESCRIPTION
## Problem

The incremental timeseries rollup (PR #87) computes per-version partials by planning aggregate SQL against a single input version's parquet schema. An oteljson source builds a per-file wide schema from the metric names present in that file, so a metric that is **added or renamed over history** is missing from older versions' parquet.

The single-pass path never hit this because it reads the unioned glob (an absent column reads as NULL per row). The new per-version partial query plans `SUM("concrete_tank_level_value")` against one version and fails:

```
export_series_to_parquet '/sources/water/reduced/tank-level/data/res=1m.series':
rollup partial SQL planning failed: Schema error: No field named
concrete_tank_level_value. Did you mean '__src_version.tank_level_value'?
```

Discovered on watershop site-staging: the Caspar tank-level metric was renamed `tank_level_value` → `concrete_tank_level_value`, so archived oteljson versions predating the rename lack the column.

## Fix

When generating the per-version partial SQL, read that version's parquet schema and emit a typed placeholder for absent source columns (`CAST(NULL AS DOUBLE)` for sum/min/max, `CAST(0 AS BIGINT)` for count). This keeps the partial output schema identical across versions — required by the cross-version merge listing table — and contributes nothing on merge (NULL sums/mins/maxes are ignored; a zero count adds nothing).

## Test

Added `test_partial_tolerates_column_absent_in_older_version`: two versions where `salinity` only appears in the newer one; asserts the per-version partial schemas are identical and the merged `salinity.sum` is NULL for the older day and correct for the newer day.