### PR TITLE
ci: publish pond .deb as ghcr OCI artifact

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -18,6 +18,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/watertown
+  DEB_PACKAGE: ${{ github.repository }}/pond-deb
 
 jobs:
   promote:
@@ -46,8 +47,11 @@ jobs:
         run: |
           IMAGE_ID=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          DEB_ID=${{ env.REGISTRY }}/${{ env.DEB_PACKAGE }}
+          DEB_ID=$(echo $DEB_ID | tr '[A-Z]' '[a-z]')
           STAMP=$(date -u +%Y%m%d-%H%M%S)
           echo "image_id=$IMAGE_ID" >> $GITHUB_OUTPUT
+          echo "deb_id=$DEB_ID" >> $GITHUB_OUTPUT
           echo "stamp=$STAMP" >> $GITHUB_OUTPUT
 
       - name: Promote (retag by digest)
@@ -68,24 +72,47 @@ jobs:
             echo "prod_${ARCH}_digest=${DIGEST}" >> $GITHUB_OUTPUT
           done
 
+      - name: Promote deb artifact (retag by digest)
+        run: |
+          set -euo pipefail
+          DEB="${{ steps.refs.outputs.deb_id }}"
+          SRC="${{ github.event.inputs.source }}"
+          STAMP="${{ steps.refs.outputs.stamp }}"
+          for ARCH in amd64 arm64; do
+            SRC_REF="${DEB}:${SRC}-${ARCH}"
+            PROD_REF="${DEB}:prod-${ARCH}"
+            STAMPED_REF="${DEB}:prod-${STAMP}-${ARCH}"
+            echo "=== Promoting ${SRC_REF}"
+            DIGEST=$(crane digest "${SRC_REF}")
+            echo "    digest: ${DIGEST}"
+            crane cp "${SRC_REF}" "${PROD_REF}"
+            crane cp "${SRC_REF}" "${STAMPED_REF}"
+          done
+
       - name: Sign promoted images with Sigstore
         run: |
           set -euo pipefail
           IMAGE="${{ steps.refs.outputs.image_id }}"
+          DEB="${{ steps.refs.outputs.deb_id }}"
           STAMP="${{ steps.refs.outputs.stamp }}"
           for ARCH in amd64 arm64; do
             cosign sign --yes "${IMAGE}:prod-${ARCH}"
             cosign sign --yes "${IMAGE}:prod-${STAMP}-${ARCH}"
+            cosign sign --yes "${DEB}:prod-${ARCH}"
+            cosign sign --yes "${DEB}:prod-${STAMP}-${ARCH}"
           done
 
       - name: Summary
         run: |
           IMAGE="${{ steps.refs.outputs.image_id }}"
