### PR TITLE
cmd: richer pond log + verify/show fixes, and a required pond birthplace

### DIFF
--- a/crates/cmd/src/commands/apply.rs
+++ b/crates/cmd/src/commands/apply.rs
@@ -388,10 +388,7 @@ pub async fn apply_command(ship_context: &ShipContext, files: &[String]) -> Resu
     };
 
     let tx = ship
-        .begin_write(&steward::PondUserMetadata::new(vec![
-            "apply".to_string(),
-            format!("{} resource(s)", specs.len()),
-        ]))
+        .begin_write(&ship_context.command_metadata())
         .await
         .map_err(|e| anyhow!("apply: failed to begin transaction: {}", e))?;
 
@@ -930,7 +927,7 @@ mod tests {
 
             let init_args = vec!["pond".to_string(), "init".to_string()];
             let ship_context = ShipContext::pond_only(Some(&pond_path), init_args.clone());
-            init_command(&ship_context).await?;
+            init_command(&ship_context, "test-host").await?;
 
             Ok(Self {
                 temp_dir,

--- a/crates/cmd/src/commands/cat.rs
+++ b/crates/cmd/src/commands/cat.rs
@@ -538,7 +538,7 @@ mod tests {
             let ship_context = ShipContext::pond_only(Some(&pond_path), init_args.clone());
 
             // Initialize the pond
-            init_command(&ship_context).await?;
+            init_command(&ship_context, "test-host").await?;
 
             let test_content =
                 "timestamp,value\n2024-01-01T00:00:00Z,42.0\n2024-01-01T01:00:00Z,43.5\n";

--- a/crates/cmd/src/commands/control.rs
+++ b/crates/cmd/src/commands/control.rs
@@ -25,7 +25,6 @@ struct RecentTransaction {
     tx_kind: String,
     started_at: Option<i64>,
     final_state: Option<String>,
-    ended_at: Option<i64>,
     error_metadata: Option<String>,
     duration_ms: Option<i64>,
 }
@@ -94,10 +93,16 @@ pub async fn control_command(ship_context: &ShipContext, mode: ControlMode) -> R
 
     match mode {
         ControlMode::Recent { limit } => {
-            show_recent_transactions(ship.control_table_mut(), limit).await?;
+            crate::common::with_read_transaction(&mut ship, vec!["log".to_string()], async |tx| {
+                show_recent_transactions(tx, limit).await
+            })
+            .await?;
         }
         ControlMode::Detail { txn_seq } => {
-            show_transaction_detail(ship.control_table_mut(), txn_seq).await?;
+            crate::common::with_read_transaction(&mut ship, vec!["log".to_string()], async |tx| {
+                show_transaction_detail(tx, txn_seq).await
+            })
+            .await?;
         }
         ControlMode::Incomplete => {
             show_incomplete_operations(ship.control_table_mut()).await?;
@@ -120,116 +125,193 @@ pub async fn control_command(ship_context: &ShipContext, mode: ControlMode) -> R
     Ok(())
 }
 
-/// Show recent transactions with summary status
-async fn show_recent_transactions(
-    control_table: &mut steward::ControlTable,
-    limit: usize,
-) -> Result<()> {
-    // Control table automatically sees latest Delta commits via DataFusion
+/// Per-transaction operation summary, aggregated from the data Delta
+/// table.  Reads (which never write a data commit) have no entry.
+#[derive(Debug, Deserialize)]
+struct OpSummary {
+    txn_seq: i64,
+    ops: i64,
+    files: i64,
+    dirs: i64,
+    partitions: i64,
+}
 
-    control_table.print_banner();
-
-    // Use control table's SessionContext (following tlogfs pattern)
-    // This ensures we see all committed transactions via Delta's latest _delta_log
-    let ctx = control_table.session_context();
-
-    // Post-D2 lean schema lives at table "control" with columns:
-    //   pond_id, record_kind, txn_seq, txn_id,
-    //   commit_kind, has_commit_kind,
-    //   parent_seq, has_parent_seq,
-    //   duration_ms, has_duration_ms,
-    //   ts_micros, metadata_json
-    //
-    // Transaction kind is inferred from lifecycle records:
-    //   * a tx with a `data_committed` record is a "write"
-    //   * any other tx (begin -> completed/failed only) is a "read"
-    //
-    // Setting records (record_kind='setting') and post-commit records
-    // (parent_seq present) are excluded from this view.
-    let sql = format!(
-        r#"
-        WITH user_txns AS (
-            SELECT *
-            FROM control
-            WHERE record_kind <> 'setting'
-              AND NOT (has_parent_seq = true AND parent_seq <> txn_seq)
-        ),
-        recent_seqs AS (
-            SELECT DISTINCT txn_seq
-            FROM user_txns
-            WHERE txn_seq > 0
-            ORDER BY txn_seq DESC
-            LIMIT {limit}
-        )
-        SELECT
-            t.txn_seq,
-            t.txn_id,
-            CASE
-                WHEN MAX(CASE WHEN t.record_kind = 'data_committed' THEN 1 ELSE 0 END) = 1
-                    THEN 'write'
-                ELSE 'read'
-            END AS tx_kind,
-            MAX(CASE WHEN t.record_kind = 'begin' THEN t.ts_micros END) AS started_at,
-            MAX(CASE
-                WHEN t.record_kind IN ('data_committed', 'completed', 'failed')
-                    THEN t.record_kind
-            END) AS final_state,
-            MAX(CASE
-                WHEN t.record_kind IN ('data_committed', 'completed', 'failed')
-                    THEN t.ts_micros
-            END) AS ended_at,
-            MAX(CASE WHEN t.record_kind = 'failed' THEN t.metadata_json END) AS error_metadata,
-            MAX(CASE WHEN t.has_duration_ms = true THEN t.duration_ms END) AS duration_ms
-        FROM user_txns t
-        WHERE t.txn_seq IN (SELECT txn_seq FROM recent_seqs)
-        GROUP BY t.txn_seq, t.txn_id
-        ORDER BY t.txn_seq ASC, started_at ASC
-        "#,
-        limit = limit
-    );
-
-    let df = ctx
-        .sql(&sql)
+/// Render the enriched transaction log (the `pond log` default view).
+///
+/// Combines three sources so the operator can see, at a glance, *what*
+/// each transaction did and whether it succeeded:
+///   * control table -- lifecycle (status, timing, duration, errors);
+///   * data Delta commit metadata (`pond_txn`) -- the original CLI
+///     command that produced the transaction;
+///   * data Delta table -- a count of the objects the transaction wrote.
+///
+/// Output is newest-first, matching `pond show` and `git log`.
+/// Build a map from `txn_seq` to the original CLI command (argv) by
+/// reading the `pond_txn` metadata embedded in each data Delta commit.
+/// Compaction/optimize commits carry no `pond_txn` and are skipped.
+async fn build_command_map(
+    pond: &steward::StewardTransactionGuard<'_>,
+) -> Result<std::collections::HashMap<i64, Vec<String>>> {
+    let mut command_map: std::collections::HashMap<i64, Vec<String>> =
+        std::collections::HashMap::new();
+    let commits = pond
+        .get_commit_history(None)
         .await
-        .map_err(|e| anyhow!("Failed to query recent transactions: {}", e))?;
+        .map_err(|e| anyhow!("Failed to read commit history: {}", e))?;
+    for commit in &commits {
+        if let Some(meta) = tlogfs::PondTxnMetadata::from_delta_metadata(&commit.info) {
+            _ = command_map.insert(meta.txn_seq, meta.user.args);
+        }
+    }
+    Ok(command_map)
+}
 
-    let batches = df
-        .collect()
-        .await
-        .map_err(|e| anyhow!("Failed to collect query results: {}", e))?;
+/// Render a stored command argv as a single canonical `pond ...` line.
+fn render_command(args: &[String]) -> String {
+    format!("pond {}", normalize_command_args(args))
+}
 
-    // Print header
+async fn show_recent_transactions(tx: &mut steward::Transaction<'_>, limit: usize) -> Result<()> {
+    use std::collections::HashMap;
+
+    // --- Phase 1: control-table lifecycle + commit-history commands ---
+    // These only need shared access to the pond guard; collect everything
+    // into owned values so the borrow ends before we reach for the data
+    // session context (which needs a mutable borrow of `tx`).
+    let (transactions, command_map) = {
+        let pond = tx
+            .as_pond()
+            .ok_or_else(|| anyhow!("`pond log` requires a pond transaction"))?;
+
+        pond.control_table().print_banner();
+
+        let ctx = pond.control_table().session_context();
+
+        // Post-D2 lean schema lives at table "control".  A transaction's
+        // kind is inferred from its lifecycle records: a tx with a
+        // `data_committed` record is a "write"; anything else is a "read".
+        // `recent_seqs` keeps only transactions that actually attempted a
+        // write (they have a `data_committed` or `failed` record), so pure
+        // reads -- including this `pond log` invocation's own in-flight read
+        // -- never appear.  Crashed/incomplete writes are surfaced
+        // separately by `pond log --incomplete`.
+        let sql = format!(
+            r#"
+            WITH user_txns AS (
+                SELECT *
+                FROM control
+                WHERE record_kind <> 'setting'
+                  AND NOT (has_parent_seq = true AND parent_seq <> txn_seq)
+            ),
+            recent_seqs AS (
+                SELECT txn_seq
+                FROM user_txns
+                WHERE txn_seq > 0
+                GROUP BY txn_seq
+                HAVING MAX(CASE WHEN record_kind IN ('data_committed', 'failed') THEN 1 ELSE 0 END) = 1
+                ORDER BY txn_seq DESC
+                LIMIT {limit}
+            )
+            SELECT
+                t.txn_seq,
+                t.txn_id,
+                CASE
+                    WHEN MAX(CASE WHEN t.record_kind = 'data_committed' THEN 1 ELSE 0 END) = 1
+                        THEN 'write'
+                    ELSE 'read'
+                END AS tx_kind,
+                MAX(CASE WHEN t.record_kind = 'begin' THEN t.ts_micros END) AS started_at,
+                MAX(CASE
+                    WHEN t.record_kind IN ('data_committed', 'completed', 'failed')
+                        THEN t.record_kind
+                END) AS final_state,
+                MAX(CASE WHEN t.record_kind = 'failed' THEN t.metadata_json END) AS error_metadata,
+                MAX(CASE WHEN t.has_duration_ms = true THEN t.duration_ms END) AS duration_ms
+            FROM user_txns t
+            WHERE t.txn_seq IN (SELECT txn_seq FROM recent_seqs)
+            GROUP BY t.txn_seq, t.txn_id
+            ORDER BY t.txn_seq DESC, started_at DESC
+            "#,
+            limit = limit
+        );
+
+        let batches = ctx
+            .sql(&sql)
+            .await
+            .map_err(|e| anyhow!("Failed to query recent transactions: {}", e))?
+            .collect()
+            .await
+            .map_err(|e| anyhow!("Failed to collect query results: {}", e))?;
+
+        let mut transactions = Vec::new();
+        for batch in &batches {
+            let batch_txns: Vec<RecentTransaction> = serde_arrow::from_record_batch(batch)
+                .map_err(|e| anyhow!("Failed to deserialize transaction records: {}", e))?;
+            transactions.extend(batch_txns);
+        }
+
+        // Map txn_seq -> original CLI command from data Delta commit
+        // metadata (`pond_txn`).
+        let command_map = build_command_map(pond).await?;
+
+        (transactions, command_map)
+    };
+
+    // --- Phase 2: per-transaction operation summary from the data table ---
+    let op_map = if transactions.is_empty() {
+        HashMap::new()
+    } else {
+        let seq_list = transactions
+            .iter()
+            .map(|t| t.txn_seq.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let session = tx
+            .session_context()
+            .await
+            .map_err(|e| anyhow!("Failed to get session context: {}", e))?;
+        let sql = format!(
+            r#"
+            SELECT
+                txn_seq,
+                CAST(COUNT(*) AS BIGINT) AS ops,
+                CAST(COUNT(DISTINCT CASE WHEN file_type <> 'directory' THEN node_id END) AS BIGINT) AS files,
+                CAST(COUNT(DISTINCT CASE WHEN file_type = 'directory' THEN node_id END) AS BIGINT) AS dirs,
+                CAST(COUNT(DISTINCT part_id) AS BIGINT) AS partitions
+            FROM delta_table
+            WHERE txn_seq IN ({seq_list})
+            GROUP BY txn_seq
+            "#
+        );
+        let batches = session
+            .sql(&sql)
+            .await
+            .map_err(|e| anyhow!("Failed to query operation summary: {}", e))?
+            .collect()
+            .await
+            .map_err(|e| anyhow!("Failed to collect operation summary: {}", e))?;
+        let mut map: HashMap<i64, OpSummary> = HashMap::new();
+        for batch in &batches {
+            let rows: Vec<OpSummary> = serde_arrow::from_record_batch(batch)
+                .map_err(|e| anyhow!("Failed to deserialize operation summary: {}", e))?;
+            for row in rows {
+                _ = map.insert(row.txn_seq, row);
+            }
+        }
+        map
+    };
+
+    // --- Phase 3: render ---
     println!("\n+===========================================================================+");
-    println!("|                        RECENT TRANSACTIONS                                 |");
+    println!("|                          TRANSACTION LOG                                   |");
     println!("+===========================================================================+\n");
 
-    if batches.is_empty() || batches.iter().all(|b| b.num_rows() == 0) {
+    if transactions.is_empty() {
         println!("No transactions found.\n");
         return Ok(());
     }
 
-    // Deserialize batches into structs using serde_arrow
-    let mut transactions = Vec::new();
-    for batch in &batches {
-        let batch_txns: Vec<RecentTransaction> = serde_arrow::from_record_batch(batch)
-            .map_err(|e| anyhow!("Failed to deserialize transaction records: {}", e))?;
-        transactions.extend(batch_txns);
-    }
-
-    // Format output
-    for txn in transactions {
-        // Format timestamps
-        let started_at = txn
-            .started_at
-            .map(format_timestamp)
-            .unwrap_or_else(|| "<unknown>".to_string());
-
-        let ended_at = txn
-            .ended_at
-            .map(format_timestamp)
-            .unwrap_or_else(|| "incomplete".to_string());
-
-        // Status indicator
+    for txn in &transactions {
         let status = match txn.final_state.as_deref() {
             Some("data_committed") => "COMMITTED",
             Some("completed") => "COMPLETED",
@@ -238,51 +320,116 @@ async fn show_recent_transactions(
             None => "INCOMPLETE",
         };
 
-        // Duration
-        let duration_str = txn
+        let when = txn
+            .started_at
+            .map(format_timestamp)
+            .unwrap_or_else(|| "<unknown time>".to_string());
+        let duration = txn
             .duration_ms
             .map(|d| format!("{}ms", d))
-            .unwrap_or_else(|| "N/A".to_string());
+            .unwrap_or_else(|| "n/a".to_string());
+
+        let command = match command_map.get(&txn.txn_seq) {
+            Some(args) if !args.is_empty() => render_command(args),
+            _ if txn.tx_kind == "read" => "(read-only, no changes)".to_string(),
+            _ => "(no command recorded)".to_string(),
+        };
 
         println!(
-            "+- Transaction {} ({}) -----------------------------",
-            txn.txn_seq, txn.tx_kind
+            "+- Transaction {}  ({})  {} {}",
+            txn.txn_seq,
+            txn.tx_kind,
+            status,
+            "-".repeat(40usize.saturating_sub(status.len() + txn.tx_kind.len()))
         );
-        println!("|  Status       : {}", status);
-        println!("|  UUID         : {}", txn.txn_id);
-        println!("|  Started      : {}", started_at);
-        println!("|  Ended        : {}", ended_at);
-        println!("|  Duration     : {}", duration_str);
-        // CLI args are no longer captured in the post-D2 lean control
-        // table.  Source the original command from data Delta commit
-        // metadata (`pond_txn`) if it is needed.
+        println!("|  Command  : {}", command);
+        println!("|  When     : {}  ({})", when, duration);
+        println!("|  Changes  : {}", format_changes(op_map.get(&txn.txn_seq)));
+        println!("|  TxnID    : {}", txn.txn_id);
 
-        // Show error if present (parsed from metadata_json on Failed records)
         if let Some(reason) = txn
             .error_metadata
             .as_deref()
             .and_then(extract_failure_reason)
         {
-            println!("|  Error        : {}", truncate_error(&reason));
+            println!("|  Error    : {}", truncate_error(&reason));
         }
 
-        println!("+----------------------------------------------------------------");
-        println!();
+        println!("+----------------------------------------------------------------------------");
     }
+    println!();
 
     Ok(())
 }
 
+/// Render a human-readable change summary from an [`OpSummary`].
+fn format_changes(summary: Option<&OpSummary>) -> String {
+    let Some(s) = summary else {
+        return "(no data changes)".to_string();
+    };
+    let mut parts = Vec::new();
+    if s.files > 0 {
+        parts.push(format!("{} file{}", s.files, plural(s.files)));
+    }
+    if s.dirs > 0 {
+        parts.push(format!(
+            "{} director{}",
+            s.dirs,
+            if s.dirs == 1 { "y" } else { "ies" }
+        ));
+    }
+    let what = if parts.is_empty() {
+        "no objects".to_string()
+    } else {
+        parts.join(", ")
+    };
+    format!(
+        "{} operation{} -> {} across {} partition{}",
+        s.ops,
+        plural(s.ops),
+        what,
+        s.partitions,
+        plural(s.partitions),
+    )
+}
+
+/// Return "s" for plural counts, "" for singular.
+fn plural(n: i64) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+/// Normalize stored command args for display.  Args may or may not carry a
+/// leading binary token (legacy hand-built metadata used "pond"; the init
+/// transaction stores ["pond", "init"]; argv-based metadata strips argv[0]).
+/// Drop any leading "pond" token and re-join so the caller can prefix a
+/// single canonical "pond ".
+fn normalize_command_args(args: &[String]) -> String {
+    let rest = match args.first() {
+        Some(first) if first == "pond" => &args[1..],
+        _ => args,
+    };
+    rest.join(" ")
+}
+
 /// Show detailed lifecycle for a specific transaction
-async fn show_transaction_detail(
-    control_table: &mut steward::ControlTable,
-    txn_seq: i64,
-) -> Result<()> {
+async fn show_transaction_detail(tx: &mut steward::Transaction<'_>, txn_seq: i64) -> Result<()> {
+    let pond = tx
+        .as_pond()
+        .ok_or_else(|| anyhow!("`pond log` requires a pond transaction"))?;
+
     // Control table automatically sees latest Delta commits via DataFusion
-    control_table.print_banner();
+    pond.control_table().print_banner();
+
+    // The original CLI command for this transaction lives in the data
+    // Delta commit metadata (`pond_txn`), not the control table.
+    let command = build_command_map(pond)
+        .await?
+        .get(&txn_seq)
+        .filter(|args| !args.is_empty())
+        .map(|args| render_command(args));
 
     // Use control table's SessionContext (following tlogfs pattern)
-    let ctx = control_table.session_context();
+    let ctx = pond.control_table().session_context();
 
     // Post-D2 lean schema: post-commit records carry the parent
     // transaction's seq in `parent_seq` (with `has_parent_seq=true`).
@@ -376,9 +523,10 @@ async fn show_transaction_detail(
                 println!("|  Sequence     : {}", current_txn_seq);
                 println!("|  UUID         : {}", txn_id);
                 println!("|  Timestamp    : {}", timestamp);
-                // CLI args are not persisted in the post-D2 control table;
-                // see `pond_txn` in the data Delta commit metadata for
-                // the original command.
+                match &command {
+                    Some(cmd) => println!("|  Command      : {}", cmd),
+                    None => println!("|  Command      : (no command recorded)"),
+                }
                 println!("+----------------------------------------------------------------");
             }
             "data_committed" => {
@@ -609,9 +757,14 @@ async fn show_pond_config(control_table: &steward::ControlTable) -> Result<()> {
             .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
             .unwrap_or_else(|| "unknown".to_string())
     );
+    println!("Created by:     {}", metadata.birth_username);
     println!(
-        "Created by:     {}@{}",
-        metadata.birth_username, metadata.birth_hostname
+        "Birthplace:     {}",
+        if metadata.birthplace.is_empty() {
+            "(unspecified)"
+        } else {
+            &metadata.birthplace
+        }
     );
     println!();
     println!("Factory Modes:");

--- a/crates/cmd/src/commands/copy.rs
+++ b/crates/cmd/src/commands/copy.rs
@@ -291,7 +291,7 @@ async fn copy_directory_recursive(
 
     pond_ship
         .write_transaction(
-            &steward::PondUserMetadata::new(vec!["copy-recursive".to_string()]),
+            &ship_context.command_metadata(),
             async |fs| {
                 let root = fs.root().await?;
 
@@ -478,7 +478,7 @@ async fn copy_in(ship_context: &ShipContext, sources: &[String], dest: &str) -> 
 
     // Use scoped write transaction on the pond side
     pond_ship.write_transaction(
-        &steward::PondUserMetadata::new(vec!["copy".to_string(), dest.clone()]),
+        &ship_context.command_metadata(),
         async |pond_fs| {
             let pond_root = pond_fs.root().await?;
 
@@ -915,7 +915,7 @@ mod tests {
             let ship_context = ShipContext::pond_only(Some(&pond_path), init_args.clone());
 
             // Initialize the pond
-            init_command(&ship_context).await?;
+            init_command(&ship_context, "test-host").await?;
 
             Ok(TestSetup {
                 pond_path,
@@ -1678,7 +1678,7 @@ mod tests {
         );
 
         // Initialize the pond
-        init_command(&ship_context).await?;
+        init_command(&ship_context, "test-host").await?;
 
         // Copy using relative path: host:///file.txt resolves to host_files_dir/file.txt
         copy_command(

--- a/crates/cmd/src/commands/describe.rs
+++ b/crates/cmd/src/commands/describe.rs
@@ -664,7 +664,7 @@ mod tests {
                 mount_specs: Vec::new(),
                 original_args: vec!["pond".to_string(), "init".to_string()],
             };
-            init_command(&ship_context).await?;
+            init_command(&ship_context, "test-host").await?;
 
             Ok(TestSetup {
                 temp_dir,

--- a/crates/cmd/src/commands/export.rs
+++ b/crates/cmd/src/commands/export.rs
@@ -165,7 +165,7 @@ async fn export_pond_data(
 
     let export_summary = crate::common::with_write_transaction(
         &mut ship,
-        vec!["export".to_string()],
+        ship_context.command_args(),
         async |stx_guard| {
             let mut export_summary = ExportSummary::default();
 

--- a/crates/cmd/src/commands/init.rs
+++ b/crates/cmd/src/commands/init.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 /// Replica bootstrap (formerly `--from-backup` / `--config`) is going
 /// away in the D4 redesign: use `pond init` + `pond remote add` +
 /// `pond pull` (or the future `pond restart-from-compact`) instead.
-pub async fn init_command(ship_context: &ShipContext) -> Result<()> {
+pub async fn init_command(ship_context: &ShipContext, birthplace: &str) -> Result<()> {
     let pond_path = ship_context.resolve_pond_path()?;
     let pond_path_display = pond_path.display().to_string();
 
@@ -29,14 +29,14 @@ pub async fn init_command(ship_context: &ShipContext) -> Result<()> {
     }
 
     info!("Initializing pond at: {pond_path_display}");
-    init_normal(ship_context).await
+    init_normal(ship_context, birthplace).await
 }
 
 /// Normal initialization - creates empty pond with initial transaction
-async fn init_normal(ship_context: &ShipContext) -> Result<()> {
+async fn init_normal(ship_context: &ShipContext, birthplace: &str) -> Result<()> {
     // Pond doesn't exist, so create a new one
     // This creates both the filesystem infrastructure AND the initial /txn/1 transaction
-    let _ship = ship_context.create_pond().await?;
+    let _ship = ship_context.create_pond(birthplace).await?;
     log::debug!("Pond initialized successfully with transaction #1");
     Ok(())
 }

--- a/crates/cmd/src/commands/list.rs
+++ b/crates/cmd/src/commands/list.rs
@@ -122,7 +122,7 @@ mod tests {
             let ship_context = ShipContext::pond_only(Some(&pond_path), init_args.clone());
 
             // Initialize the pond
-            init_command(&ship_context).await?;
+            init_command(&ship_context, "test-host").await?;
 
             Ok(Self {
                 ship_context,

--- a/crates/cmd/src/commands/mkdir.rs
+++ b/crates/cmd/src/commands/mkdir.rs
@@ -27,82 +27,71 @@ pub async fn mkdir_command(
 
     debug!("Creating directory in pond: {path} (create_parents: {create_parents})");
 
-    ship.write_transaction(
-        &steward::PondUserMetadata::new(vec![
-            "mkdir".to_string(),
-            path_for_closure.clone(),
-            if create_parents {
-                "-p".to_string()
-            } else {
-                "".to_string()
-            },
-        ]),
-        async |fs| {
-            let root = fs.root().await?;
+    ship.write_transaction(&ship_context.command_metadata(), async |fs| {
+        let root = fs.root().await?;
 
-            if create_parents {
-                let path_components: Vec<&str> = path_for_closure
-                    .trim_start_matches('/')
-                    .split('/')
-                    .filter(|s| !s.is_empty())
-                    .collect();
+        if create_parents {
+            let path_components: Vec<&str> = path_for_closure
+                .trim_start_matches('/')
+                .split('/')
+                .filter(|s| !s.is_empty())
+                .collect();
 
-                if path_components.is_empty() {
-                    return Ok(());
-                }
-
-                let mut current_path = String::new();
-                for (i, component) in path_components.iter().enumerate() {
-                    if path_for_closure.starts_with('/') || i > 0 {
-                        current_path.push('/');
-                    }
-                    current_path.push_str(component);
-
-                    if root.exists(&current_path).await {
-                        match root.open_dir_path(&current_path).await {
-                            Ok(_) => continue,
-                            Err(_) => {
-                                return Err(tinyfs::Error::Other(format!(
-                                    "Path '{}' exists but is not a directory",
-                                    current_path
-                                ))
-                                .into());
-                            }
-                        }
-                    } else {
-                        _ = root.create_dir_path(&current_path).await?;
-                    }
-                }
-            } else {
-                if path_for_closure.is_empty() || path_for_closure == "/" {
-                    return Ok(());
-                }
-
-                if let Some(parent_pos) = path_for_closure.rfind('/') {
-                    let parent_path = if parent_pos == 0 {
-                        "/"
-                    } else {
-                        &path_for_closure[..parent_pos]
-                    };
-
-                    if !root.exists(parent_path).await {
-                        return Err(tinyfs::Error::not_found(format!(
-                            "Parent directory '{}' does not exist",
-                            parent_path
-                        ))
-                        .into());
-                    }
-                }
-
-                if root.exists(&path_for_closure).await {
-                    return Err(tinyfs::Error::already_exists(&path_for_closure).into());
-                }
-
-                _ = root.create_dir_path(&path_for_closure).await?;
+            if path_components.is_empty() {
+                return Ok(());
             }
-            Ok(())
-        },
-    )
+
+            let mut current_path = String::new();
+            for (i, component) in path_components.iter().enumerate() {
+                if path_for_closure.starts_with('/') || i > 0 {
+                    current_path.push('/');
+                }
+                current_path.push_str(component);
+
+                if root.exists(&current_path).await {
+                    match root.open_dir_path(&current_path).await {
+                        Ok(_) => continue,
+                        Err(_) => {
+                            return Err(tinyfs::Error::Other(format!(
+                                "Path '{}' exists but is not a directory",
+                                current_path
+                            ))
+                            .into());
+                        }
+                    }
+                } else {
+                    _ = root.create_dir_path(&current_path).await?;
+                }
+            }
+        } else {
+            if path_for_closure.is_empty() || path_for_closure == "/" {
+                return Ok(());
+            }
+
+            if let Some(parent_pos) = path_for_closure.rfind('/') {
+                let parent_path = if parent_pos == 0 {
+                    "/"
+                } else {
+                    &path_for_closure[..parent_pos]
+                };
+
+                if !root.exists(parent_path).await {
+                    return Err(tinyfs::Error::not_found(format!(
+                        "Parent directory '{}' does not exist",
+                        parent_path
+                    ))
+                    .into());
+                }
+            }
+
+            if root.exists(&path_for_closure).await {
+                return Err(tinyfs::Error::already_exists(&path_for_closure).into());
+            }
+
+            _ = root.create_dir_path(&path_for_closure).await?;
+        }
+        Ok(())
+    })
     .await
     .map_err(|e| anyhow::anyhow!("Failed to create directory: {}", e))?;
 
@@ -132,7 +121,7 @@ mod tests {
             let ship_context = ShipContext::pond_only(Some(&pond_path), init_args.clone());
 
             // Initialize pond
-            init_command(&ship_context)
+            init_command(&ship_context, "test-host")
                 .await
                 .expect("Failed to initialize pond");
 

--- a/crates/cmd/src/commands/mknod.rs
+++ b/crates/cmd/src/commands/mknod.rs
@@ -63,27 +63,19 @@ pub async fn mknod_command(
 
     // mknod needs the transaction guard for tx.state() (provider context), so it
     // takes the full Transaction (not the &FS-only Steward::write_transaction).
-    crate::common::with_write_transaction(
-        &mut ship,
-        vec![
-            "mknod".to_string(),
-            factory_type_clone.clone(),
-            path_clone.clone(),
-        ],
-        async |tx| {
-            mknod_impl(
-                tx,
-                tx,
-                &path_clone,
-                &factory_type_clone,
-                stored_config_bytes.clone(),
-                expanded_content.into_bytes(),
-                overwrite,
-            )
-            .await
-            .map_err(|e| anyhow!("mknod operation failed: {}", e))
-        },
-    )
+    crate::common::with_write_transaction(&mut ship, ship_context.command_args(), async |tx| {
+        mknod_impl(
+            tx,
+            tx,
+            &path_clone,
+            &factory_type_clone,
+            stored_config_bytes.clone(),
+            expanded_content.into_bytes(),
+            overwrite,
+        )
+        .await
+        .map_err(|e| anyhow!("mknod operation failed: {}", e))
+    })
     .await?;
 
     Ok(())
@@ -215,7 +207,7 @@ mod tests {
             let ship_context = ShipContext::pond_only(Some(&pond_path), init_args.clone());
 
             // Initialize pond
-            init_command(&ship_context).await?;
+            init_command(&ship_context, "test-host").await?;
 
             Ok(Self {
                 temp_dir,

--- a/crates/cmd/src/commands/run.rs
+++ b/crates/cmd/src/commands/run.rs
@@ -84,12 +84,7 @@ async fn run_host_command(
 
     // Open host steward
     let mut ship = ship_context.open_host()?;
-    let tx = ship
-        .begin_write(&steward::PondUserMetadata::new(vec![
-            "run".to_string(),
-            config_path.to_string(),
-        ]))
-        .await?;
+    let tx = ship.begin_write(&ship_context.command_metadata()).await?;
 
     // Read config bytes from host filesystem
     let host_path = url.path();
@@ -194,12 +189,7 @@ async fn run_pond_command(
     log::debug!("Loaded factory modes: {:?}", all_factory_modes);
 
     // Start write transaction for the entire operation
-    let mut tx = ship
-        .begin_write(&steward::PondUserMetadata::new(vec![
-            "run".to_string(),
-            config_path.to_string(),
-        ]))
-        .await?;
+    let mut tx = ship.begin_write(&ship_context.command_metadata()).await?;
 
     match run_pond_command_impl(
         &mut tx,

--- a/crates/cmd/src/commands/show.rs
+++ b/crates/cmd/src/commands/show.rs
@@ -62,7 +62,8 @@ async fn show_filesystem_transactions(
 
     // Route to appropriate display mode
     match mode {
-        "brief" | "concise" => show_brief_mode(&commit_history, &store_path, &pond_path, tx).await,
+        "brief" => show_brief_mode(&commit_history, &store_path, &pond_path, tx).await,
+        "concise" => show_concise_mode(tx).await,
         "detailed" => show_detailed_mode(&commit_history, &store_path, &pond_path, tx).await,
         _ => Err(steward::StewardError::Dyn(
             format!(
@@ -225,7 +226,11 @@ async fn show_brief_mode(
         }
     }
 
-    // Resolve partition paths by traversing TinyFS
+    // Resolve partition paths by traversing TinyFS.  Partition map keys
+    // are the raw OpLog `part_id` hex strings.  A partition is owned by a
+    // self-partitioned physical directory, so its path is found by
+    // reconstructing that directory's FileID (part_id + pond_id) and
+    // looking it up in a FileID-keyed path map -- mirroring detailed mode.
     log::debug!("Resolving partition paths via TinyFS...");
     let root = tx
         .root()
@@ -236,21 +241,29 @@ async fn show_brief_mode(
         steward::StewardError::Dyn(format!("Failed to collect matches: {}", e).into())
     })?;
 
-    // Build path map from all matched entries
+    // Build a FileID-string -> path map from all matched entries, plus the
+    // root directory (which collect_matches does not itself yield).
+    let mut path_map: HashMap<String, String> = HashMap::new();
     for (node_path, _captured) in matches {
-        let node_id = node_path.id();
-        let path = node_path.path();
-        let node_id_str = node_id.to_string();
-
-        if let Some(stats) = partition_map.get_mut(&node_id_str) {
-            stats.path_name = Some(path.to_string_lossy().to_string());
-        }
+        _ = path_map.insert(
+            node_path.id().to_string(),
+            node_path.path().to_string_lossy().to_string(),
+        );
     }
+    let root_file_id = root.node_path().id();
+    let pond_id = root_file_id.pond_id();
+    _ = path_map.insert(root_file_id.to_string(), "/".to_string());
 
-    // Also add the root directory
-    let root_node_id = root.node_path().id();
-    if let Some(stats) = partition_map.get_mut(&root_node_id.to_string()) {
-        stats.path_name = Some("/".to_string());
+    // For each partition, reconstruct the owning directory's FileID and
+    // resolve its path.
+    for (part_id_hex, stats) in partition_map.iter_mut() {
+        let Ok(part_id) = tinyfs::PartID::from_hex_string(part_id_hex) else {
+            continue;
+        };
+        let dir_file_id = tinyfs::FileID::from_physical_dir_node_id(part_id.to_node_id(), pond_id);
+        if let Some(path) = path_map.get(&dir_file_id.to_string()) {
+            stats.path_name = Some(path.clone());
+        }
     }
 
     // Format the output
@@ -328,6 +341,101 @@ async fn query_transaction_commands(
     _control_table: &steward::ControlTable,
 ) -> Result<std::collections::HashMap<i64, Vec<String>>, steward::StewardError> {
     Ok(std::collections::HashMap::new())
+}
+
+/// Show a one-line-per-transaction summary (newest first).  Each line
+/// reports the transaction sequence, how many OpLog operations it wrote,
+/// how many distinct nodes it touched, and when it committed.
+async fn show_concise_mode(
+    tx: &mut steward::Transaction<'_>,
+) -> Result<String, steward::StewardError> {
+    use arrow::array::{Array, Int64Array};
+
+    let control_table = tx
+        .as_pond()
+        .expect("show command requires a pond transaction")
+        .control_table();
+    control_table.print_banner();
+
+    let session_ctx = tx.session_context().await.map_err(|e| {
+        steward::StewardError::Dyn(format!("Failed to get session context: {}", e).into())
+    })?;
+
+    let sql = "
+        SELECT txn_seq,
+            CAST(COUNT(*) AS BIGINT) AS ops,
+            CAST(COUNT(DISTINCT node_id) AS BIGINT) AS nodes,
+            CAST(MAX(timestamp) AS BIGINT) AS ts
+        FROM delta_table
+        GROUP BY txn_seq
+        ORDER BY txn_seq DESC
+    ";
+
+    let batches = session_ctx
+        .sql(sql)
+        .await
+        .map_err(|e| {
+            steward::StewardError::Dyn(format!("Failed to query transactions: {}", e).into())
+        })?
+        .collect()
+        .await
+        .map_err(|e| {
+            steward::StewardError::Dyn(format!("Failed to collect transactions: {}", e).into())
+        })?;
+
+    let mut output = String::new();
+    output.push_str("\nTransactions (newest first)\n");
+    output.push_str("---------------------------\n");
+
+    let mut any_rows = false;
+    for batch in &batches {
+        let col = |name: &str| -> Result<&Int64Array, steward::StewardError> {
+            batch
+                .column_by_name(name)
+                .ok_or_else(|| {
+                    steward::StewardError::Dyn(format!("Missing {} column", name).into())
+                })?
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| {
+                    steward::StewardError::Dyn(format!("Failed to downcast {} column", name).into())
+                })
+        };
+        let txn_seqs = col("txn_seq")?;
+        let ops = col("ops")?;
+        let nodes = col("nodes")?;
+        let ts = col("ts")?;
+
+        for i in 0..batch.num_rows() {
+            any_rows = true;
+            let when = if ts.is_null(i) {
+                "unknown time".to_string()
+            } else {
+                format_micros_timestamp(ts.value(i))
+            };
+            output.push_str(&format!(
+                "  seq {:>5}  {:>4} op(s)  {:>4} node(s)  {}\n",
+                txn_seqs.value(i),
+                ops.value(i),
+                nodes.value(i),
+                when,
+            ));
+        }
+    }
+
+    if !any_rows {
+        output.push_str("  (no transactions)\n");
+    }
+    output.push('\n');
+
+    Ok(output)
+}
+
+/// Format a microsecond Unix timestamp as a readable UTC string.
+fn format_micros_timestamp(micros: i64) -> String {
+    chrono::DateTime::from_timestamp_micros(micros)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+        .unwrap_or_else(|| format!("<invalid timestamp: {}>", micros))
 }
 
 /// Show detailed transaction log using transaction sequences
@@ -815,7 +923,7 @@ mod tests {
             let ship_context = ShipContext::pond_only(Some(pond_path.clone()), init_args.clone());
 
             // Initialize pond
-            init_command(&ship_context)
+            init_command(&ship_context, "test-host")
                 .await
                 .expect("Failed to initialize pond");
 
@@ -862,7 +970,7 @@ mod tests {
         let pond_path = temp_dir.path().join("test_pond");
 
         // Initialize pond using steward - this creates the full Delta Lake setup
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to initialize pond");
 

--- a/crates/cmd/src/commands/status.rs
+++ b/crates/cmd/src/commands/status.rs
@@ -40,15 +40,22 @@ pub async fn status_command(ship_context: &ShipContext) -> Result<()> {
     println!("===========");
     println!();
     println!("Identity");
-    println!("  Pond ID:   {}", metadata.pond_id);
+    println!("  Pond ID:    {}", metadata.pond_id);
     println!(
-        "  Created:   {} by {}@{}",
+        "  Created:    {} by {}",
         format_timestamp(metadata.birth_timestamp),
         metadata.birth_username,
-        metadata.birth_hostname
+    );
+    println!(
+        "  Birthplace: {}",
+        if metadata.birthplace.is_empty() {
+            "(unspecified)"
+        } else {
+            &metadata.birthplace
+        }
     );
     if let Ok(path) = ship_context.resolve_pond_path() {
-        println!("  Location:  {}", path.display());
+        println!("  Location:   {}", path.display());
     }
     println!();
 

--- a/crates/cmd/src/commands/temporal.rs
+++ b/crates/cmd/src/commands/temporal.rs
@@ -779,62 +779,58 @@ pub async fn set_extended_attributes_command(
     attributes: HashMap<String, String>,
 ) -> Result<()> {
     let mut ship = ship_context.open_pond().await?;
-    crate::common::with_write_transaction(
-        &mut ship,
-        vec!["set_extended_attributes".into(), target_path.clone()],
-        async |tx| {
-            debug!("Setting extended attributes for target_path: {target_path}");
+    crate::common::with_write_transaction(&mut ship, ship_context.command_args(), async |tx| {
+        debug!("Setting extended attributes for target_path: {target_path}");
 
-            // Get TinyFS working directory from the transaction
-            let tinyfs_root = tx.root().await?;
+        // Get TinyFS working directory from the transaction
+        let tinyfs_root = tx.root().await?;
 
-            debug!("About to get async writer for target_path: {target_path}");
+        debug!("About to get async writer for target_path: {target_path}");
 
-            // Use TinyFS async writer to either add a new version to existing file or create new FileSeries
-            // This handles both cases automatically: existing file gets new version, missing file gets created
-            let mut writer = tinyfs_root
-                .async_writer_path_with_type(&target_path, tinyfs::EntryType::TablePhysicalSeries)
-                .await
-                .map_err(|e| anyhow!("Failed to get FileSeries writer: {}", e))?;
+        // Use TinyFS async writer to either add a new version to existing file or create new FileSeries
+        // This handles both cases automatically: existing file gets new version, missing file gets created
+        let mut writer = tinyfs_root
+            .async_writer_path_with_type(&target_path, tinyfs::EntryType::TablePhysicalSeries)
+            .await
+            .map_err(|e| anyhow!("Failed to get FileSeries writer: {}", e))?;
 
-            debug!("Got FileSeries writer for target_path: {target_path}");
+        debug!("Got FileSeries writer for target_path: {target_path}");
 
-            // Write empty content to create a pending record
-            use tokio::io::AsyncWriteExt;
-            writer
-                .write_all(&[])
-                .await
-                .map_err(|e| anyhow!("Failed to write empty content: {}", e))?;
-            writer
-                .flush()
-                .await
-                .map_err(|e| anyhow!("Failed to flush empty content: {}", e))?;
+        // Write empty content to create a pending record
+        use tokio::io::AsyncWriteExt;
+        writer
+            .write_all(&[])
+            .await
+            .map_err(|e| anyhow!("Failed to write empty content: {}", e))?;
+        writer
+            .flush()
+            .await
+            .map_err(|e| anyhow!("Failed to flush empty content: {}", e))?;
 
-            debug!("Wrote and flushed empty content, pending record should now exist");
+        debug!("Wrote and flushed empty content, pending record should now exist");
 
-            // Complete the write operation to create the pending record
-            writer
-                .shutdown()
-                .await
-                .map_err(|e| anyhow!("Failed to complete empty write: {}", e))?;
+        // Complete the write operation to create the pending record
+        writer
+            .shutdown()
+            .await
+            .map_err(|e| anyhow!("Failed to complete empty write: {}", e))?;
 
-            debug!("Writer shutdown complete, pending record should now exist");
+        debug!("Writer shutdown complete, pending record should now exist");
 
-            debug!("About to set extended attributes on pending version");
+        debug!("About to set extended attributes on pending version");
 
-            // Now apply extended attributes to the pending record created by shutdown
-            tinyfs_root
-                .set_extended_attributes(&target_path, attributes)
-                .await
-                .map_err(|e| anyhow!("Failed to set extended attributes: {}", e))?;
+        // Now apply extended attributes to the pending record created by shutdown
+        tinyfs_root
+            .set_extended_attributes(&target_path, attributes)
+            .await
+            .map_err(|e| anyhow!("Failed to set extended attributes: {}", e))?;
 
-            debug!("Applied extended attributes to pending FileSeries version");
+        debug!("Applied extended attributes to pending FileSeries version");
 
-            debug!("Completed FileSeries write with extended attributes");
+        debug!("Completed FileSeries write with extended attributes");
 
-            Ok(())
-        },
-    )
+        Ok(())
+    })
     .await?;
 
     debug!("Created metadata-only FileSeries version with extended attributes");

--- a/crates/cmd/src/commands/verify.rs
+++ b/crates/cmd/src/commands/verify.rs
@@ -17,6 +17,7 @@
 //! When invoked without `name`, every attached remote is verified.
 //! Each remote is processed independently; one failure does not halt
 //! the others.
+#![allow(clippy::print_stdout)]
 
 use crate::commands::remote::{list_remote_names, load_remote_attachment};
 use crate::common::ShipContext;
@@ -36,7 +37,7 @@ pub async fn verify_command(ship_context: &ShipContext, name: Option<String>) ->
     };
 
     if targets.is_empty() {
-        log::info!("no remotes attached; nothing to verify");
+        println!("No remotes attached; nothing to verify.");
         return Ok(());
     }
 
@@ -113,19 +114,19 @@ fn print_report(name: &str, report: &RemoteVerifyReport) {
             seq
         ),
     };
-    log::info!("{}", header);
+    println!("{}", header);
 
     for m in &report.mismatches {
         match (&m.consumer_live, &m.remote_recorded) {
-            (Some(_), None) => log::info!(
+            (Some(_), None) => println!(
                 "  partition `{}`: present locally, absent on remote",
                 m.partition
             ),
-            (None, Some(_)) => log::info!(
+            (None, Some(_)) => println!(
                 "  partition `{}`: present on remote, absent locally",
                 m.partition
             ),
-            (Some(_), Some(_)) => log::info!(
+            (Some(_), Some(_)) => println!(
                 "  partition `{}`: checksums differ between local and remote",
                 m.partition
             ),
@@ -134,11 +135,11 @@ fn print_report(name: &str, report: &RemoteVerifyReport) {
     }
 
     if let Some(boundary) = report.divergence_boundary {
-        log::info!(
+        println!(
             "  divergence boundary: consumer last agreed with remote at seq={} (drift began after)",
             boundary
         );
     } else if !report.ok && report.remote_latest_seq.is_some() {
-        log::info!("  divergence boundary: no prior bundle in remote history agrees with consumer");
+        println!("  divergence boundary: no prior bundle in remote history agrees with consumer");
     }
 }

--- a/crates/cmd/src/common.rs
+++ b/crates/cmd/src/common.rs
@@ -67,6 +67,24 @@ impl ShipContext {
         get_pond_path_with_override(self.pond_path.clone())
     }
 
+    /// The CLI argument vector with the binary path (argv[0]) stripped, for
+    /// recording in transaction metadata.  This is the real command the
+    /// user ran, so `pond log` can faithfully show what each transaction
+    /// did instead of a hand-built, often-incomplete label.
+    #[must_use]
+    pub fn command_args(&self) -> Vec<String> {
+        self.original_args.iter().skip(1).cloned().collect()
+    }
+
+    /// Transaction metadata carrying the real CLI command (see
+    /// [`command_args`](Self::command_args)).  Write commands should pass
+    /// this to `write_transaction` / `begin_write` so the audit log is
+    /// accurate.
+    #[must_use]
+    pub fn command_metadata(&self) -> steward::PondUserMetadata {
+        steward::PondUserMetadata::new(self.command_args())
+    }
+
     /// Create a Ship for an existing pond (read-only operations)
     pub async fn open_pond(&self) -> Result<steward::Steward> {
         let pond_path = self.resolve_pond_path()?;
@@ -76,9 +94,9 @@ impl ShipContext {
     }
 
     /// Initialize a new pond (for init command only)
-    pub async fn create_pond(&self) -> Result<steward::Steward> {
+    pub async fn create_pond(&self, birthplace: &str) -> Result<steward::Steward> {
         let pond_path = self.resolve_pond_path()?;
-        steward::Steward::create_pond(&pond_path)
+        steward::Steward::create_pond(&pond_path, birthplace)
             .await
             .map_err(|e| anyhow!("Failed to initialize pond: {}", e))
     }
@@ -419,7 +437,7 @@ impl FileInfo {
 
         let time_str = dt.format("%Y-%m-%d %H:%M:%S").to_string();
 
-        let node_id_str = format_node_id(&self.node_id);
+        let node_id_str = format_node_id(&self.node_id.node_id());
 
         let version_str = format!("v{}", self.metadata.version);
 

--- a/crates/cmd/src/common.rs
+++ b/crates/cmd/src/common.rs
@@ -437,7 +437,15 @@ impl FileInfo {
 
         let time_str = dt.format("%Y-%m-%d %H:%M:%S").to_string();
 
-        let node_id_str = format_node_id(&self.node_id.node_id());
+        // Show two provenance tags: the node's own id (unique per entry, for
+        // identity) and the owning pond's id (shared within a pond, which
+        // reveals the origin pond for cross-pond imports). This mirrors the
+        // FileID Display form `[node]@[pond]`.
+        let node_id_str = format!(
+            "{}@{}",
+            format_node_id(&self.node_id.node_id()),
+            format_node_id(&self.node_id.pond_id())
+        );
 
         let version_str = format!("v{}", self.metadata.version);
 

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -210,7 +210,13 @@ struct RemoteAddOptions {
 #[derive(Subcommand)]
 enum Commands {
     /// Initialize a new pond
-    Init,
+    Init {
+        /// Birthplace of the pond: an immutable label for where this pond
+        /// is created (for example a hostname, site, or deployment name).
+        /// Recorded permanently in the pond's identity metadata.
+        #[arg(long)]
+        birthplace: String,
+    },
     /// Recover from crash by checking and restoring transaction metadata
     Recover,
     /// Run Delta Lake maintenance (checkpoint, vacuum, optional compaction)
@@ -530,9 +536,9 @@ async fn main() -> Result<()> {
     let started = Instant::now();
 
     let result = match cli.command {
-        Commands::Init => {
+        Commands::Init { birthplace } => {
             // Init command creates a new empty pond.
-            commands::init_command(&ship_context).await
+            commands::init_command(&ship_context, &birthplace).await
         }
         Commands::Recover => {
             // Recover command works with potentially damaged pond, handle specially

--- a/crates/cmd/tests/control.rs
+++ b/crates/cmd/tests/control.rs
@@ -33,7 +33,7 @@ impl TestSetup {
         let ship_context = ShipContext::pond_only(Some(&pond_path), init_args);
 
         // Initialize pond
-        init_command(&ship_context).await?;
+        init_command(&ship_context, "test-host").await?;
 
         Ok(TestSetup {
             _temp_dir: temp_dir,
@@ -1294,7 +1294,7 @@ async fn test_transaction_completion_records_written() {
 /// Test that replica pond preserves transaction sequence numbers from source
 ///
 /// This test verifies the fix for a bug where replica ponds had an off-by-one
-/// error in transaction sequences. The bug was caused by calling create_pond()
+/// error in transaction sequences. The bug was caused by calling create_pond("test-host")
 /// during restoration, which recorded an initial "pond init" transaction, then
 /// bundle restoration added the source's "pond init" as a second transaction.
 ///
@@ -1307,7 +1307,7 @@ async fn test_replica_preserves_transaction_sequences() {
 
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
 
-    // Part 1: Verify that create_pond() records transaction #1
+    // Part 1: Verify that create_pond("test-host") records transaction #1
     println!("\n--- Part 1: Normal pond creation ---");
     let normal_path = temp_dir.path().join("normal_pond");
     let normal_context = ShipContext::pond_only(
@@ -1316,7 +1316,7 @@ async fn test_replica_preserves_transaction_sequences() {
     );
 
     let normal_ship = normal_context
-        .create_pond()
+        .create_pond("test-host")
         .await
         .expect("Failed to create normal pond");
 

--- a/crates/cmd/tests/replicate_simple.rs
+++ b/crates/cmd/tests/replicate_simple.rs
@@ -36,7 +36,7 @@ impl SimpleReplicationTest {
         let ship_context =
             ShipContext::pond_only(Some(self.source_pond.clone()), vec!["pond".to_string()]);
 
-        init_command(&ship_context).await?;
+        init_command(&ship_context, "test-host").await?;
         Ok(())
     }
 

--- a/crates/cmd/tests/test_executable_factory.rs
+++ b/crates/cmd/tests/test_executable_factory.rs
@@ -29,7 +29,7 @@ async fn setup_test_ship() -> (ShipContext, TempDir) {
     };
 
     // Initialize the pond
-    cmd::commands::init::init_command(&ship_context)
+    cmd::commands::init::init_command(&ship_context, "test-host")
         .await
         .expect("Failed to initialize pond");
 

--- a/crates/cmd/tests/test_remote_cli.rs
+++ b/crates/cmd/tests/test_remote_cli.rs
@@ -101,7 +101,7 @@ async fn pond_remote_push_pull_roundtrip() {
 
     // 1) Source pond + one user write transaction.
     let src_ctx = ctx_for(&src_pond, vec!["pond", "init"]);
-    init_command(&src_ctx).await.expect("init src");
+    init_command(&src_ctx, "test-host").await.expect("init src");
     write_small_file(
         &src_ctx,
         "/hello.txt",
@@ -256,7 +256,7 @@ async fn pond_remote_push_pull_large_file_roundtrip() {
 
     // 1) Source pond + one user write transaction.
     let src_ctx = ctx_for(&src_pond, vec!["pond", "init"]);
-    init_command(&src_ctx).await.expect("init src");
+    init_command(&src_ctx, "test-host").await.expect("init src");
     write_small_file(&src_ctx, "/big.bin", &big, vec!["copy", "big.bin"])
         .await
         .expect("write big.bin");
@@ -367,7 +367,7 @@ async fn pond_push_no_remotes_is_noop() {
     let scratch = TempDir::new().expect("tempdir");
     let pond_path = scratch.path().join("pond");
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     push_command(&ctx, None).await.expect("push noop");
 }
 
@@ -378,7 +378,7 @@ async fn pond_pull_no_remotes_is_noop() {
     let scratch = TempDir::new().expect("tempdir");
     let pond_path = scratch.path().join("pond");
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     pull_command(&ctx, None).await.expect("pull noop");
 }
 
@@ -396,7 +396,7 @@ async fn pond_verify_ok_after_push() {
     let remote_url = format!("file://{}", remote_path.display());
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     write_small_file(&ctx, "/v.txt", b"verify me", vec!["copy", "v.txt"])
         .await
         .expect("write v.txt");
@@ -446,7 +446,7 @@ async fn pond_verify_no_remotes_is_noop() {
     let scratch = TempDir::new().expect("tempdir");
     let pond_path = scratch.path().join("pond");
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     verify_command(&ctx, None).await.expect("verify noop");
 }
 
@@ -457,7 +457,7 @@ async fn pond_status_fresh_pond() {
     let scratch = TempDir::new().expect("tempdir");
     let pond_path = scratch.path().join("pond");
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     status_command(&ctx).await.expect("status fresh");
 }
 
@@ -473,7 +473,7 @@ async fn pond_status_with_backup() {
     let remote_url = format!("file://{}", remote_path.display());
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     write_small_file(&ctx, "/s.txt", b"status", vec!["copy", "s.txt"])
         .await
         .expect("write s.txt");
@@ -522,7 +522,7 @@ async fn pond_restart_from_compact_no_restart_point() {
     let remote_url = format!("file://{}", remote_path.display());
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     write_small_file(&ctx, "/r.txt", b"restart", vec!["copy", "r.txt"])
         .await
         .expect("write r.txt");
@@ -589,7 +589,7 @@ async fn pond_remote_add_rejects_duplicate() {
     std::fs::create_dir_all(&remote_b).expect("mkdir remote_b");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     add_backup_command(
         &ctx, "origin", &url_a, false, None, None, None, None, false, false,
@@ -632,7 +632,7 @@ async fn post_commit_auto_push_publishes_to_file_remote() {
 
     // 1) Source pond.
     let src_ctx = ctx_for(&src_pond, vec!["pond", "init"]);
-    init_command(&src_ctx).await.expect("init src");
+    init_command(&src_ctx, "test-host").await.expect("init src");
 
     // 2) Create the remote bucket as a fresh Delta table.
     let store_id = {
@@ -729,7 +729,7 @@ async fn post_commit_auto_push_skips_pull_mode_remotes() {
     let remote_url = format!("file://{}", remote_path.display());
 
     let src_ctx = ctx_for(&src_pond, vec!["pond", "init"]);
-    init_command(&src_ctx).await.expect("init src");
+    init_command(&src_ctx, "test-host").await.expect("init src");
 
     // Create the bucket so any erroneous push would actually succeed
     // and update the watermark; the test would catch that.
@@ -796,7 +796,7 @@ async fn pond_remote_add_auto_initializes_fresh_remote() {
     std::fs::create_dir_all(&remote_path).expect("mkdir remote");
 
     let src_ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&src_ctx).await.expect("init src");
+    init_command(&src_ctx, "test-host").await.expect("init src");
 
     // No Remote::create_at_url call here -- add_backup_command must do it.
     add_backup_command(
@@ -861,7 +861,7 @@ async fn pond_remote_add_push_refuses_foreign_store_id() {
         .expect("create foreign remote");
 
     let src_ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&src_ctx).await.expect("init src");
+    init_command(&src_ctx, "test-host").await.expect("init src");
 
     let err = add_backup_command(
         &src_ctx,
@@ -898,7 +898,7 @@ async fn pond_remote_add_pull_refuses_empty_remote() {
     std::fs::create_dir_all(&remote_path).expect("mkdir empty remote");
 
     let dst_ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&dst_ctx).await.expect("init dst");
+    init_command(&dst_ctx, "test-host").await.expect("init dst");
 
     let err = add_remote_command(
         &dst_ctx,
@@ -948,7 +948,7 @@ async fn pond_remote_add_persists_mount_path() {
         .expect("init upstream");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     // Pull attach with an explicit non-root mount path.
     add_remote_command(
@@ -1034,7 +1034,7 @@ async fn pond_backup_add_bidirectional_records_both_mode() {
     std::fs::create_dir_all(&remote_path).expect("mkdir remote");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     add_backup_command(
         &ctx,
@@ -1072,7 +1072,7 @@ async fn pond_remote_add_rejects_relative_mount_path() {
     std::fs::create_dir_all(&remote_path).expect("mkdir remote");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     let err = add_remote_command(
         &ctx,
@@ -1115,7 +1115,7 @@ async fn pond_remote_remove_clears_mount_path_key() {
         .expect("create foreign remote");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     add_remote_command(
         &ctx,
@@ -1167,7 +1167,7 @@ async fn pond_remote_add_root_path_refuses_foreign_store_id() {
         .expect("create foreign remote");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     let err = add_remote_command(
         &ctx,
@@ -1207,7 +1207,7 @@ async fn pond_remote_add_nonroot_path_refuses_matching_store_id() {
     // with the same store_id (simulating a self-mirror -- which is
     // valid for `/` but invalid for a non-root mount).
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     let local_id = {
         let ship = ctx.open_pond().await.expect("open");
         ship.control_table().pond_id_uuid()
@@ -1260,7 +1260,7 @@ async fn cross_pond_pull_materializes_mount_entry() {
 
     // 1) Pond A: init + write a file.
     let a_ctx = ctx_for(&a_pond, vec!["pond", "init"]);
-    init_command(&a_ctx).await.expect("init A");
+    init_command(&a_ctx, "test-host").await.expect("init A");
     write_small_file(
         &a_ctx,
         "/sensor.txt",
@@ -1299,7 +1299,7 @@ async fn cross_pond_pull_materializes_mount_entry() {
 
     // 3) Pond B: init (gets its own distinct pond_id).
     let b_ctx = ctx_for(&b_pond, vec!["pond", "init"]);
-    init_command(&b_ctx).await.expect("init B");
+    init_command(&b_ctx, "test-host").await.expect("init B");
     let b_pond_id = {
         let ship = b_ctx.open_pond().await.expect("open B");
         ship.control_table().pond_id_uuid()
@@ -1397,7 +1397,7 @@ async fn cross_pond_pull_does_not_inflate_local_seq() {
 
     // 1) Pond A: init (seq 1) + four writes (seq 2..5) so A's frontier is high.
     let a_ctx = ctx_for(&a_pond, vec!["pond", "init"]);
-    init_command(&a_ctx).await.expect("init A");
+    init_command(&a_ctx, "test-host").await.expect("init A");
     for i in 0..4 {
         write_small_file(
             &a_ctx,
@@ -1443,7 +1443,7 @@ async fn cross_pond_pull_does_not_inflate_local_seq() {
 
     // 3) Pond B: init -> local seq 1.
     let b_ctx = ctx_for(&b_pond, vec!["pond", "init"]);
-    init_command(&b_ctx).await.expect("init B");
+    init_command(&b_ctx, "test-host").await.expect("init B");
     let b_seq_before = {
         let mut ship = b_ctx.open_pond().await.expect("open B");
         ship.as_pond_mut().expect("pond steward").last_write_seq()
@@ -1526,7 +1526,7 @@ async fn foreign_mount_writes_are_refused() {
 
     // Set up A with a small file and push to remote.
     let a_ctx = ctx_for(&a_pond, vec!["pond", "init"]);
-    init_command(&a_ctx).await.expect("init A");
+    init_command(&a_ctx, "test-host").await.expect("init A");
     write_small_file(&a_ctx, "/data.txt", b"upstream", vec!["copy", "data.txt"])
         .await
         .expect("write data.txt on A");
@@ -1558,7 +1558,7 @@ async fn foreign_mount_writes_are_refused() {
 
     // B pulls A as a cross-pond import.
     let b_ctx = ctx_for(&b_pond, vec!["pond", "init"]);
-    init_command(&b_ctx).await.expect("init B");
+    init_command(&b_ctx, "test-host").await.expect("init B");
     add_remote_command(
         &b_ctx,
         "upstream",
@@ -1660,7 +1660,7 @@ async fn foreign_post_commit_factories_skipped_in_auto_exec() {
     //    /system/run/ directory has a real dynamic-node entry that
     //    cross-pond import will replicate to B.
     let a_ctx = ctx_for(&a_pond, vec!["pond", "init"]);
-    init_command(&a_ctx).await.expect("init A");
+    init_command(&a_ctx, "test-host").await.expect("init A");
     let a_pond_id = {
         let ship = a_ctx.open_pond().await.expect("open A");
         ship.control_table().pond_id_uuid()
@@ -1708,7 +1708,7 @@ async fn foreign_post_commit_factories_skipped_in_auto_exec() {
 
     // 2) Pond B: init.
     let b_ctx = ctx_for(&b_pond, vec!["pond", "init"]);
-    init_command(&b_ctx).await.expect("init B");
+    init_command(&b_ctx, "test-host").await.expect("init B");
 
     // 3) B cross-pond-imports A at /imports/upstream.
     add_remote_command(
@@ -1797,7 +1797,7 @@ async fn pond_remote_remove_detach_preserves_mount_entry() {
 
     // Set up A with a file, push to remote.
     let a_ctx = ctx_for(&a_pond, vec!["pond", "init"]);
-    init_command(&a_ctx).await.expect("init A");
+    init_command(&a_ctx, "test-host").await.expect("init A");
     write_small_file(&a_ctx, "/blob.txt", b"keep me", vec!["copy", "blob.txt"])
         .await
         .expect("write blob.txt on A");
@@ -1829,7 +1829,7 @@ async fn pond_remote_remove_detach_preserves_mount_entry() {
 
     // B cross-pond-imports A and pulls.
     let b_ctx = ctx_for(&b_pond, vec!["pond", "init"]);
-    init_command(&b_ctx).await.expect("init B");
+    init_command(&b_ctx, "test-host").await.expect("init B");
     add_remote_command(
         &b_ctx,
         "upstream",
@@ -1911,7 +1911,7 @@ async fn pond_remote_remove_purge_drops_mount_entry() {
     let remote_url = format!("file://{}", remote_path.display());
 
     let a_ctx = ctx_for(&a_pond, vec!["pond", "init"]);
-    init_command(&a_ctx).await.expect("init A");
+    init_command(&a_ctx, "test-host").await.expect("init A");
     write_small_file(&a_ctx, "/blob.txt", b"keep me", vec!["copy", "blob.txt"])
         .await
         .expect("write blob.txt on A");
@@ -1942,7 +1942,7 @@ async fn pond_remote_remove_purge_drops_mount_entry() {
         .expect("push from A");
 
     let b_ctx = ctx_for(&b_pond, vec!["pond", "init"]);
-    init_command(&b_ctx).await.expect("init B");
+    init_command(&b_ctx, "test-host").await.expect("init B");
     add_remote_command(
         &b_ctx,
         "upstream",
@@ -2015,7 +2015,7 @@ async fn pond_backup_remove_purge_is_no_op_for_mount() {
     let remote_url = format!("file://{}", remote_path.display());
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
     let pond_id = {
         let ship = ctx.open_pond().await.expect("open");
         ship.control_table().pond_id_uuid()
@@ -2087,7 +2087,7 @@ async fn pond_remote_add_refuses_duplicate_mount_path() {
         .expect("create remote b");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     add_remote_command(
         &ctx,
@@ -2150,7 +2150,7 @@ async fn pond_remote_add_refuses_duplicate_mount_path_trailing_slash() {
         .expect("create remote b");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     add_remote_command(
         &ctx,
@@ -2205,7 +2205,7 @@ async fn pond_remote_add_refuses_duplicate_foreign_store_id() {
         .expect("create remote");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     add_remote_command(
         &ctx,
@@ -2261,7 +2261,7 @@ async fn pond_remote_add_overwrite_same_name_same_path_succeeds() {
         .expect("create remote");
 
     let ctx = ctx_for(&pond_path, vec!["pond", "init"]);
-    init_command(&ctx).await.expect("init");
+    init_command(&ctx, "test-host").await.expect("init");
 
     add_remote_command(
         &ctx,
@@ -2339,7 +2339,7 @@ async fn cross_pond_3deep_does_not_re_replicate_foreign_mount() {
 
     // --- Pond A: init + write + push to A's bucket. -----------------
     let a_ctx = ctx_for(&a_pond, vec!["pond", "init"]);
-    init_command(&a_ctx).await.expect("init A");
+    init_command(&a_ctx, "test-host").await.expect("init A");
     write_small_file(&a_ctx, "/a.txt", b"from pond A", vec!["copy", "a.txt"])
         .await
         .expect("write a.txt on A");
@@ -2362,7 +2362,7 @@ async fn cross_pond_3deep_does_not_re_replicate_foreign_mount() {
 
     // --- Pond B: init + mount A + pull + own write + push to B. -----
     let b_ctx = ctx_for(&b_pond, vec!["pond", "init"]);
-    init_command(&b_ctx).await.expect("init B");
+    init_command(&b_ctx, "test-host").await.expect("init B");
     add_remote_command(
         &b_ctx,
         "upstreamA",
@@ -2410,7 +2410,7 @@ async fn cross_pond_3deep_does_not_re_replicate_foreign_mount() {
 
     // --- Pond C: init + mount B + pull. ------------------------------
     let c_ctx = ctx_for(&c_pond, vec!["pond", "init"]);
-    init_command(&c_ctx).await.expect("init C");
+    init_command(&c_ctx, "test-host").await.expect("init C");
     let c_pond_id = {
         let ship = c_ctx.open_pond().await.expect("open C");
         ship.control_table().pond_id_uuid()

--- a/crates/steward/src/control_table.rs
+++ b/crates/steward/src/control_table.rs
@@ -51,7 +51,7 @@ const BOOTSTRAP_POND_ID: StdUuid = StdUuid::nil();
 
 const KEY_STORE_ID: &str = "store_id";
 const KEY_BIRTH_TIMESTAMP: &str = "birth_timestamp";
-const KEY_BIRTH_HOSTNAME: &str = "birth_hostname";
+const KEY_BIRTHPLACE: &str = "birthplace";
 const KEY_BIRTH_USERNAME: &str = "birth_username";
 
 const FACTORY_MODE_PREFIX: &str = "factory_mode:";
@@ -869,7 +869,7 @@ async fn seed_pond_metadata(
         .await
         .map_err(map_err)?;
     inner
-        .config_set(BOOTSTRAP_POND_ID, KEY_BIRTH_HOSTNAME, &m.birth_hostname)
+        .config_set(BOOTSTRAP_POND_ID, KEY_BIRTHPLACE, &m.birthplace)
         .await
         .map_err(map_err)?;
     inner
@@ -900,10 +900,7 @@ async fn load_pond_metadata(inner: &InnerControlTable) -> Result<PondMetadata, S
         .get(KEY_BIRTH_TIMESTAMP)
         .and_then(|s| s.parse::<i64>().ok())
         .unwrap_or(0);
-    let birth_hostname = bootstrap
-        .get(KEY_BIRTH_HOSTNAME)
-        .cloned()
-        .unwrap_or_else(|| "unknown".to_string());
+    let birthplace = bootstrap.get(KEY_BIRTHPLACE).cloned().unwrap_or_default();
     let birth_username = bootstrap
         .get(KEY_BIRTH_USERNAME)
         .cloned()
@@ -911,7 +908,7 @@ async fn load_pond_metadata(inner: &InnerControlTable) -> Result<PondMetadata, S
     Ok(PondMetadata {
         pond_id,
         birth_timestamp,
-        birth_hostname,
+        birthplace,
         birth_username,
     })
 }
@@ -946,7 +943,12 @@ pub fn pond_metadata_banner(data: &PondMetadata) {
         format!("Created {}", created_str),
     ];
 
-    let right = vec![data.birth_username.clone(), data.birth_hostname.clone()];
+    let birthplace = if data.birthplace.is_empty() {
+        "(unspecified)".to_string()
+    } else {
+        data.birthplace.clone()
+    };
+    let right = vec![data.birth_username.clone(), birthplace];
 
     println!(
         "{}",

--- a/crates/steward/src/dispatch.rs
+++ b/crates/steward/src/dispatch.rs
@@ -42,8 +42,13 @@ impl Steward {
     // -- Pond-specific constructors (wrap Ship) --
 
     /// Initialize a completely new pond.
-    pub async fn create_pond<P: AsRef<Path>>(pond_path: P) -> Result<Self, StewardError> {
-        Ok(Steward::Pond(Box::new(Ship::create_pond(pond_path).await?)))
+    pub async fn create_pond<P: AsRef<Path>>(
+        pond_path: P,
+        birthplace: impl Into<String>,
+    ) -> Result<Self, StewardError> {
+        Ok(Steward::Pond(Box::new(
+            Ship::create_pond(pond_path, birthplace).await?,
+        )))
     }
 
     /// Open an existing pond.

--- a/crates/steward/src/guard.rs
+++ b/crates/steward/src/guard.rs
@@ -192,7 +192,7 @@ impl<'a> StewardTransactionGuard<'a> {
     /// Initialize the root directory in the oplog.
     ///
     /// This is used during pond creation / restoration to set up the
-    /// filesystem root. Most callers should use `Ship::create_pond()` instead.
+    /// filesystem root. Most callers should use `Ship::create_pond("test-host")` instead.
     pub async fn initialize_root_directory(&self) -> Result<(), tlogfs::TLogFSError> {
         self.state()?.initialize_root_directory().await
     }

--- a/crates/steward/src/rebuild.rs
+++ b/crates/steward/src/rebuild.rs
@@ -127,7 +127,7 @@ pub async fn rebuild_control_table(
     let metadata = PondMetadata {
         pond_id: pond_id_uuid7,
         birth_timestamp,
-        birth_hostname: "unknown".to_string(),
+        birthplace: String::new(),
         birth_username: "unknown".to_string(),
     };
 

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -67,8 +67,14 @@ impl std::fmt::Display for CollapseReport {
 impl Ship {
     /// Initialize a completely new pond with proper transaction #1.
     ///
+    /// `birthplace` is a user-asserted, immutable label for where the pond
+    /// was created (recorded in the pond's identity metadata).
+    ///
     /// Use `open_pond()` to work with ponds that already exist.
-    pub async fn create_pond<P: AsRef<Path>>(pond_path: P) -> Result<Self, StewardError> {
+    pub async fn create_pond<P: AsRef<Path>>(
+        pond_path: P,
+        birthplace: impl Into<String>,
+    ) -> Result<Self, StewardError> {
         let meta = PondUserMetadata::new(vec!["pond".to_string(), "init".to_string()]);
 
         // Create infrastructure (includes root directory initialization with txn_seq=1)
@@ -78,6 +84,7 @@ impl Ship {
             true,
             Some(meta.clone()),
             None, // No preserved metadata for fresh pond
+            Some(birthplace.into()),
         )
         .await?;
 
@@ -146,13 +153,13 @@ impl Ship {
         // Report pond identity (already set by create_infrastructure)
         let metadata = ship.control_table.pond_metadata().clone();
         info!(
-            "Pond created with ID: {} at {} by {}@{}",
+            "Pond created with ID: {} at {} by {} (birthplace: {})",
             metadata.pond_id,
             chrono::DateTime::from_timestamp_micros(metadata.birth_timestamp)
                 .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
                 .unwrap_or_else(|| "unknown".to_string()),
             metadata.birth_username,
-            metadata.birth_hostname
+            metadata.birthplace
         );
 
         // Set default factory modes for primary pond
@@ -168,11 +175,11 @@ impl Ship {
 
     /// Create pond infrastructure for bundle restoration (replication/backup restore).
     ///
-    /// Unlike `create_pond()`, this creates the pond structure WITHOUT recording
+    /// Unlike `create_pond("test-host")`, this creates the pond structure WITHOUT recording
     /// the initial transaction #1. The first bundle will create txn_seq=1 with
     /// the original command metadata from the source pond.
     ///
-    /// Use this ONLY when restoring from bundles. Use `create_pond()` for normal initialization.
+    /// Use this ONLY when restoring from bundles. Use `create_pond("test-host")` for normal initialization.
     ///
     /// # Arguments
     /// * `pond_path` - Path to the pond directory
@@ -249,7 +256,7 @@ impl Ship {
 
     /// Open an existing, pre-initialized pond.
     pub async fn open_pond<P: AsRef<Path>>(pond_path: P) -> Result<Self, StewardError> {
-        Self::create_infrastructure(pond_path, false, None, None).await
+        Self::create_infrastructure(pond_path, false, None, None, None).await
     }
 
     /// Internal method to create just the filesystem infrastructure.
@@ -271,6 +278,7 @@ impl Ship {
         create_new: bool,
         txn_metadata: Option<PondUserMetadata>,
         preserve_metadata: Option<PondMetadata>,
+        birthplace: Option<String>,
     ) -> Result<Self, StewardError> {
         let data_path = get_data_path(pond_path.as_ref());
         let control_path = get_control_path(pond_path.as_ref());
@@ -297,7 +305,10 @@ impl Ship {
             // the control table (cache) and, implicitly via the upcoming root
             // initialization, the data table (canonical).
             assert!(preserve_metadata.is_none());
-            let metadata = PondMetadata::default();
+            let metadata = PondMetadata {
+                birthplace: birthplace.unwrap_or_default(),
+                ..PondMetadata::default()
+            };
             let pond_id = metadata.pond_id.to_string();
             debug!(
                 "Creating control table with pond identity: {}",
@@ -326,7 +337,7 @@ impl Ship {
                         );
                         // Auto-heal: rewrite the control cache to match the
                         // canonical data-table value.  Birth metadata (timestamp,
-                        // hostname, username) is preserved from the existing
+                        // birthplace, username) is preserved from the existing
                         // control cache - those fields live only there.
                         let healed = PondMetadata {
                             pond_id: from_data.parse::<uuid7::Uuid>().map_err(|e| {
@@ -336,7 +347,7 @@ impl Ship {
                                 ))
                             })?,
                             birth_timestamp: ct.pond_metadata().birth_timestamp,
-                            birth_hostname: ct.pond_metadata().birth_hostname.clone(),
+                            birthplace: ct.pond_metadata().birthplace.clone(),
                             birth_username: ct.pond_metadata().birth_username.clone(),
                         };
                         ct.set_pond_metadata(&healed).await?;
@@ -1127,6 +1138,7 @@ impl Ship {
             true,
             Some(txn_meta.clone()),
             None, // No preserved metadata for fresh pond
+            None, // birthplace unset for this legacy constructor
         )
         .await?;
 
@@ -1255,7 +1267,7 @@ mod tests {
         let pond_path = temp_dir.path().join("test_pond");
 
         // Use production initialization code (same as pond init)
-        let ship = Ship::create_pond(&pond_path)
+        let ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to initialize pond");
 
@@ -1284,7 +1296,7 @@ mod tests {
         let pond_path = temp_dir.path().join("pond");
 
         // Create a fresh pond; both tables will agree on the same pond_id.
-        let ship = Ship::create_pond(&pond_path)
+        let ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("create_pond failed");
         let canonical_id = ship.control_table.pond_metadata().pond_id.to_string();
@@ -1340,7 +1352,7 @@ mod tests {
         let pond_path = temp_dir.path().join("test_pond");
 
         // Use the same constructor as production (pond init)
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to initialize pond");
 
@@ -1368,7 +1380,7 @@ mod tests {
         let pond_path = temp_dir.path().join("test_pond");
 
         // Use production initialization (pond init) - this creates version 0
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to initialize pond");
 
@@ -1419,7 +1431,7 @@ mod tests {
 
         // FIRST: Create a properly initialized pond and simulate a crash scenario
         {
-            let mut ship = Ship::create_pond(&pond_path)
+            let mut ship = Ship::create_pond(&pond_path, "test-host")
                 .await
                 .expect("Failed to create ship");
 
@@ -1530,7 +1542,7 @@ mod tests {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let pond_path = temp_dir.path().join("test_pond");
 
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create ship");
 
@@ -1575,7 +1587,7 @@ mod tests {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let pond_path = temp_dir.path().join("test_pond");
 
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create ship");
 
@@ -1592,7 +1604,7 @@ mod tests {
 
         // Step 1: Initialize pond using production code (pond init)
         {
-            let _ship = Ship::create_pond(&pond_path)
+            let _ship = Ship::create_pond(&pond_path, "test-host")
                 .await
                 .expect("Failed to initialize pond");
         }
@@ -1739,7 +1751,7 @@ mod tests {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let pond_path = temp_dir.path().join("test_pond");
 
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create ship");
 
@@ -1786,7 +1798,7 @@ mod tests {
         let pond_path = temp_dir.path().join("test_pond_new_api");
 
         // Initialize a new pond
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create pond");
 
@@ -1824,7 +1836,7 @@ mod tests {
         let pond_path = temp_dir.path().join("test_pond_sequences");
 
         // Initialize pond - this creates root directory with txn_seq=1
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create pond");
 
@@ -1891,7 +1903,7 @@ mod tests {
         let pond_path = temp_dir.path().join("test_root_version");
 
         // Initialize pond
-        let ship = Ship::create_pond(&pond_path)
+        let ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create pond");
 
@@ -1932,7 +1944,7 @@ mod tests {
         let pond_path = temp_dir.path().join("test_dir_tree");
 
         // Initialize pond
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create pond");
 
@@ -2035,7 +2047,7 @@ mod tests {
 
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let pond_path = temp_dir.path().join("test_pond_collapse");
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create pond");
 
@@ -2135,7 +2147,7 @@ mod tests {
 
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let pond_path = temp_dir.path().join("test_pond_multi_collapse");
-        let mut ship = Ship::create_pond(&pond_path)
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .expect("Failed to create pond");
 
@@ -2194,7 +2206,9 @@ mod tests {
     async fn test_control_log_cleanup_bounds_delta_log() {
         let temp_dir = tempdir().expect("temp dir");
         let pond_path = temp_dir.path().join("test_pond");
-        let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
+            .await
+            .expect("create pond");
 
         // Drive enough write transactions to accumulate control commit JSONs
         // well past a checkpoint boundary.

--- a/crates/steward/tests/debug_transaction_versions.rs
+++ b/crates/steward/tests/debug_transaction_versions.rs
@@ -16,7 +16,7 @@ async fn test_debug_transaction_versions() -> Result<()> {
     debug!("=== Testing Delta Lake version progression ===");
 
     // Initialize pond
-    let mut ship = Ship::create_pond(&pond_path)
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
         .await
         .map_err(|e| anyhow::anyhow!("Failed to initialize pond: {}", e))?;
 
@@ -77,7 +77,7 @@ async fn test_delta_table_version_inspection() -> Result<()> {
     debug!("=== Inspecting Delta Lake table versions directly ===");
 
     // Initialize pond
-    let _ship = Ship::create_pond(&pond_path)
+    let _ship = Ship::create_pond(&pond_path, "test-host")
         .await
         .map_err(|e| anyhow::anyhow!("Failed to initialize pond: {}", e))?;
 

--- a/crates/steward/tests/rebuild_control_test.rs
+++ b/crates/steward/tests/rebuild_control_test.rs
@@ -42,7 +42,7 @@ async fn rebuild_control_recovers_identity_and_history() -> Result<()> {
 
     // 1) Build a pond with several write transactions.
     let (orig_pond_id, orig_last_seq) = {
-        let mut ship = Ship::create_pond(&pond_path).await?;
+        let mut ship = Ship::create_pond(&pond_path, "test-host").await?;
         write_file(&mut ship, "/a.txt", b"alpha", vec!["copy", "a.txt"]).await?;
         write_file(&mut ship, "/b.txt", b"beta", vec!["copy", "b.txt"]).await?;
         let pond_id = ship.control_table().pond_id_uuid();
@@ -114,7 +114,7 @@ async fn rebuild_control_requires_force_when_control_exists() -> Result<()> {
     let pond_path = temp.path().join("pond");
 
     {
-        let mut ship = Ship::create_pond(&pond_path).await?;
+        let mut ship = Ship::create_pond(&pond_path, "test-host").await?;
         write_file(&mut ship, "/x.txt", b"x", vec!["copy", "x.txt"]).await?;
     }
 

--- a/crates/steward/tests/remote_adapter_test.rs
+++ b/crates/steward/tests/remote_adapter_test.rs
@@ -43,7 +43,9 @@ async fn ship_remote_push_pull_roundtrip() {
     let remote_path = tmp.path().join("remote");
 
     // 1. Source pond + one write transaction.
-    let mut src = Ship::create_pond(&src_path).await.expect("create src");
+    let mut src = Ship::create_pond(&src_path, "test-host")
+        .await
+        .expect("create src");
     let src_pond_id = src.control_table().pond_id_uuid();
     let src_pond_meta = src.control_table().pond_metadata().clone();
 
@@ -142,7 +144,9 @@ async fn ship_remote_push_pull_two_transactions() {
     let dst_path = tmp.path().join("dst");
     let remote_path = tmp.path().join("remote");
 
-    let mut src = Ship::create_pond(&src_path).await.expect("create src");
+    let mut src = Ship::create_pond(&src_path, "test-host")
+        .await
+        .expect("create src");
     let src_pond_id = src.control_table().pond_id_uuid();
     let src_pond_meta = src.control_table().pond_metadata().clone();
 
@@ -234,7 +238,9 @@ async fn ship_remote_pull_empty_remote_is_noop() {
     let remote_path = tmp.path().join("remote");
 
     // Create dst pond first so we have a pond_id to reuse for the remote.
-    let mut dst = Ship::create_pond(&dst_path).await.expect("create dst");
+    let mut dst = Ship::create_pond(&dst_path, "test-host")
+        .await
+        .expect("create dst");
     let dst_pond_id = dst.control_table().pond_id_uuid();
 
     let remote = Remote::create(&remote_path, dst_pond_id)
@@ -266,7 +272,9 @@ async fn ship_remote_actions_at_version_filters_by_pond_id() {
     let pond_path = tmp.path().join("pond");
 
     // Create a pond and commit one write so a Delta commit exists.
-    let mut ship = Ship::create_pond(&pond_path).await.expect("create");
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
+        .await
+        .expect("create");
     let local_pond_id = ship.control_table().pond_id_uuid();
     ship.write_transaction(&meta("seed_write"), async |fs| {
         let root = fs.root().await?;
@@ -377,7 +385,9 @@ async fn ship_remote_bootstrap_consumer_no_compact() {
     let remote_path = tmp.path().join("remote");
 
     // 1) Source pond + one write.
-    let mut src = Ship::create_pond(&src_path).await.expect("create src");
+    let mut src = Ship::create_pond(&src_path, "test-host")
+        .await
+        .expect("create src");
     let src_pond_id = src.control_table().pond_id_uuid();
     src.write_transaction(&meta("seed"), async |fs| {
         let root = fs.root().await?;
@@ -505,7 +515,9 @@ async fn ship_compute_live_checksums_is_deterministic() {
     let tmp = tempdir().expect("tempdir");
     let pond_path = tmp.path().join("pond");
 
-    let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
+        .await
+        .expect("create pond");
     let pond_id = ship.control_table().pond_id_uuid();
 
     ship.write_transaction(&meta("seed"), async |fs| {
@@ -560,7 +572,9 @@ async fn ship_compute_live_checksums_changes_with_content() {
     let tmp = tempdir().expect("tempdir");
     let pond_path = tmp.path().join("pond");
 
-    let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
+        .await
+        .expect("create pond");
     let pond_id = ship.control_table().pond_id_uuid();
 
     // Initial write.
@@ -619,7 +633,9 @@ async fn ship_compute_live_checksums_unknown_pond_id_is_empty() {
     let tmp = tempdir().expect("tempdir");
     let pond_path = tmp.path().join("pond");
 
-    let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
+        .await
+        .expect("create pond");
 
     ship.write_transaction(&meta("seed"), async |fs| {
         let root = fs.root().await?;
@@ -668,7 +684,9 @@ async fn ship_remote_push_replicates_pond_init() {
     let pond_path = tmp.path().join("pond");
     let remote_path = tmp.path().join("remote");
 
-    let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
+        .await
+        .expect("create pond");
     let pond_id = ship.control_table().pond_id_uuid();
 
     // No data writes -- only the pond_init txn (txn_seq=1) exists, whose
@@ -741,7 +759,9 @@ async fn push_pending_to_remote_errors_on_corrupt_watermark() {
     let pond_path = tmp.path().join("pond");
     let remote_path = tmp.path().join("remote");
 
-    let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
+        .await
+        .expect("create pond");
     let pond_id = ship.control_table().pond_id_uuid();
 
     let remote = Remote::create(&remote_path, pond_id)
@@ -801,7 +821,9 @@ async fn ship_remote_native_write_then_verify_passes() {
     let remote_path = tmp.path().join("remote");
 
     // 1. Source pond with a real write transaction.
-    let mut src = Ship::create_pond(&src_path).await.expect("create src");
+    let mut src = Ship::create_pond(&src_path, "test-host")
+        .await
+        .expect("create src");
     let src_pond_id = src.control_table().pond_id_uuid();
 
     src.write_transaction(&meta("write_for_verify"), async |fs| {
@@ -872,7 +894,9 @@ async fn ship_compact_records_pushable_compact_transaction() {
     let tmp = tempdir().expect("tempdir");
     let pond_path = tmp.path().join("pond");
 
-    let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
+        .await
+        .expect("create pond");
     let pond_id = ship.control_table().pond_id_uuid();
 
     // Several writes -> several small parquet files in the root partition.
@@ -1001,7 +1025,9 @@ async fn ship_compact_bundle_drives_restart_from_compact() {
     let remote_path = tmp.path().join("remote");
 
     // 1. Source pond with several writes, all under the root partition.
-    let mut src = Ship::create_pond(&src_path).await.expect("create src");
+    let mut src = Ship::create_pond(&src_path, "test-host")
+        .await
+        .expect("create src");
     let src_pond_id = src.control_table().pond_id_uuid();
     let src_pond_meta = src.control_table().pond_metadata().clone();
 
@@ -1087,7 +1113,9 @@ async fn ship_compact_survives_reopen() {
     let pond_path = tmp.path().join("pond");
 
     let compact_seq = {
-        let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
+            .await
+            .expect("create pond");
         for i in 0..4 {
             let _ = write_one(
                 &mut ship,
@@ -1140,7 +1168,9 @@ async fn ship_maintain_compact_survives_reopen() {
     let pond_path = tmp.path().join("pond");
 
     let expected_seq = {
-        let mut ship = Ship::create_pond(&pond_path).await.expect("create pond");
+        let mut ship = Ship::create_pond(&pond_path, "test-host")
+            .await
+            .expect("create pond");
         for i in 0..4 {
             let _ = write_one(
                 &mut ship,
@@ -1181,7 +1211,9 @@ async fn ship_replica_verify_matches_after_bootstrap() {
     let remote_path = tmp.path().join("remote");
 
     // Producer with a few writes.
-    let mut src = Ship::create_pond(&src_path).await.expect("create src");
+    let mut src = Ship::create_pond(&src_path, "test-host")
+        .await
+        .expect("create src");
     let pond_id = src.control_table().pond_id_uuid();
     for i in 0..3 {
         let _ = write_one(

--- a/crates/steward/tests/ship_lifecycle_test.rs
+++ b/crates/steward/tests/ship_lifecycle_test.rs
@@ -15,7 +15,7 @@ async fn test_ship_drop_and_reopen() -> Result<()> {
 
     // Initialize pond with first Ship instance
     {
-        let _ship = Ship::create_pond(&pond_path)
+        let _ship = Ship::create_pond(&pond_path, "test-host")
             .await
             .map_err(|e| anyhow::anyhow!("Failed to initialize pond: {}", e))?;
 
@@ -48,7 +48,7 @@ async fn test_ship_multiple_transactions_same_instance() -> Result<()> {
     let pond_path = temp_dir.path().join("same_instance_test_pond");
 
     // Initialize pond and keep the Ship instance
-    let mut ship = Ship::create_pond(&pond_path)
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
         .await
         .map_err(|e| anyhow::anyhow!("Failed to initialize pond: {}", e))?;
 

--- a/crates/steward/tests/test_post_commit_factory.rs
+++ b/crates/steward/tests/test_post_commit_factory.rs
@@ -15,7 +15,7 @@ async fn test_post_commit_factory_execution() -> Result<()> {
     let pond_path = temp_dir.path().join("post_commit_test_pond");
 
     // Initialize pond
-    let mut ship = Ship::create_pond(&pond_path)
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
         .await
         .map_err(|e| anyhow::anyhow!("Failed to initialize pond: {}", e))?;
 
@@ -204,7 +204,7 @@ async fn test_post_commit_not_triggered_by_read_transaction() -> Result<()> {
     let pond_path = temp_dir.path().join("post_commit_read_test_pond");
 
     // Initialize pond
-    let mut ship = Ship::create_pond(&pond_path)
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
         .await
         .map_err(|e| anyhow::anyhow!("Failed to initialize pond: {}", e))?;
 
@@ -276,7 +276,7 @@ async fn test_post_commit_multiple_factories_ordered() -> Result<()> {
     let temp_dir = tempdir()?;
     let pond_path = temp_dir.path().join("post_commit_ordered_test_pond");
 
-    let mut ship = Ship::create_pond(&pond_path).await?;
+    let mut ship = Ship::create_pond(&pond_path, "test-host").await?;
 
     // Set factory mode early to prevent error logs
     ship.control_table_mut()

--- a/crates/steward/tests/write_lock_test.rs
+++ b/crates/steward/tests/write_lock_test.rs
@@ -48,7 +48,7 @@ async fn write_lock_blocks_concurrent_writer() -> Result<()> {
     let pond_path = temp.path().join("pond");
 
     // Create pond + first Ship.
-    let mut ship_a = Ship::create_pond(&pond_path)
+    let mut ship_a = Ship::create_pond(&pond_path, "test-host")
         .await
         .map_err(|e| anyhow::anyhow!("create_pond: {e}"))?;
 
@@ -93,7 +93,7 @@ async fn read_transaction_emits_no_control_records() -> Result<()> {
     let pond_path = temp.path().join("pond");
     let control_path = steward::get_control_path(&pond_path);
 
-    let mut ship = Ship::create_pond(&pond_path)
+    let mut ship = Ship::create_pond(&pond_path, "test-host")
         .await
         .map_err(|e| anyhow::anyhow!("create_pond: {e}"))?;
 

--- a/crates/tinyfs/src/context.rs
+++ b/crates/tinyfs/src/context.rs
@@ -257,8 +257,10 @@ pub struct PondMetadata {
     pub pond_id: uuid7::Uuid,
     /// Timestamp when this pond was originally created (microseconds since epoch)
     pub birth_timestamp: i64,
-    /// Hostname where the pond was originally created
-    pub birth_hostname: String,
+    /// Birthplace of the pond: a user-asserted, immutable label for where
+    /// this pond was originally created (for example a hostname, site, or
+    /// deployment name).  Set once at `pond init` and preserved across replicas.
+    pub birthplace: String,
     /// Username who originally created the pond
     pub birth_username: String,
 }
@@ -269,8 +271,9 @@ impl Default for PondMetadata {
         let pond_id = uuid7::uuid7();
         let birth_timestamp = chrono::Utc::now().timestamp_micros();
 
-        // Note: std::net::hostname() is unstable, using placeholder
-        let birth_hostname = "unknown".into();
+        // Birthplace is user-asserted at `pond init`; the default is empty
+        // and is overridden by the value the operator provides.
+        let birthplace = String::new();
 
         let birth_username = std::env::var("USER")
             .or_else(|_| std::env::var("USERNAME"))
@@ -279,7 +282,7 @@ impl Default for PondMetadata {
         Self {
             pond_id,
             birth_timestamp,
-            birth_hostname,
+            birthplace,
             birth_username,
         }
     }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,7 +6,7 @@
 
 | Command | Purpose | Example |
 |---------|---------|---------|
-| `pond init` | Initialize a new pond | `pond init` |
+| `pond init` | Initialize a new pond | `pond init --birthplace water-prod` |
 | `pond mkdir` | Create directories | `pond mkdir /data` |
 | `pond copy` | Copy files into pond | `pond copy host:///tmp/data.csv /data/` |
 | `pond list` | List files (glob patterns) | `pond list '**/*'` |
@@ -61,10 +61,15 @@ Initialize a new pond at the path specified by `$POND`.
 
 ```bash
 export POND=/data/mypond
-pond init
+pond init --birthplace water-prod
 ```
 
 Creates the pond directory structure with Delta Lake metadata.
+
+The required `--birthplace` is an immutable label for where the pond is
+created (for example a hostname, site, or deployment name).  It is
+recorded permanently in the pond's identity metadata and shown by
+`pond status`, `pond log`, and `pond config`.
 
 ---
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -268,6 +268,12 @@ $ pond log --txn-seq 42    # full lifecycle detail for one transaction
 $ pond log --incomplete    # transactions that need `pond recover`
 ```
 
+`pond log` reconstructs, for each write transaction, the originating CLI
+command (from the `pond_txn` metadata in the data Delta commit), the
+timing and status (from the control table), and a one-line change summary
+(files/directories/partitions touched, from the data table).  Pure reads
+are omitted; crashed writes appear under `pond log --incomplete`.
+
 ### Configuration
 
 ```

--- a/testsuite/tests/001-basic-init.sh
+++ b/testsuite/tests/001-basic-init.sh
@@ -8,7 +8,7 @@ set -e
 echo "=== Experiment: Basic Init ==="
 
 # Initialize pond
-pond init
+pond init --birthplace test-host
 echo "✓ pond init succeeded"
 
 # List root directory

--- a/testsuite/tests/002-mkdir-basic.sh
+++ b/testsuite/tests/002-mkdir-basic.sh
@@ -7,7 +7,7 @@ set -e
 
 echo "=== Experiment: Mkdir Basic ==="
 
-pond init
+pond init --birthplace test-host
 echo "✓ pond init succeeded"
 
 # Create single directory

--- a/testsuite/tests/003-list-patterns.sh
+++ b/testsuite/tests/003-list-patterns.sh
@@ -8,7 +8,7 @@ set -e
 echo "=== Experiment: List Pattern Variations ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 echo "✓ pond init succeeded"
 echo ""
 

--- a/testsuite/tests/010-copy-csv.sh
+++ b/testsuite/tests/010-copy-csv.sh
@@ -7,7 +7,7 @@ set -e
 
 echo "=== Experiment: Copy CSV ==="
 
-pond init
+pond init --birthplace test-host
 
 # Create test data
 cat > /tmp/data.csv << 'EOF'

--- a/testsuite/tests/020-cat-with-sql.sh
+++ b/testsuite/tests/020-cat-with-sql.sh
@@ -7,7 +7,7 @@ set -e
 
 echo "=== Experiment: Cat with SQL ==="
 
-pond init
+pond init --birthplace test-host
 
 # Create test data
 cat > /tmp/data.csv << 'EOF'

--- a/testsuite/tests/021-query-investigation.sh
+++ b/testsuite/tests/021-query-investigation.sh
@@ -8,7 +8,7 @@ set -e
 echo "=== Experiment: Query Flag Investigation ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 # Create test data with clear filter boundary
 cat > /tmp/data.csv << 'EOF'

--- a/testsuite/tests/022-verify-table-default.sh
+++ b/testsuite/tests/022-verify-table-default.sh
@@ -8,7 +8,7 @@ set -e
 echo "=== Experiment: Verify Table Default ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 # Create test data
 cat > /tmp/data.csv << 'EOF'

--- a/testsuite/tests/023-table-format-storage.sh
+++ b/testsuite/tests/023-table-format-storage.sh
@@ -8,7 +8,7 @@ set -e
 echo "=== Experiment: Table Format Storage ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/data.csv << 'EOF'
 timestamp,temperature

--- a/testsuite/tests/024-csv-url-scheme.sh
+++ b/testsuite/tests/024-csv-url-scheme.sh
@@ -8,7 +8,7 @@ set -e
 echo "=== Experiment: CSV URL Scheme ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/data.csv << 'EOF'
 timestamp,temperature,humidity

--- a/testsuite/tests/025-csv-workflow.sh
+++ b/testsuite/tests/025-csv-workflow.sh
@@ -10,7 +10,7 @@ set -e
 echo "=== Experiment: CSV Workflow ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/data.csv << 'EOF'
 timestamp,temperature,humidity

--- a/testsuite/tests/026-copy-overwrite-semantics.sh
+++ b/testsuite/tests/026-copy-overwrite-semantics.sh
@@ -10,7 +10,7 @@ source check.sh
 echo "=== Experiment: Copy Overwrite Semantics ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 pond mkdir -p /etc/site
 
 # --- Round 1: initial copy ---

--- a/testsuite/tests/027-data-node-entry-type-cast.sh
+++ b/testsuite/tests/027-data-node-entry-type-cast.sh
@@ -16,7 +16,7 @@ source check.sh
 
 echo "=== Experiment: data-file -> series/table entry-type cast ==="
 
-pond init
+pond init --birthplace test-host
 
 # ---- Setup: produce a real Parquet file (no external tooling) ----
 # A synthetic-timeseries node is queryable; copy it OUT to the host to obtain

--- a/testsuite/tests/030-logfile-ingest-basic.sh
+++ b/testsuite/tests/030-logfile-ingest-basic.sh
@@ -15,7 +15,7 @@ echo ""
 # Use a fixed pond location to preserve state between runs
 export POND=/pond
 
-pond init
+pond init --birthplace test-host
 
 #############################
 # SETUP HOST LOG FILES

--- a/testsuite/tests/031-logfile-ingest-persistence-bug.sh
+++ b/testsuite/tests/031-logfile-ingest-persistence-bug.sh
@@ -46,7 +46,7 @@ cat /tmp/ingest.yaml
 
 echo ""
 echo "=== Initializing pond ==="
-pond init
+pond init --birthplace test-host
 
 #############################
 # CREATE FACTORY NODE

--- a/testsuite/tests/032-logfile-ingest-large-file.sh
+++ b/testsuite/tests/032-logfile-ingest-large-file.sh
@@ -14,7 +14,7 @@ echo ""
 # Use a fixed pond location to preserve state between runs
 export POND=/pond
 
-pond init
+pond init --birthplace test-host
 
 #############################
 # SETUP - Create 100KB log file (above 64KB threshold)

--- a/testsuite/tests/033-syslog-ingest.sh
+++ b/testsuite/tests/033-syslog-ingest.sh
@@ -11,7 +11,7 @@ echo "=== Experiment: Syslog Ingest with logfile-ingest ==="
 echo ""
 
 export POND=/pond
-pond init
+pond init --birthplace test-host
 
 #############################
 # STEP 1: Configure rsyslog and logrotate

--- a/testsuite/tests/034-oteljson-url-scheme.sh
+++ b/testsuite/tests/034-oteljson-url-scheme.sh
@@ -10,7 +10,7 @@ set -e
 echo "=== Experiment: OtelJSON URL Scheme ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 #############################
 # CREATE SAMPLE OTELJSON DATA

--- a/testsuite/tests/035-septic-oteljson-exploration.sh
+++ b/testsuite/tests/035-septic-oteljson-exploration.sh
@@ -23,7 +23,7 @@ if [ ! -f "$SAMPLE" ]; then
 fi
 echo "Using sample: ${SAMPLE} ($(wc -l < "$SAMPLE") lines)"
 
-pond init
+pond init --birthplace test-host
 
 #############################
 # INGEST THE SAMPLE DATA

--- a/testsuite/tests/036-septic-temporal-reduce.sh
+++ b/testsuite/tests/036-septic-temporal-reduce.sh
@@ -20,7 +20,7 @@ if [ ! -f "$SAMPLE" ]; then
 fi
 echo "Using sample: ${SAMPLE} ($(wc -l < "$SAMPLE") lines, $(wc -c < "$SAMPLE") bytes)"
 
-pond init
+pond init --birthplace test-host
 
 #############################
 # STEP 1: INGEST RAW DATA

--- a/testsuite/tests/037-septic-sitegen-pipeline.sh
+++ b/testsuite/tests/037-septic-sitegen-pipeline.sh
@@ -31,7 +31,7 @@ INGESTED_PATH="/ingest/${INGESTED_NAME}"
 
 OUTDIR=/tmp/septic-site
 
-pond init
+pond init --birthplace test-host
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Step 1: Set up directory structure

--- a/testsuite/tests/039-oteljson-variable-schema-glob.sh
+++ b/testsuite/tests/039-oteljson-variable-schema-glob.sh
@@ -15,7 +15,7 @@ set -e
 echo "=== Experiment: OtelJSON Variable Schema Glob ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 #############################
 # CREATE SYNTHETIC OTELJSON FILES WITH EVOLVING SCHEMAS

--- a/testsuite/tests/040-multi-reduce-shared-source.sh
+++ b/testsuite/tests/040-multi-reduce-shared-source.sh
@@ -20,7 +20,7 @@ set -e
 echo "=== Experiment: Multi-Reduce Shared Source ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 #############################
 # CREATE SYNTHETIC OTELJSON FILES

--- a/testsuite/tests/041-weblog-format-provider.sh
+++ b/testsuite/tests/041-weblog-format-provider.sh
@@ -12,7 +12,7 @@ source check.sh
 echo "=== Experiment: Weblog Format Provider ==="
 
 export POND=/pond
-pond init
+pond init --birthplace test-host
 
 #############################
 # STEP 1: Create sample CLF access logs

--- a/testsuite/tests/042-apply-init.sh
+++ b/testsuite/tests/042-apply-init.sh
@@ -8,7 +8,7 @@ source check.sh
 
 echo "=== Experiment: pond apply -- init ==="
 
-pond init
+pond init --birthplace test-host
 
 # ==============================================================================
 # Step 1: Create config files with k8s-style format
@@ -90,11 +90,11 @@ echo "--- Step 4: Verify transaction log ---"
 LOG_OUT=$(pond log --limit 5)
 echo "$LOG_OUT"
 
-# Post-D2 the control table no longer stores `cli_args`, so `pond log` cannot
-# print the originating command name.  Assert instead that the first apply
-# produced a committed write transaction (the second apply is idempotent and
-# rolls back without committing).
+# `pond log` now reconstructs the originating CLI command from the data
+# Delta commit metadata (`pond_txn`), so the apply command appears in the
+# log.  Assert the write transaction committed and the command is shown.
 check 'echo "$LOG_OUT" | grep -q "(write)"' "transaction log contains a write transaction"
 check 'echo "$LOG_OUT" | grep -q "COMMITTED"' "transaction log contains a COMMITTED transaction"
+check 'echo "$LOG_OUT" | grep -q "Command  : pond apply"' "transaction log shows the apply command"
 
 check_finish

--- a/testsuite/tests/043-apply-update-validation.sh
+++ b/testsuite/tests/043-apply-update-validation.sh
@@ -9,7 +9,7 @@ source check.sh
 
 echo "=== Experiment: pond apply -- update and validation ==="
 
-pond init
+pond init --birthplace test-host
 
 # ==============================================================================
 # Step 1: Initial apply -- create a node

--- a/testsuite/tests/044-apply-copy-lifecycle.sh
+++ b/testsuite/tests/044-apply-copy-lifecycle.sh
@@ -9,7 +9,7 @@ source check.sh
 
 echo "=== Experiment: pond apply -- copy and lifecycle ==="
 
-pond init
+pond init --birthplace test-host
 
 # ==============================================================================
 # Step 1: Create host content to copy
@@ -130,11 +130,12 @@ echo "--- Step 5: Verify transaction log ---"
 
 LOG_OUT=$(pond log --limit 5)
 echo "$LOG_OUT"
-# Post-D2 the control table no longer stores `cli_args`, so `pond log` cannot
-# print the originating command name.  Assert instead that a committed write
-# transaction is present after running apply.
+# `pond log` now reconstructs the originating CLI command from the data
+# Delta commit metadata (`pond_txn`).  Assert a committed write transaction
+# is present and its command is shown.
 check 'echo "$LOG_OUT" | grep -q "(write)"' "write transaction in log"
 check 'echo "$LOG_OUT" | grep -q "COMMITTED"' "COMMITTED transaction in log"
+check 'echo "$LOG_OUT" | grep -q "Command  : pond apply"' "apply command shown in log"
 
 # ==============================================================================
 # Step 6: Copy with overwrite=false should fail if exists

--- a/testsuite/tests/045-temporal-reduce-partition-isolation.sh
+++ b/testsuite/tests/045-temporal-reduce-partition-isolation.sh
@@ -21,7 +21,7 @@ set -e
 
 echo "=== Experiment: temporal-reduce partition isolation ==="
 
-pond init
+pond init --birthplace test-host
 
 #############################
 # TWO SOURCE FILES, DISJOINT EXTRA COLUMNS, DISTINCT OUTPUT PARTITIONS

--- a/testsuite/tests/046-rollup-oteljson-schema-evolution.sh
+++ b/testsuite/tests/046-rollup-oteljson-schema-evolution.sh
@@ -29,7 +29,7 @@ source check.sh
 
 echo "=== Experiment: Rollup over oteljson schema evolution ==="
 
-pond init
+pond init --birthplace test-host
 
 # ---- Setup: two oteljson files with evolving schemas ----
 #

--- a/testsuite/tests/100-synthetic-timeseries-basic.sh
+++ b/testsuite/tests/100-synthetic-timeseries-basic.sh
@@ -6,7 +6,7 @@ set -e
 
 echo "=== Experiment: Synthetic Timeseries Factory ==="
 
-pond init
+pond init --birthplace test-host
 
 # --- Create the factory config inside the container --------------------------
 cat > /tmp/synth.yaml << 'EOF'

--- a/testsuite/tests/101-timeseries-join-synthetic.sh
+++ b/testsuite/tests/101-timeseries-join-synthetic.sh
@@ -7,7 +7,7 @@ set -e
 
 echo "=== Experiment: Timeseries Join with Synthetic Data ==="
 
-pond init
+pond init --birthplace test-host
 
 # --- Create the dynamic directory config inline ------------------------------
 # station_a: Jan 1–15  sine temperature (offset 20), sine pressure (offset 1013)

--- a/testsuite/tests/102-timeseries-pivot-synthetic.sh
+++ b/testsuite/tests/102-timeseries-pivot-synthetic.sh
@@ -7,7 +7,7 @@ set -e
 
 echo "=== Experiment: Timeseries Pivot with Synthetic Data ==="
 
-pond init
+pond init --birthplace test-host
 
 # --- Build the full pipeline in a single dynamic-dir --------------------------
 # Layer 1: two synthetic-timeseries (station_a, station_b)

--- a/testsuite/tests/103-temporal-reduce-synthetic.sh
+++ b/testsuite/tests/103-temporal-reduce-synthetic.sh
@@ -7,7 +7,7 @@ set -e
 
 echo "=== Experiment: Temporal Reduce with Synthetic Data ==="
 
-pond init
+pond init --birthplace test-host
 
 # --- Create the source synthetic-timeseries -----------------------------------
 # 24 hours of data at 1-minute intervals = 1441 rows (inclusive endpoints)

--- a/testsuite/tests/104-timeseries-join-empty-input.sh
+++ b/testsuite/tests/104-timeseries-join-empty-input.sh
@@ -9,7 +9,7 @@ set -e
 
 echo "=== Experiment: Timeseries Join with a Zero-Match Input ==="
 
-pond init
+pond init --birthplace test-host
 
 # --- Dynamic directory config ------------------------------------------------
 # station_a (scope StationA) and station_b (scope StationB) both exist.

--- a/testsuite/tests/201-sitegen-markdown-maudit.sh
+++ b/testsuite/tests/201-sitegen-markdown-maudit.sh
@@ -14,7 +14,7 @@ source check.sh
 
 echo "=== Experiment: Sitegen Factory — Markdown + Maud ==="
 
-pond init
+pond init --birthplace test-host
 
 OUTDIR=/tmp/sitegen-dist
 

--- a/testsuite/tests/203-temporal-reduce-isolation.sh
+++ b/testsuite/tests/203-temporal-reduce-isolation.sh
@@ -16,7 +16,7 @@ source check.sh
 
 echo "=== Experiment: Temporal-Reduce Factory Isolation ==="
 
-pond init
+pond init --birthplace test-host
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Step 1: Create synthetic sensor data (same as test 201)

--- a/testsuite/tests/204-sitegen-html-passthrough.sh
+++ b/testsuite/tests/204-sitegen-html-passthrough.sh
@@ -12,7 +12,7 @@ source check.sh
 
 echo "=== Experiment: Sitegen HTML Pass-Through ==="
 
-pond init
+pond init --birthplace test-host
 
 OUTDIR=/tmp/sitegen-html-test
 

--- a/testsuite/tests/205-sitegen-base-url.sh
+++ b/testsuite/tests/205-sitegen-base-url.sh
@@ -9,7 +9,7 @@ source check.sh
 
 echo "=== Experiment: Sitegen base_url ==="
 
-pond init
+pond init --birthplace test-host
 
 OUTDIR=/tmp/sitegen-baseurl-test
 

--- a/testsuite/tests/206-high-freq-temporal-reduce.sh
+++ b/testsuite/tests/206-high-freq-temporal-reduce.sh
@@ -8,7 +8,7 @@ source check.sh
 
 echo "=== Experiment: High-frequency temporal reduce + count verification ==="
 
-pond init
+pond init --birthplace test-host
 
 OUTDIR=/tmp/sitegen-hf-test
 

--- a/testsuite/tests/302-hostmount-copy-out.sh
+++ b/testsuite/tests/302-hostmount-copy-out.sh
@@ -11,7 +11,7 @@ source check.sh
 echo "=== Experiment: Copy Out via Hostmount ==="
 echo ""
 
-pond init
+pond init --birthplace test-host
 
 # ---------------------------------------------------------------------------
 # Setup: create test data in the pond

--- a/testsuite/tests/400-dual-pond-observability.sh
+++ b/testsuite/tests/400-dual-pond-observability.sh
@@ -25,7 +25,7 @@ echo ""
 echo "=== Setting up Pond1 (Log Collector) ==="
 
 export POND=/pond1
-pond init
+pond init --birthplace test-host
 echo "✓ Pond1 initialized at ${POND}"
 
 # Create log directory structure
@@ -77,7 +77,7 @@ echo ""
 echo "=== Setting up Pond2 (Observer) ==="
 
 export POND=/pond2
-pond init
+pond init --birthplace test-host
 echo "✓ Pond2 initialized at ${POND}"
 
 pond mkdir /observations

--- a/testsuite/tests/500-s3-replication-minio.sh
+++ b/testsuite/tests/500-s3-replication-minio.sh
@@ -66,7 +66,7 @@ echo ""
 echo "=== Setting up Pond (Primary) ==="
 
 export POND=/pond1
-pond init
+pond init --birthplace test-host
 echo "[OK] Pond initialized"
 
 pond mkdir /data

--- a/testsuite/tests/501-pond-id-mismatch-detection.sh
+++ b/testsuite/tests/501-pond-id-mismatch-detection.sh
@@ -65,7 +65,7 @@ echo "--- Step 1: Create first pond, attach, and push ---"
 POND1_DIR=$(mktemp -d)
 export POND="${POND1_DIR}"
 
-pond init
+pond init --birthplace test-host
 
 # First attach auto-initializes the bucket as a fresh Delta table
 # with Pond1's pond_id as the store_id.
@@ -95,7 +95,7 @@ echo "--- Step 2: Create second pond, try to attach to same bucket ---"
 POND2_DIR=$(mktemp -d)
 export POND="${POND2_DIR}"
 
-pond init
+pond init --birthplace test-host
 
 POND2_ID=$(pond config 2>/dev/null | grep "Pond ID" | awk '{print $NF}')
 echo "Pond2 ID: ${POND2_ID}"

--- a/testsuite/tests/502-remote-storage-options-env-expansion.sh
+++ b/testsuite/tests/502-remote-storage-options-env-expansion.sh
@@ -54,7 +54,7 @@ echo "[OK] bucket ready"
 
 export POND=/tmp/502-pond
 rm -rf "$POND"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir /data >/dev/null
 printf 'timestamp,sensor_id,value\n2024-01-01T00:00:00Z,s1,1.0\n2024-01-01T01:00:00Z,s1,2.0\n' > /tmp/502-data.csv
 pond copy host:///tmp/502-data.csv /data/data.csv >/dev/null

--- a/testsuite/tests/510-synth-logs-replication-cycle.sh
+++ b/testsuite/tests/510-synth-logs-replication-cycle.sh
@@ -129,7 +129,7 @@ echo ""
 echo "=== Phase 2: Setup Pond1 (Primary) ==="
 
 export POND=/pond1
-pond init
+pond init --birthplace test-host
 pond mkdir -p /data/metrics
 pond mkdir -p /system/run
 
@@ -177,7 +177,7 @@ echo ""
 echo "=== Phase 4: Setup Pond2 (Cross-Pond Replica) ==="
 
 export POND=/pond2
-pond init
+pond init --birthplace test-host
 
 # Cross-pond import: store_id from the remote MUST differ from Pond2's
 # fresh pond_id; first pull materializes the /imports/origin mount entry.

--- a/testsuite/tests/520-remote-show-verification.sh
+++ b/testsuite/tests/520-remote-show-verification.sh
@@ -104,7 +104,7 @@ echo "=== Phase 1: Pond setup + push ==="
 
 export POND=/pond1
 rm -rf "${POND}"
-pond init
+pond init --birthplace test-host
 pond mkdir -p /data
 
 # Create three files of varying sizes -- all under the 64KB large-file

--- a/testsuite/tests/521-external-tool-verification.sh
+++ b/testsuite/tests/521-external-tool-verification.sh
@@ -110,7 +110,7 @@ echo "=== Phase 1: Pond setup + push ==="
 
 export POND=/pond1
 rm -rf "${POND}"
-pond init
+pond init --birthplace test-host
 pond mkdir -p /data
 
 # A small text file -- guarantees one source parquet whose chunk_count = 1.

--- a/testsuite/tests/522-emergency-recovery-tool.sh
+++ b/testsuite/tests/522-emergency-recovery-tool.sh
@@ -150,7 +150,7 @@ echo "=== Phase 1: Pond1 setup + push ==="
 
 export POND=/pond1
 rm -rf "${POND}"
-pond init
+pond init --birthplace test-host
 
 pond backup add origin "${BUCKET_URL}" \
     --region us-east-1 \

--- a/testsuite/tests/523-emergency-erase-and-auto-bucket.sh
+++ b/testsuite/tests/523-emergency-erase-and-auto-bucket.sh
@@ -111,7 +111,7 @@ echo "=== Phase 1: Pond1 attach + push ==="
 
 export POND=/pond1
 rm -rf "${POND}"
-pond init
+pond init --birthplace test-host
 
 POND1_ID=$(pond config | grep "Pond ID" | awk '{print $NF}')
 echo "Pond1 ID: ${POND1_ID}"
@@ -179,7 +179,7 @@ echo "=== Phase 3: Pond2 attaches same URL, bucket auto-inits ==="
 
 export POND=/pond2
 rm -rf "${POND}"
-pond init
+pond init --birthplace test-host
 
 POND2_ID=$(pond config | grep "Pond ID" | awk '{print $NF}')
 echo "Pond2 ID: ${POND2_ID}"
@@ -208,7 +208,7 @@ echo "=== Phase 4: Pond3 attach to occupied bucket should fail ==="
 
 export POND=/pond3
 rm -rf "${POND}"
-pond init
+pond init --birthplace test-host
 
 POND3_ID=$(pond config | grep "Pond ID" | awk '{print $NF}')
 echo "Pond3 ID: ${POND3_ID}"

--- a/testsuite/tests/530-cross-pond-import-minio.sh
+++ b/testsuite/tests/530-cross-pond-import-minio.sh
@@ -107,7 +107,7 @@ echo "=== Phase 1: Pond A (producer) — init and populate ==="
 
 export POND=/tmp/pond-a
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond mkdir /data >/dev/null
 pond mkdir /data/nested >/dev/null
@@ -183,7 +183,7 @@ echo "=== Phase 3: Pond B (consumer) — init and write local data ==="
 
 export POND=/tmp/pond-b
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 POND_ID_B=$(pond config 2>/dev/null | awk '/^Pond ID:/ {print $NF; exit}')
 echo "Pond B pond_id: ${POND_ID_B}"

--- a/testsuite/tests/531-recursive-cross-pond-import.sh
+++ b/testsuite/tests/531-recursive-cross-pond-import.sh
@@ -129,7 +129,7 @@ echo "=== Phase 1: Pond A — init, write /data/a.txt, push to bucket-A ==="
 
 export POND=/tmp/pond-a-531
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond mkdir /data >/dev/null
 echo "from pond A" > /tmp/a-531.txt
@@ -154,7 +154,7 @@ echo "=== Phase 2: Pond B — mount A, pull, add own data, push to bucket-B ==="
 
 export POND=/tmp/pond-b-531
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond remote add upstreamA "s3://${BUCKET_A}" /imports/A \
     "${s3_args[@]}" --overwrite >/dev/null
@@ -189,7 +189,7 @@ echo "=== Phase 3: Pond C — mount B, pull ==="
 
 export POND=/tmp/pond-c-531
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond remote add upstreamB "s3://${BUCKET_B}" /imports/B \
     "${s3_args[@]}" --overwrite >/dev/null

--- a/testsuite/tests/532-cross-pond-path-boundaries.sh
+++ b/testsuite/tests/532-cross-pond-path-boundaries.sh
@@ -129,7 +129,7 @@ echo ""
 echo "=== Phase 1: Pond A — init, populate, push ==="
 export POND=/tmp/pond-a
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond mkdir /data >/dev/null
 
@@ -171,7 +171,7 @@ echo ""
 echo "=== Phase 2: Pond B — init, attach + pull A as /imports/A ==="
 export POND=/tmp/pond-b
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 POND_ID_B=$(pond config 2>/dev/null | awk '/^Pond ID:/ {print $NF; exit}')
 echo "Pond B pond_id: ${POND_ID_B}"

--- a/testsuite/tests/533-cross-pond-factory-resolution.sh
+++ b/testsuite/tests/533-cross-pond-factory-resolution.sh
@@ -136,7 +136,7 @@ echo ""
 echo "=== Phase 1: Pond A — init, populate, install factories, push ==="
 export POND=/tmp/pond-a-533
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond mkdir /data >/dev/null
 cat > /tmp/sensors.csv << 'EOF'
@@ -189,7 +189,7 @@ echo ""
 echo "=== Phase 2: Pond B — init, cross-pond-import A at /imports/A ==="
 export POND=/tmp/pond-b-533
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 POND_ID_B=$(pond config 2>/dev/null | awk '/^Pond ID:/ {print $NF; exit}')
 echo "Pond B pond_id: ${POND_ID_B}"

--- a/testsuite/tests/534-cross-pond-format-cache-persistence.sh
+++ b/testsuite/tests/534-cross-pond-format-cache-persistence.sh
@@ -131,7 +131,7 @@ echo "=== Phase 1: Pond A (producer) — raw oteljson ingest files ==="
 
 export POND=/tmp/pond-a-534
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir -p /ingest >/dev/null
 
 # Three independent raw oteljson files, mirroring the per-file ingest
@@ -177,7 +177,7 @@ echo ""
 echo "=== Phase 3: Pond B (consumer) — init + cross-pond pull ==="
 export POND=/tmp/pond-b-534
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 POND_ID_B=$(pond config 2>/dev/null | awk '/^Pond ID:/ {print $NF; exit}')
 check "Pond A and Pond B have distinct pond_ids" \

--- a/testsuite/tests/535-dynamic-format-cache-reuse.sh
+++ b/testsuite/tests/535-dynamic-format-cache-reuse.sh
@@ -126,7 +126,7 @@ git commit -q -m "Initial sensor CSV (max temp 22.1)"
 cd /
 
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 cat > /tmp/git-dyncache.yaml << EOF
 url: file://${REPO_DIR}
 ref: main

--- a/testsuite/tests/540-import-watermark-incremental.sh
+++ b/testsuite/tests/540-import-watermark-incremental.sh
@@ -126,7 +126,7 @@ echo ""
 echo "=== Phase 1: Pond A — init, populate, push ==="
 export POND=/tmp/pond-a-540
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond mkdir -p /data/sensors >/dev/null
 pond mkdir -p /data/logs >/dev/null
@@ -160,7 +160,7 @@ echo ""
 echo "=== Phase 2: Pond B — init, attach A as /imports/A ==="
 export POND=/tmp/pond-b-540
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond remote add upstream "s3://${BUCKET_NAME}" /imports/A \
     --region us-east-1 \

--- a/testsuite/tests/541-import-watermark-unrelated-txn.sh
+++ b/testsuite/tests/541-import-watermark-unrelated-txn.sh
@@ -123,7 +123,7 @@ echo ""
 echo "=== Phase 1: Pond A — init, populate one file, push ==="
 export POND=/tmp/pond-a-541
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir -p /data/sensors >/dev/null
 
 cat > /tmp/temps.csv << 'EOF'
@@ -149,7 +149,7 @@ echo ""
 echo "=== Phase 2: Pond B — init, attach A as /imports/A, pull #1 ==="
 export POND=/tmp/pond-b-541
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond remote add upstream "s3://${BUCKET_NAME}" /imports/A \
     --region us-east-1 \

--- a/testsuite/tests/542-import-watermark-restore.sh
+++ b/testsuite/tests/542-import-watermark-restore.sh
@@ -121,7 +121,7 @@ echo ""
 echo "=== Phase 1: Pond A — multi-txn history, push ==="
 export POND=/tmp/pond-a-542
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir -p /data/sensors >/dev/null
 pond mkdir -p /data/logs >/dev/null
 
@@ -158,7 +158,7 @@ echo ""
 echo "=== Phase 2: Pond B (original) — attach + first pull ==="
 export POND=/tmp/pond-b-542
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond remote add upstream "s3://${BUCKET_NAME}" /imports/A \
     --region us-east-1 \
@@ -194,7 +194,7 @@ check "Pond B physically removed" "[ ! -d /tmp/pond-b-542 ]"
 
 echo ""
 echo "=== Phase 4: Pond B' (fresh) — re-init, re-attach, pre-pull state ==="
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond remote add upstream "s3://${BUCKET_NAME}" /imports/A \
     --region us-east-1 \

--- a/testsuite/tests/550-recursive-sitegen.sh
+++ b/testsuite/tests/550-recursive-sitegen.sh
@@ -94,7 +94,7 @@ echo ""
 echo "=== Phase 1: Pond A — data + sitegen factory + standalone build ==="
 export POND=/tmp/pond-a-550
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 # Synthetic sensors (parents of dynamic-dir)
 cat > /tmp/sensors.yaml << 'YAML'
@@ -254,7 +254,7 @@ echo ""
 echo "=== Phase 2: Pond B — attach producer, install top-level sitegen ==="
 export POND=/tmp/pond-b-550
 rm -rf "${POND}"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 pond remote add upstream "s3://${BUCKET_NAME}" /sources/producer \
     --region us-east-1 \

--- a/testsuite/tests/600-git-ingest-basic-pull.sh
+++ b/testsuite/tests/600-git-ingest-basic-pull.sh
@@ -29,7 +29,7 @@ echo "Created test repo at $REPO_DIR"
 cd /
 
 # --- Initialize pond and create factory -------------------------------------
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/git-ingest.yaml << EOF
 url: file://${REPO_DIR}

--- a/testsuite/tests/601-git-ingest-incremental.sh
+++ b/testsuite/tests/601-git-ingest-incremental.sh
@@ -27,7 +27,7 @@ git commit -m "Initial commit"
 cd /
 
 # --- Initialize pond and do first pull ---------------------------------------
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/git-ingest.yaml << EOF
 url: file://${REPO_DIR}

--- a/testsuite/tests/602-git-ingest-symlinks.sh
+++ b/testsuite/tests/602-git-ingest-symlinks.sh
@@ -31,7 +31,7 @@ git commit -m "Nested dirs and symlinks"
 cd /
 
 # --- Initialize pond and pull -------------------------------------------------
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/git-ingest.yaml << EOF
 url: file://${REPO_DIR}

--- a/testsuite/tests/603-git-ingest-status.sh
+++ b/testsuite/tests/603-git-ingest-status.sh
@@ -23,7 +23,7 @@ echo "Commit SHA: $COMMIT_SHA"
 cd /
 
 # --- Initialize pond ----------------------------------------------------------
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/git-ingest.yaml << EOF
 url: file://${REPO_DIR}

--- a/testsuite/tests/604-git-ingest-prefix.sh
+++ b/testsuite/tests/604-git-ingest-prefix.sh
@@ -41,7 +41,7 @@ cd /
 # --- Test 1: prefix = "site" ------------------------------------------------
 echo ""
 echo "--- Test 1: prefix=site ---"
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/git-prefix1.yaml << EOF
 url: file://${REPO_DIR}

--- a/testsuite/tests/605-git-ingest-env-expansion.sh
+++ b/testsuite/tests/605-git-ingest-env-expansion.sh
@@ -38,7 +38,7 @@ echo "--- Test 1: env var with default (GIT_TEST_REF unset -> main) ---"
 # Ensure GIT_TEST_REF is NOT set
 unset GIT_TEST_REF
 
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/git-envref.yaml << 'EOF'
 url: file:///tmp/test-envref
@@ -68,7 +68,7 @@ echo "--- Test 2: env var set (GIT_TEST_REF=dev) ---"
 
 # Re-init a fresh pond
 rm -rf "$POND"
-pond init
+pond init --birthplace test-host
 
 export GIT_TEST_REF=dev
 

--- a/testsuite/tests/606-git-ingest-format-provider.sh
+++ b/testsuite/tests/606-git-ingest-format-provider.sh
@@ -35,7 +35,7 @@ echo "Created test repo at $REPO_DIR"
 cd /
 
 # --- Initialize pond and create git-ingest factory ---------------------------
-pond init
+pond init --birthplace test-host
 
 cat > /tmp/git-csv.yaml << EOF
 url: file://${REPO_DIR}

--- a/testsuite/tests/632-logfile-ingest-cumulative-blake3.sh
+++ b/testsuite/tests/632-logfile-ingest-cumulative-blake3.sh
@@ -17,7 +17,7 @@ echo "=== Test: Logfile Ingest Cumulative BLAKE3 ==="
 echo ""
 
 export POND=/pond
-pond init
+pond init --birthplace test-host
 
 #############################
 # SETUP

--- a/testsuite/tests/633-logfile-ingest-rotation-past-size.sh
+++ b/testsuite/tests/633-logfile-ingest-rotation-past-size.sh
@@ -21,7 +21,7 @@ echo "=== Test: Rotation Where New File Grew Past Old Size ==="
 echo ""
 
 export POND=/pond
-pond init
+pond init --birthplace test-host
 
 #############################
 # SETUP

--- a/testsuite/tests/634-logfile-ingest-truncated-no-archive.sh
+++ b/testsuite/tests/634-logfile-ingest-truncated-no-archive.sh
@@ -14,7 +14,7 @@ echo "=== Test: Truncated File Without Archive ==="
 echo ""
 
 export POND=/pond
-pond init
+pond init --birthplace test-host
 
 #############################
 # SETUP

--- a/testsuite/tests/700-billing-bootstrap-and-cycle.sh
+++ b/testsuite/tests/700-billing-bootstrap-and-cycle.sh
@@ -14,7 +14,7 @@ source check.sh
 
 echo "=== Experiment: billing bootstrap + full cycle issuance ==="
 
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 # ==============================================================================
 # Step 1: Apply the accounts factory

--- a/testsuite/tests/701-billing-fix-mistakes.sh
+++ b/testsuite/tests/701-billing-fix-mistakes.sh
@@ -12,7 +12,7 @@ source check.sh
 
 echo "=== Experiment: billing -- fixing operator mistakes ==="
 
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 # ---- Setup ----
 

--- a/testsuite/tests/702-billing-verify-detects.sh
+++ b/testsuite/tests/702-billing-verify-detects.sh
@@ -11,7 +11,7 @@ source check.sh
 
 echo "=== Experiment: billing -- verify detects corruption ==="
 
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 # ---- Setup: a clean issued cycle ----
 

--- a/testsuite/tests/710-remote-backup-lifecycle.sh
+++ b/testsuite/tests/710-remote-backup-lifecycle.sh
@@ -43,7 +43,7 @@ backup_field() {  # name colnum
 }
 
 echo "--- Step 1: init + ingest ---"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 printf 'alpha\nbravo\ncharlie\n' > /tmp/710-a.txt
 pond copy host:///tmp/710-a.txt /a.txt >/dev/null 2>&1
 check 'pond cat /a.txt | grep -q bravo' "raw file ingested"

--- a/testsuite/tests/711-cross-pond-file-import.sh
+++ b/testsuite/tests/711-cross-pond-file-import.sh
@@ -47,7 +47,7 @@ remote_last_pulled() {  # name
 
 echo "--- Step 1: producer ingest + backup add (auto-push) ---"
 export POND="$P1"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir -p /data >/dev/null 2>&1
 printf 'p1-one\np1-two\n'   > /tmp/711-f1.txt
 printf 'p1-three\np1-four\n' > /tmp/711-f2.txt
@@ -59,7 +59,7 @@ check '[ -n "'"${F1_MD5}"'" ]' "producer f1 md5 computed"
 
 echo "--- Step 2: consumer cross-pond import + pull ---"
 export POND="$P2"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond remote add upstream "file://${REMOTE}" /imports/up > /tmp/711-add.log 2>&1
 check_contains /tmp/711-add.log "remote add reports pull mount" "mode=pull, mount=/imports/up"
 pond pull upstream > /tmp/711-pull1.log 2>&1

--- a/testsuite/tests/712-maintain-compact-push.sh
+++ b/testsuite/tests/712-maintain-compact-push.sh
@@ -36,7 +36,7 @@ mkdir -p "$REMOTE"
 
 echo "--- Step 1: producer ingest + backup add ---"
 export POND="$P1"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir -p /data >/dev/null 2>&1
 for i in 1 2 3 4; do
     printf 'compact-row-%d\n' "$i" > /tmp/712-f$i.txt
@@ -61,7 +61,7 @@ check_contains /tmp/712-verify.log "verify clean after compact" "live data match
 
 echo "--- Step 5: fresh consumer pulls (incl. compact baseline) ---"
 export POND="$P2"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond remote add upstream "file://${REMOTE}" /imports/up >/dev/null 2>&1
 pond pull upstream > /tmp/712-pull.log 2>&1
 check 'grep -qE "applied [1-9][0-9]* bundle" /tmp/712-pull.log' "consumer applied bundles"

--- a/testsuite/tests/713-rebuild-control.sh
+++ b/testsuite/tests/713-rebuild-control.sh
@@ -35,7 +35,7 @@ rm -rf "$POND"
 pond_id() { pond config 2>/dev/null | grep -iE "pond[ _]?id" | grep -oE "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | head -1; }
 
 echo "--- Step 1: init + writes ---"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 for i in 1 2 3; do
     printf 'rc-row-%d\n' "$i" > /tmp/713-f$i.txt
     pond copy host:///tmp/713-f$i.txt /f$i.txt >/dev/null 2>&1

--- a/testsuite/tests/714-restart-from-compact.sh
+++ b/testsuite/tests/714-restart-from-compact.sh
@@ -38,7 +38,7 @@ mkdir -p "$REMOTE"
 
 echo "--- Step 1: producer + compact baseline ---"
 export POND="$P1"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir -p /data >/dev/null 2>&1
 for i in 1 2 3; do
     printf 'prod-row-%d\n' "$i" > /tmp/714-f$i.txt
@@ -52,7 +52,7 @@ check '[ -n "'"${SRC_MD5}"'" ]' "producer f2 md5 computed"
 
 echo "--- Step 2: consumer own data + cross-pond import ---"
 export POND="$P2"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 printf 'consumer-private\n' > /tmp/714-own.txt
 pond mkdir -p /local >/dev/null 2>&1
 pond copy host:///tmp/714-own.txt /local/own.txt >/dev/null 2>&1

--- a/testsuite/tests/715-cross-pond-divergent-frontier.sh
+++ b/testsuite/tests/715-cross-pond-divergent-frontier.sh
@@ -59,7 +59,7 @@ cons_pulled() {  # remote-name -> LAST_PULLED_SEQ field
 
 echo "--- Step 1: SLOW producer (low frontier) ---"
 export POND="$SLOW"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir -p /data >/dev/null 2>&1
 pond backup add origin "file://${R_SLOW}" >/dev/null 2>&1
 printf 'slow-one\n' > /tmp/715-slow1.txt
@@ -69,7 +69,7 @@ check '[ -n "'"${SLOW1_MD5}"'" ]' "slow producer s1 md5 computed"
 
 echo "--- Step 2: FAST producer (high frontier) ---"
 export POND="$FAST"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond mkdir -p /data >/dev/null 2>&1
 pond backup add origin "file://${R_FAST}" >/dev/null 2>&1
 # Push the frontier well past the slow producer's: each copy is one
@@ -83,7 +83,7 @@ check '[ -n "'"${FAST1_MD5}"'" ]' "fast producer f1 md5 computed"
 
 echo "--- Step 3: consumer imports BOTH producers ---"
 export POND="$CONS"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond remote add slow "file://${R_SLOW}" /imports/slow >/dev/null 2>&1
 pond remote add fast "file://${R_FAST}" /imports/fast >/dev/null 2>&1
 pond pull slow > /tmp/715-pull-slow1.log 2>&1

--- a/testsuite/tests/716-collapse-versions.sh
+++ b/testsuite/tests/716-collapse-versions.sh
@@ -24,7 +24,7 @@ source check.sh
 echo "=== Experiment: data:series version collapse ==="
 
 export POND=/pond
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 mkdir -p /var/log/app
 cat > /tmp/716-ingest.yaml << 'EOF'

--- a/testsuite/tests/717-collapse-push-pull.sh
+++ b/testsuite/tests/717-collapse-push-pull.sh
@@ -31,7 +31,7 @@ mkdir -p "$REMOTE"
 
 echo "--- Step 1: producer accumulates a multi-version series file ---"
 export POND="$P1"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 
 mkdir -p /var/log/app717
 cat > /tmp/717-ingest.yaml << 'EOF'
@@ -70,7 +70,7 @@ check_contains /tmp/717-verify.log "verify clean after collapse" "live data matc
 
 echo "--- Step 6: fresh consumer pulls and reproduces content ---"
 export POND="$P2"
-pond init >/dev/null
+pond init --birthplace test-host >/dev/null
 pond remote add upstream "file://${REMOTE}" /imports/up >/dev/null 2>&1
 pond pull upstream > /tmp/717-pull.log 2>&1
 check 'grep -qE "applied [1-9][0-9]* bundle" /tmp/717-pull.log' "consumer applied bundles"


### PR DESCRIPTION
Two related observability/identity improvements:

1. pond log now shows what each write did, not just timing/status. Each transaction block combines three sources: the originating CLI command (reconstructed from the data Delta pond_txn metadata), the control-table lifecycle (status, timing, duration, errors), and a one-line change summary (files/dirs/partitions) from the data table. Pure reads (including pond log's own read) are excluded; crashed writes surface under --incomplete. pond log --txn-seq N also shows the command. Write commands now record real argv via ShipContext::command_metadata()/command_args() instead of inconsistent hand-built labels.

   Also fixes: pond list -l duplicate ids, show brief-mode partition paths, a real show -m concise mode, and verify output now prints to stdout (was log::info!).

2. The pond's birthplace is now a required, user-asserted identity. `pond init` requires --birthplace <label>; it replaces the useless hardcoded birth_hostname="unknown" with an immutable PondMetadata field (on-disk control key "birthplace") shown in status/log/config banners. Threaded through Ship::create_pond/create_infrastructure and Steward::create_pond; all callers, tests, and the testsuite updated to pass a birthplace.