### PR TITLE
deb: Conflicts/Replaces duckpond so dpkg -i supersedes the old package

### DIFF
--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -47,6 +47,14 @@ assets (DuckDB-WASM, Observable Plot, D3) needed for chart rendering.
 section = "utils"
 priority = "optional"
 depends = "libc6, ca-certificates"
+# Watertown is the renamed successor of the old `duckpond` package and
+# ships the same `/usr/bin/pond`.  Conflicts + Replaces is the Debian
+# package-rename idiom: it lets `dpkg -i watertown_*.deb` automatically
+# remove an installed `duckpond` and take over its files, instead of
+# aborting with "trying to overwrite '/usr/bin/pond', which is also in
+# package duckpond".
+conflicts = "duckpond"
+replaces = "duckpond"
 assets = [
     ["target/release/pond",                              "usr/bin/",                       "755"],
     ["../sitegen/vendor/dist/duckdb-eh.wasm",            "usr/share/watertown/vendor/",     "644"],


### PR DESCRIPTION
## Problem
The watertown `.deb` ships `/usr/bin/pond` — the same path the legacy `duckpond` `.deb` owned. On a host that still had `duckpond` installed, `dpkg -i watertown_*.deb` aborts:

```
dpkg: error processing archive watertown_0.52.0-1_arm64.deb (--install):
 trying to overwrite '/usr/bin/pond', which is also in package duckpond 0.52.0-1
```

During the watershop staging migration this made the terraform `install-watertown.sh` step fail to install the deb, silently leaving the stale pre-rename binary in place.

## Fix
Add `conflicts = "duckpond"` + `replaces = "duckpond"` to `[package.metadata.deb]`. This is the Debian package-rename idiom: the Conflicts+Replaces combination makes `dpkg -i` automatically remove the installed `duckpond` and take over its files, instead of aborting.

## Test
- `cargo deb -p cmd` builds; `dpkg-deb -f` shows `Conflicts: duckpond` / `Replaces: duckpond`.
- Companion caspar.water PR makes the terraform provisioner propagate an `install-watertown.sh` failure (which had masked this bug).