### PR TITLE
Bound control-table delta log via explicit short retention

### DIFF
--- a/crates/steward/src/maintenance.rs
+++ b/crates/steward/src/maintenance.rs
@@ -15,14 +15,16 @@
 //! - **Checkpoint** -- collapse the JSON delta log into a single parquet
 //!   checkpoint file.  Created every `CHECKPOINT_INTERVAL` versions (default 10).
 //! - **Log cleanup** -- remove expired JSON log files older than the
-//!   retention period (only after a checkpoint exists).
+//!   retention period (only after a checkpoint exists). The replicated data
+//!   table uses its 30-day table default; the never-replicated control table
+//!   uses a short retention so its high-churn log does not grow without bound.
 //! - **Vacuum** -- delete parquet data files no longer referenced by the
 //!   current table version. Runs every `VACUUM_INTERVAL` versions (default 10)
 //!   to avoid unnecessary scans on every commit.
 //! - **Compact** -- merge many small parquet files into fewer large ones
 //!   (only on explicit request via `pond maintain --compact`).
 
-use chrono::Duration;
+use chrono::{Duration, Utc};
 use deltalake::DeltaTable;
 use deltalake::checkpoints;
 use deltalake::kernel::schema::partitions::{PartitionFilter, PartitionValue};
@@ -44,6 +46,16 @@ const VACUUM_RETENTION_HOURS: u64 = 0;
 /// How often to run vacuum when no Remove actions are present (every N versions).
 /// This provides a safety net in case the Remove-action detection misses something.
 const VACUUM_INTERVAL: u64 = 10;
+
+/// Log retention for the control table's aggressive `_delta_log` cleanup.
+///
+/// The control table is never replicated to a remote and its transaction
+/// history is stored as parquet rows, not as delta-log commit JSONs, so old
+/// commit and superseded-checkpoint files become pure overhead once a newer
+/// checkpoint exists. A short retention bounds the `_delta_log` to roughly this
+/// window of churn while staying clear of any in-flight concurrent reader, which
+/// only ever needs files from the most recent checkpoint onward.
+pub const CONTROL_LOG_RETENTION_MINUTES: i64 = 5;
 
 /// Default target size for compaction (128 MB).
 const COMPACT_TARGET_SIZE: u64 = 128 * 1024 * 1024;