+          DEB="${{ steps.refs.outputs.deb_id }}"
           STAMP="${{ steps.refs.outputs.stamp }}"
           {
             echo "## Promoted \`${{ github.event.inputs.source }}\` → \`prod\`"
             echo ""
-            echo "Rollback handle: \`${IMAGE}:prod-${STAMP}-<arch>\`"
+            echo "Image rollback handle: \`${IMAGE}:prod-${STAMP}-<arch>\`"
+            echo "Deb rollback handle:   \`${DEB}:prod-${STAMP}-<arch>\`"
             echo ""
-            echo "Prod hosts will pull the new image on their next systemd timer tick (\`--pull=newer\`)."
+            echo "Prod container hosts pull the new image on their next systemd timer tick (\`pond.sh --pull-image\`)."
+            echo "Selfmon hosts on \`DEB_CHANNEL=prod\` pull the new deb on their next hourly update-selfmon tick."
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -11,6 +11,11 @@ env:
   RUST_BACKTRACE: 1
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/watertown
+  DEB_PACKAGE: ${{ github.repository }}/pond-deb
+  # Pinned oras release used to push the .deb as an OCI artifact.
+  ORAS_VERSION: 1.3.2
+  ORAS_SHA256_AMD64: 9229ccc6d17bb282039ad4a69abb16dcb887a5bce567c075d731d9b3c7ad8eaf
+  ORAS_SHA256_ARM64: 8db4a223bd6034deff198e791ea7cb3af0840df25b7e9f370e2f1f3fd20d389b
 
 jobs:
   check:
@@ -140,6 +145,126 @@ jobs:
           cosign sign --yes ${{ steps.meta.outputs.image_id }}:${{ steps.meta.outputs.version }}-${{ matrix.arch }}
           if [ -n "${{ steps.meta.outputs.extra_tag }}" ]; then
             cosign sign --yes ${{ steps.meta.outputs.image_id }}:${{ steps.meta.outputs.extra_tag }}-${{ matrix.arch }}
+          fi
+
+  build-deb:
+    name: Build & Publish Deb (${{ matrix.arch }})
+    needs: check
+    # Same gate as build-container: always on main/workflow_dispatch, on PRs
+    # only when the 'build-container' label is present.
+    if: |
+      (success() || failure()) && (
+        github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'build-container')
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # For Sigstore signing
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install build tooling (brotli, cargo-deb, oras)
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y brotli
+          cargo install cargo-deb --locked
+          case "${{ matrix.arch }}" in
+            amd64) ORAS_SHA=${ORAS_SHA256_AMD64} ;;
+            arm64) ORAS_SHA=${ORAS_SHA256_ARM64} ;;
+            *) echo "unsupported arch ${{ matrix.arch }}" >&2; exit 1 ;;
+          esac
+          TARBALL=oras_${ORAS_VERSION}_linux_${{ matrix.arch }}.tar.gz
+          curl -fsSL -o "${TARBALL}" \
+            "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/${TARBALL}"
+          echo "${ORAS_SHA}  ${TARBALL}" | sha256sum -c -
+          mkdir -p oras-install
+          tar -xzf "${TARBALL}" -C oras-install oras
+          sudo install -m 0755 oras-install/oras /usr/local/bin/oras
+          oras version
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.6.0
+
+      - name: Build vendor assets
+        run: make vendor
+
+      - name: Build Debian package
+        run: cargo deb -p cmd
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          PKG=${{ env.REGISTRY }}/${{ env.DEB_PACKAGE }}
+          PKG=$(echo "$PKG" | tr '[A-Z]' '[a-z]')
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            VERSION=pr-${{ github.event.pull_request.number }}
+            EXTRA_TAG=""
+          else
+            VERSION=latest
+            EXTRA_TAG=sha-${SHORT_SHA}
+          fi
+          DEB=$(ls -t target/debian/watertown_*_${{ matrix.arch }}.deb | head -1)
+          echo "pkg=$PKG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "extra_tag=$EXTRA_TAG" >> $GITHUB_OUTPUT
+          echo "deb=$DEB" >> $GITHUB_OUTPUT
+
+      - name: Log in to Container Registry (oras)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | oras login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Log in to Container Registry (Cosign)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | cosign login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Push Debian package as OCI artifact
+        run: |
+          set -euo pipefail
+          PKG="${{ steps.meta.outputs.pkg }}"
+          VERSION="${{ steps.meta.outputs.version }}"
+          EXTRA_TAG="${{ steps.meta.outputs.extra_tag }}"
+          DEB="${{ steps.meta.outputs.deb }}"
+          ARCH="${{ matrix.arch }}"
+          # Push from target/debian so the artifact carries the bare .deb
+          # filename (the box reads its version back via dpkg-deb -f).
+          ( cd "$(dirname "$DEB")" && \
+            oras push "${PKG}:${VERSION}-${ARCH}" \
+              "$(basename "$DEB"):application/vnd.debian.binary-package" )
+          if [ -n "${EXTRA_TAG}" ]; then
+            oras tag "${PKG}:${VERSION}-${ARCH}" "${EXTRA_TAG}-${ARCH}"
+          fi
+
+      - name: Sign Debian artifact with Sigstore
+        run: |
+          set -euo pipefail
+          PKG="${{ steps.meta.outputs.pkg }}"
+          VERSION="${{ steps.meta.outputs.version }}"
+          EXTRA_TAG="${{ steps.meta.outputs.extra_tag }}"
+          ARCH="${{ matrix.arch }}"
+          cosign sign --yes "${PKG}:${VERSION}-${ARCH}"
+          if [ -n "${EXTRA_TAG}" ]; then
+            cosign sign --yes "${PKG}:${EXTRA_TAG}-${ARCH}"
           fi
 
   comment-pr:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,23 +8,46 @@ This document describes the release process for Watertown and addresses software
 
 All builds are performed via GitHub Actions (see `.github/workflows/rust-ci.yml`):
 
-1. **On Pull Requests**: Run tests, clippy, and format checks only
-2. **On Main Branch**: Run tests + build and publish container image + create .deb package
-3. **On Version Tags** (`v*`): Same as main, with version-tagged artifacts
+1. **On Pull Requests**: Run tests, clippy, and format checks only.  The
+   container image and `.deb` artifact jobs run on a PR only when the
+   `build-container` label is present.
+2. **On Main Branch**: Run tests + build and publish the multi-arch container
+   image (`build-container`) + build and publish the `.deb` as an OCI artifact
+   (`build-deb`)
+3. **On `workflow_dispatch`**: Same as main.
 
 ### Artifacts Produced
 
-For each successful build on main or version tags:
+For each successful build on `main` or `workflow_dispatch`:
 
-- **Container Image**: `ghcr.io/jmacd/watertown:latest` (or version tag)
-  - Built with Podman on GitHub's Ubuntu runners
+- **Container Image**: `ghcr.io/jmacd/watertown/watertown:latest-<arch>`
+  (plus `sha-<short>-<arch>`)
+  - Built with Podman on GitHub's Ubuntu runners (amd64 + arm64)
   - Based on Debian Bookworm (glibc 2.36)
