### PR TITLE
sitegen: fix blank overlay charts (width:"container" refit)

### DIFF
--- a/crates/sitegen/assets/overlay.js
+++ b/crates/sitegen/assets/overlay.js
@@ -155,15 +155,32 @@ import {
   // surface inline rather than throwing out of the (unawaited) render path.
   async function embedVega(targetEl, spec, rows, fields) {
     try {
+      targetEl.style.width = "100%";
       const embed = await loadVega();
       const renderSpec = { ...spec, data: { values: sanitizeRows(fields, rows) } };
-      await embed(targetEl, renderSpec, { actions: false, renderer: "svg" });
+      const res = await embed(targetEl, renderSpec, { actions: false, renderer: "svg" });
+      refitView(res && res.view, targetEl);
     } catch (e) {
       targetEl.innerHTML =
         '<div class="empty-state">Chart render failed: ' +
         String((e && e.message) || e) +
         "</div>";
     }
+  }
+
+  // Vega's `width: "container"` reads the element's clientWidth at embed time.
+  // When layout/fonts have not settled the element can measure zero width, which
+  // collapses every datum to x=0 and leaves the plot blank. Re-fit to the real
+  // width once the layout settles and on every resize so lines span the plot.
+  function refitView(view, targetEl) {
+    if (!view) return;
+    const refit = () => {
+      const w = targetEl.clientWidth ||
+        (targetEl.parentElement && targetEl.parentElement.clientWidth) || 700;
+      view.width(w).resize().runAsync();
+    };
+    requestAnimationFrame(refit);
+    new ResizeObserver(refit).observe(targetEl);
   }
 
   // -- Constants ---------------------------------------------------------------
@@ -423,12 +440,14 @@ import {
           try { overviewView.finalize(); } catch (e) { /* already gone */ }
           overviewView = null;
         }
+        ovHolder.style.width = "100%";
         const res = await embed(
           ovHolder,
           { ...spec, data: { values: overviewRows } },
           { actions: false, renderer: "svg" }
         );
         overviewView = res.view;
+        refitView(overviewView, ovHolder);
       } catch (e) {
         ovHolder.innerHTML =
           '<div class="empty-state">Overview render failed: ' +

--- a/testsuite/browser/tests/305-browser-overlay-chart.mjs
+++ b/testsuite/browser/tests/305-browser-overlay-chart.mjs
@@ -153,6 +153,35 @@ async function testPage(browser, pagePath) {
   );
   check(vegaSvgCount > 0, `Vega-Lite charts rendered (${vegaSvgCount})`);
 
+  // Assert the data marks span a non-zero horizontal extent. Vega's
+  // `width: "container"` reads the plot element's clientWidth at embed time; if
+  // the element measured zero width (layout/fonts not settled) every datum
+  // collapses to x=0, producing a visible SVG whose line/area paths are a
+  // degenerate vertical stack -- the "blank whitespace" regression. Require at
+  // least one mark path with a bounding-box width greater than 1px so a future
+  // collapse to zero width is caught rather than passing on SVG presence alone.
+  const markSpan = await tab.evaluate(() => {
+    const paths = document.querySelectorAll(
+      "#overlay-chart .overlay-vega svg.marks g.mark-line path, " +
+        "#overlay-chart .overlay-vega svg.marks g.mark-area path"
+    );
+    let maxWidth = 0;
+    paths.forEach((p) => {
+      try {
+        const w = p.getBBox().width;
+        if (w > maxWidth) maxWidth = w;
+      } catch (e) {
+        /* getBBox throws for detached nodes; ignore */
+      }
+    });
+    return { total: paths.length, maxWidth };
+  });
+  check(
+    markSpan.maxWidth > 1,
+    `chart marks span non-zero width ` +
+      `(max ${markSpan.maxWidth.toFixed(1)}px across ${markSpan.total} paths)`
+  );
+
   // Check that "Loading..." is gone
   const loadingVisible = await tab.evaluate(() => {
     const el = document.getElementById("overlay-chart");


### PR DESCRIPTION
PR #97 enabled the "Explore this data" button on the pump-cycle analysis pages, but the charts themselves render as blank whitespace (e.g. http://watershop.casparwater.us/analysis/pump-cycles.html).

## Root cause
Every Vega-Lite spec in `overlay.js` uses `width: "container"`, which reads the plot element's `clientWidth` at embed time. When layout/fonts have not settled that measures `0`, collapsing all data to `x=0` and leaving the plot blank. `chart.js` was already fixed for this identical symptom (commit `9314e9d4`: force `width:100%` + refit via `requestAnimationFrame`/`ResizeObserver`), but `overlay.js` never got the same fix.

## Fix
- Add a `refitView(view, targetEl)` helper mirroring `chart.js`.
- `embedVega` (analysis charts) and `embedOverview` (brush overview) now force `width:100%`, capture the Vega view, and refit on layout settle + resize.
- Browser test 305 gains a geometry assertion that mark-line/area paths span a non-zero width, so a future collapse-to-zero is caught rather than passing on SVG presence alone.

## Verification
Served the pre-generated overlay site with the patched asset and ran test 305: `22 passed, 0 failed`; marks now span 524-698px.