@@ -129,6 +141,14 @@ impl std::fmt::Display for MaintenanceReport {
 /// When `force` is false, checkpoint is only created at interval boundaries
 /// (for automatic post-commit maintenance).
 ///
+/// `log_retention` controls how `_delta_log` cleanup runs after a checkpoint:
+/// - `None` -- use the table's own `logRetentionDuration` property (Delta default
+///   30 days) via [`checkpoints::cleanup_metadata`]. Appropriate for replicated
+///   tables whose commit log may still be needed for remote version diffing.
+/// - `Some(retention)` -- delete commit JSONs and superseded checkpoints older
+///   than `now - retention` (checkpoint-aligned, never below the most recent
+///   checkpoint). Used for the control table, which is never replicated.
+///
 /// This is best-effort: errors are logged as warnings and do not propagate.
 /// The table reference is consumed and a new (possibly updated) table is
 /// returned, since vacuum/optimize operations produce a new DeltaTable.
@@ -137,6 +157,7 @@ pub async fn maintain_table(
     table_name: &str,
     force: bool,
     do_compact: bool,
+    log_retention: Option<Duration>,
 ) -> (DeltaTable, MaintenanceResult) {
     let mut result = MaintenanceResult {
         table_name: table_name.to_string(),
@@ -174,7 +195,27 @@ pub async fn maintain_table(
 
     // 2. Clean up expired log files (only meaningful after a checkpoint exists)
     if result.checkpoint_created {
-        match checkpoints::cleanup_metadata(&table, None).await {
+        let cleanup = match log_retention {
+            Some(retention) => {
+                let cutoff = Utc::now().timestamp_millis() - retention.num_milliseconds();
+                match table.snapshot() {
+                    Ok(snapshot) => {
+                        let keep_version = snapshot.version();
+                        let log_store = table.log_store();
+                        checkpoints::cleanup_expired_logs_for(
+                            keep_version,
+                            log_store.as_ref(),
+                            cutoff,
+                            None,
+                        )
+                        .await
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+            None => checkpoints::cleanup_metadata(&table, None).await,
+        };
+        match cleanup {
             Ok(cleaned) => {
                 if cleaned > 0 {
                     info!(

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -2179,9 +2179,7 @@ mod tests {
         std::fs::read_dir(log_dir)
             .map(|rd| {
                 rd.filter_map(|e| e.ok())
-                    .filter(|e| {
-                        e.path().extension().and_then(|s| s.to_str()) == Some(ext)
-                    })
+                    .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some(ext))
                     .count()
             })
             .unwrap_or(0)
@@ -2196,9 +2194,7 @@ mod tests {
     async fn test_control_log_cleanup_bounds_delta_log() {
         let temp_dir = tempdir().expect("temp dir");
         let pond_path = temp_dir.path().join("test_pond");
-        let mut ship = Ship::create_pond(&pond_path)
-            .await
-            .expect("create pond");
+        let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
 
         // Drive enough write transactions to accumulate control commit JSONs
         // well past a checkpoint boundary.

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -762,7 +762,7 @@ impl Ship {
         // Maintain data table (checkpoint + vacuum only; compaction handled above)
         let data_table = self.data_persistence.table().clone();
         let (new_data_table, mut data_result) =
-            maintenance::maintain_table(data_table, "data", force, false).await;
+            maintenance::maintain_table(data_table, "data", force, false, None).await;
         self.data_persistence.set_table(new_data_table);
         if let Some(oc) = compact_outcome {
             data_result.compacted = oc.had_data;
@@ -771,10 +771,20 @@ impl Ship {
         }
         report.data = Some(data_result);
 
-        // Maintain control table (best-effort optimize allowed; never pushed)
+        // Maintain control table (best-effort optimize allowed; never pushed).
+        // It is never replicated, so its delta log is cleaned aggressively to a
+        // short retention rather than the 30-day table default.
         let control_table = self.control_table.table().clone();
-        let (new_control_table, control_result) =
-            maintenance::maintain_table(control_table, "control", force, compact).await;
+        let (new_control_table, control_result) = maintenance::maintain_table(
+            control_table,
+            "control",
+            force,
+            compact,
+            Some(chrono::Duration::minutes(
+                maintenance::CONTROL_LOG_RETENTION_MINUTES,
+            )),
+        )
+        .await;
         self.control_table.set_table(new_control_table);
         report.control = Some(control_result);
 
@@ -2163,5 +2173,93 @@ mod tests {
         // A second sweep is a clean no-op now that nothing qualifies.
         let again = ship.collapse_versions(1).await.expect("second sweep");
         assert_eq!(again.files_collapsed, 0, "nothing left to collapse");
+    }
+
+    fn count_log_files(log_dir: &Path, ext: &str) -> usize {
+        std::fs::read_dir(log_dir)
+            .map(|rd| {
+                rd.filter_map(|e| e.ok())
+                    .filter(|e| {
+                        e.path().extension().and_then(|s| s.to_str()) == Some(ext)
+                    })
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    /// The control table is never replicated, so its `_delta_log` must be
+    /// cleaned aggressively rather than kept for the 30-day Delta default.
+    /// Many small write transactions accumulate commit JSONs; a forced maintain
+    /// with a short retention must collapse them to the latest checkpoint while
+    /// leaving the pond fully readable.
+    #[tokio::test]
+    async fn test_control_log_cleanup_bounds_delta_log() {
+        let temp_dir = tempdir().expect("temp dir");
+        let pond_path = temp_dir.path().join("test_pond");
+        let mut ship = Ship::create_pond(&pond_path)
+            .await
+            .expect("create pond");
+
+        // Drive enough write transactions to accumulate control commit JSONs
+        // well past a checkpoint boundary.
+        for i in 0..16 {
+            let meta = PondUserMetadata::new(vec![format!("commit-{i}")]);
+            ship.write_transaction(&meta, async move |fs| {
+                let root = fs.root().await?;
+                _ = tinyfs::async_helpers::convenience::create_file_path(
+                    &root,
+                    &format!("/file-{i}.txt"),
+                    format!("content-{i}").as_bytes(),
+                )
+                .await?;
+                Ok(())
+            })
+            .await
+            .expect("write transaction");
+        }
+
+        let control_log_dir = get_control_path(&pond_path).join("_delta_log");
+        let json_before = count_log_files(&control_log_dir, "json");
+        assert!(
+            json_before > 10,
+            "expected many control commit JSONs, got {json_before}"
+        );
+
+        // Let existing log files age past the tiny retention used below so the
+        // checkpoint-aligned cleanup considers them expired.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let control_table = ship.control_table.table().clone();
+        let pre_version = control_table.version().unwrap_or(-1);
+        let (cleaned_table, result) = maintenance::maintain_table(
+            control_table,
+            "control",
+            true,
+            false,
+            Some(chrono::Duration::milliseconds(10)),
+        )
+        .await;
+
+        assert!(result.checkpoint_created, "forced maintain must checkpoint");
+        assert!(
+            result.logs_cleaned > 0,
+            "expected expired control logs to be cleaned"
+        );
+        assert_eq!(
+            cleaned_table.version().unwrap_or(-1),
+            pre_version,
+            "cleanup must not change the table version"
+        );
+
+        let json_after = count_log_files(&control_log_dir, "json");
+        assert!(
+            json_after < json_before,
+            "control commit JSONs should shrink: before={json_before} after={json_after}"
+        );
+
+        // The pond must still open and replay cleanly after log cleanup.
+        drop(ship);
+        let reopened = Ship::open_pond(&pond_path).await.expect("reopen pond");
+        drop(reopened);
     }
 }

--- a/docs/configurable-settings.md
+++ b/docs/configurable-settings.md
@@ -1,0 +1,127 @@
+# Configurable Settings: Control-Table-Managed Defaults
+
+## Purpose
+
+Several operational knobs in duckpond are currently hardcoded constants or
+expressed only as `pond maintain` CLI flags. The maintenance retention work
+(see `delta-cleanup-synchronization.md`) surfaced the question of where such
+tunables belong. The answer for operator-facing defaults is the **steward
+control table**: a setting written once with `pond config set` is read on every
+subsequent pond open, so a single command changes behaviour for all later ticks
+without recompiling or editing the per-instance `run-*.sh` wrapper.
+
+This note records how settings are stored and read today and the convention for
+promoting a hardcoded constant to a control-table-managed default.
+
+## How settings are stored and read today
+
+Settings live in the control table as `RecordKind::Setting` rows. The key is
+held in the record's `txn_id` column and the value in `metadata_json`, with
+`txn_seq = 0`. Mechanics:
+
+- **Namespacing.** The steward wrapper stores operator settings under the
+  `"setting:"` prefix and factory execution modes under `"factory_mode:"`
+  (`crates/steward/src/control_table.rs:57-58`). The prefix is added/stripped
+  internally; callers use the bare key.
+- **Write.** `ControlTableWrapper::set_setting(key, value)`
+  (`control_table.rs:260`) persists via `config_set(pond_id, "setting:{key}",
+  value)` and updates the in-memory cache. The CLI entry point is
+  `pond config set <key> <value>`, routed to `set_setting`
+  (`crates/cmd/src/commands/control.rs:652`).
+- **Read.** Settings are loaded once at pond open into a cached map
+  (`control_table.rs:123` calls `config_list`). Reads use
+  `get_setting(key) -> Option<String>` (`control_table.rs:254`), which is an
+  in-memory lookup with **no per-commit Delta cost**. `pond config` (ShowConfig)
+  prints the current settings.
+- **Latest-write-wins.** `config_list` walks all `Setting` rows and keeps the
+  most recent value per key by `ts_micros`
+  (`crates/sync-steward/src/control_table.rs:739-752`).
+- **Never pruned.** `--prune` and control-table horizon deletion preserve
+  `Setting` rows explicitly (`sync-steward/src/control_table.rs:398,428-432`),
+  so a configured default survives history trimming.
+- **Per-instance, not replicated.** Settings are written under the local
+  `pond_id` and describe this replica's operational state, not logical pond
+  content. They are not pushed to remotes and are not restored automatically by
+  a restore-from-remote; an operator re-applies them after a reset.
+
+Existing keys that use this machinery include `store_id`, `birth_hostname`,
+`birth_username` (`control_table.rs:860-876`) and the per-factory mode entries.
+
+## Convention for a new configurable default
+
+To promote a hardcoded constant (or a CLI-only flag) to a control-table setting:
+
+1. **Define a stable key constant** in the owning crate, dotted under a topic
+   namespace, e.g. `maintenance.control_log_retention_minutes`. Keep the bare
+   key; the `"setting:"` prefix is applied by `set_setting`.
+2. **Keep the code default.** The existing constant stays as the fallback when
+   the setting is unset, so behaviour is unchanged out of the box. Treat unset
+   and unparseable values identically: fall back to the default and, for the
+   latter, log a warning.
+3. **Read from the cache at the decision point**, not per commit. For example,
+   `Ship::maintain` would read `self.control_table.get_setting(KEY)` once,
+   parse it to the typed value, and pass it down to `maintenance::maintain_table`
+   in place of the constant. Because each `pond` invocation opens the pond
+   fresh, a setting change takes effect on the next tick.
+4. **Validate and clamp.** Reject nonsensical values defensively at read time
+   rather than trusting the stored string.
+5. **Document the key** in `pond config` help and here.
+
+### Worked example: control-log retention
+
+The control table's `_delta_log` cleanup retention is currently the constant
+`maintenance::CONTROL_LOG_RETENTION_MINUTES = 5`
+(`crates/steward/src/maintenance.rs`). To make it operator-tunable:
+
+```text
+# one-time, persists across ticks for this instance:
+pond config set maintenance.control_log_retention_minutes 1
+```
+
+`Ship::maintain` would resolve the retention as:
+
+```rust
+let minutes = self
+    .control_table
+    .get_setting("maintenance.control_log_retention_minutes")
+    .and_then(|v| v.parse::<i64>().ok())
+    .filter(|m| *m >= 0)
+    .unwrap_or(maintenance::CONTROL_LOG_RETENTION_MINUTES);
+```
+
+and pass `Some(chrono::Duration::minutes(minutes))` to `maintain_table` for the
+control table. The replicated data table keeps `None` (its 30-day table default)
+because its commit log may still be needed for remote version diffing.
+
+This fits the "abuse selfmon to harden maintenance" workflow: an operator can
+dial the retention down on the `watershop-selfmon` instance to stress the
+checkpoint-aligned cleanup without touching code or the deployed image.
+
+## Candidates to migrate
+
+Hardcoded maintenance constants and CLI-only flags that are good candidates for
+control-table-managed defaults, once the read path above exists:
+
+| Knob | Today | Location |
+|------|-------|----------|
+| Control-log retention | `const` 5 min | `steward/src/maintenance.rs` |
+| Checkpoint interval | `const CHECKPOINT_INTERVAL = 10` | `steward/src/maintenance.rs` |
+| Vacuum interval | `const VACUUM_INTERVAL = 10` | `steward/src/maintenance.rs` |
+| Compact target size | `const COMPACT_TARGET_SIZE = 128 MiB` | `steward/src/maintenance.rs` |
+| Prune `keep_txns` default | CLI flag, default 1000 | `cmd/src/main.rs` Maintain |
+| Collapse-versions threshold | CLI flag, default 0 | `cmd/src/main.rs` Maintain |
+
+CLI flags should remain as a per-invocation override; the setting provides the
+default when the flag is absent. Resolution order: explicit flag > control-table
+setting > code constant.
+
+## Caveats
+
+- **Settings are per-pond-instance.** After a destructive reset they must be
+  re-applied (e.g. from the instance's `run-*.sh` or a one-shot `pond config
+  set`). They do not travel with a remote backup.
+- **Auto-maintain reads the same cache.** The post-commit auto-maintain path and
+  explicit `pond maintain` both resolve the setting at open, so they agree
+  within a process and pick up changes on the next open.
+- **No schema migration.** Adding a key requires no table change; an absent key
+  is simply the default.

--- a/docs/delta-cleanup-synchronization.md
+++ b/docs/delta-cleanup-synchronization.md
@@ -637,3 +637,7 @@ pub async fn maintain_table(
 window of churn while staying clear of in-flight concurrent readers. This is
 independent of, and complementary to, `--prune --keep-txns` which trims control
 *rows* rather than delta-log metadata.
+
+The retention is currently a code constant. Making it an operator-tunable
+default managed via `pond config set` is described in
+`configurable-settings.md`.

--- a/docs/delta-cleanup-synchronization.md
+++ b/docs/delta-cleanup-synchronization.md
@@ -599,3 +599,41 @@ SELECT COUNT(*) as active FROM (
 8. **Separate Delta Txn app_ids per table** -- `pond-maint-data`,
    `pond-maint-control`, `pond-maint-remote` are independent. Maintaining the
    data table doesn't block maintaining the control table.
+
+## Implementation Status: Control-Table Log Retention
+
+A live watershop `selfmon` pond (~50 control commits/min) exposed that running
+log cleanup is necessary but not sufficient. `checkpoints::cleanup_metadata`
+deletes commit files older than the table's `logRetentionDuration`, which
+defaults to **30 days**. The control table sets no such property, so on a
+freshly reset pond every commit JSON is younger than 30 days and cleanup deletes
+nothing -- the `_delta_log` grew to thousands of files (commit JSONs plus
+superseded checkpoints) within an hour even though data-parquet compaction kept
+the table's row data tiny.
+
+The fix gives `maintenance::maintain_table` an explicit `log_retention` argument:
+
+```rust
+pub async fn maintain_table(
+    table: DeltaTable,
+    table_name: &str,
+    force: bool,
+    do_compact: bool,
+    log_retention: Option<Duration>,
+) -> (DeltaTable, MaintenanceResult)
+```
+
+- `None` -- replicated tables (the data table) keep the table-default 30-day
+  `cleanup_metadata` behaviour; their commit log may still be needed for remote
+  version diffing.
+- `Some(retention)` -- the never-replicated control table calls
+  `checkpoints::cleanup_expired_logs_for` with `cutoff = now - retention`. This
+  is checkpoint-aligned: it never deletes below the most recent checkpoint, so
+  the current version always reconstructs. The control table's transaction
+  history lives in parquet rows, not the delta log, so `pond log` is unaffected.
+
+`Ship::maintain` passes `Some(Duration::minutes(CONTROL_LOG_RETENTION_MINUTES))`
+(5 minutes) for the control table, bounding its `_delta_log` to roughly one
+window of churn while staying clear of in-flight concurrent readers. This is
+independent of, and complementary to, `--prune --keep-txns` which trims control
+*rows* rather than delta-log metadata.


### PR DESCRIPTION
## Problem

The live watershop `selfmon` pond churns ~50 control commits/min. Its control-table `_delta_log` grew to **2278 commit JSONs + 48 checkpoints (17 MB)** within ~44 min of a fresh reset, even though data-parquet compaction kept the table's row data tiny (<200 KB).

Root cause: `maintain_table` cleaned the log with `checkpoints::cleanup_metadata`, which honors the table's `logRetentionDuration` — **30 days by default**. The control table sets no such property, so on a freshly reset pond every commit JSON is younger than 30 days and cleanup deletes *nothing*. The journal showed checkpoints succeeding but `cleaned=0` forever.

## Fix

Give `maintain_table` an explicit `log_retention: Option<Duration>`:

- `None` — replicated **data** table keeps the 30-day `cleanup_metadata` behavior (its log may still be needed for remote version diffing).
- `Some(retention)` — never-replicated **control** table calls `checkpoints::cleanup_expired_logs_for` with `cutoff = now - retention`. Checkpoint-aligned: never deletes below the latest checkpoint, so the current version always reconstructs. Control transaction history lives in parquet *rows*, not the delta log, so `pond log` is unaffected.

`Ship::maintain` passes `Some(Duration::minutes(5))` for the control table. Independent of and complementary to `--prune --keep-txns` (which trims control *rows*).

## Test

New steward unit test `test_control_log_cleanup_bounds_delta_log`: accumulates control commit JSONs across 16 write transactions, then asserts a forced maintain with a short retention cleans expired logs, shrinks the JSON count, preserves the version, and leaves the pond reopenable. Full steward suite (75 tests) green; clippy clean.

## Follow-up

Once merged + image rebuilt, redeploy selfmon to confirm the live `_delta_log` stays bounded (journal should show `cleaned=N` for control).