-  - Includes pond binary at `/usr/bin/pond`
-  
-- **Debian Package**: `pond_<version>_amd64.deb`
-  - Available as GitHub Actions artifact (90 day retention)
-  - Dependencies: libssl3, ca-certificates
-  - Installs to `/usr/bin/pond`
+  - Includes the pond binary at `/usr/bin/pond`
+  - Cosign-signed via Sigstore keyless signing
+
+- **Debian Package (OCI artifact)**:
+  `ghcr.io/jmacd/watertown/pond-deb:latest-<arch>` (plus `sha-<short>-<arch>`)
+  - Built with `cargo deb -p cmd` on amd64 + arm64 runners
+  - Pushed as an OCI artifact with `oras` (media type
+    `application/vnd.debian.binary-package`); the artifact carries the real
+    `watertown_<version>_<arch>.deb` filename
+  - Package name `watertown`, installs `/usr/bin/pond` plus the sitegen vendor
+    blobs to `/usr/share/watertown/vendor/`
+  - Cosign-signed via Sigstore keyless signing
+  - Consumed by the natively-installed `watershop-selfmon` pond, which pulls
+    it hourly (see caspar.water `config/scripts/update-selfmon.sh`)
+
+### Promotion to prod
+
+`.github/workflows/promote.yml` (manual `workflow_dispatch`) retags an existing
+`latest-<arch>` (or `sha-…` / `prod-…`) tag to `prod-<arch>` for **both** the
+container image and the `pond-deb` artifact in lockstep, using `crane cp` (a
+digest-preserving retag, not a rebuild), plus a dated `prod-<stamp>-<arch>`
+rollback handle, then cosign-signs each. Container hosts select `latest-` for
+`*-staging` instances and `prod-` otherwise; the selfmon host selects its deb
+channel via the `DEB_CHANNEL` env (default `latest`).
 
 ### Creating a Release
 
@@ -166,22 +189,31 @@ slsa-verifier verify-artifact pond \
 - **Minimum RAM**: 1GB (monitor memory usage)
 - **Dependencies**: libssl3, ca-certificates
 
-### Installation via .deb Package
+### Installation via .deb Package (OCI artifact)
+
+The `.deb` is published as an OCI artifact rather than a GitHub Release asset.
+Pull it with `oras` (the package is public, no login required) and install:
 
 ```bash
-# Download from GitHub Release
-wget https://github.com/jmacd/watertown/releases/download/v0.16.0/pond_0.16.0_amd64.deb
+# Pull the newest deb for this arch (e.g. arm64) into the current dir
+oras pull ghcr.io/jmacd/watertown/pond-deb:latest-arm64
 
-# Install
-sudo dpkg -i pond_0.16.0_amd64.deb
+# Install (auto-supersedes a legacy `duckpond` package via Conflicts/Replaces)
+sudo dpkg -i watertown_*_arm64.deb
 sudo apt-get install -f  # Install any missing dependencies
 
 # Verify
 pond --version
 
 # Uninstall
-sudo dpkg -r pond
+sudo dpkg -r watertown
 ```
+
+On the `watershop-selfmon` host this is automated: an hourly
+`pond-selfmon-update@.timer` runs `update-selfmon.sh`, which pulls the deb for
+its `DEB_CHANNEL` and installs it only when the pulled version is newer.
+`tools/build-on-watershop.sh` remains a dev-only fallback for fast local
+iteration without waiting for CI.
 
 ### Running in Production
 


### PR DESCRIPTION
Implements **Repo A** of `docs/selfmon-deb-pipeline-design.md`: publish the `pond` Debian package as a ghcr OCI artifact with latest/prod promotion parity matching the container images.

## Changes
- **`rust-ci.yml`**: new `build-deb` job (matrix amd64/arm64, same runners/gate as `build-container`). Builds `watertown_<ver>_<arch>.deb` via `make vendor` + `cargo deb -p cmd`, pushes it to `ghcr.io/jmacd/watertown/pond-deb:{latest,sha-<short>}-<arch>` (or `pr-<n>-<arch>`) with a pinned `oras` (v1.3.2, checksum-verified), and cosign-signs it.
- **`promote.yml`**: after the image-promote loop, retag the `pond-deb` artifact `latest->prod-<arch>` + dated rollback handle via `crane cp` (digest-preserving), and cosign-sign. Summary updated.
- **`RELEASING.md`**: corrected to describe the real flow (ghcr OCI deb artifact, `oras pull`, hourly selfmon timer, `promote.yml`) instead of the aspirational GitHub-Release-artifact text.

## Sequencing
Land this first so `pond-deb:latest-arm64` exists; the caspar.water box-side consumer (jmacd/caspar.water#…) pulls it. No production impact — additive CI only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>