### PR TITLE
deb: fix stale vendor asset (vega-bundle.mjs) breaking build-deb

### DIFF
--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -42,7 +42,7 @@ extended-description = """\
 Watertown is a local-first data management tool for small industrial
 systems built on Apache Arrow, DataFusion, and Delta Lake.  This
 package installs the `pond` CLI plus the sitegen browser-side vendor
-assets (DuckDB-WASM, Observable Plot, D3) needed for chart rendering.
+assets (DuckDB-WASM and Vega-Lite) needed for chart rendering.
 """
 section = "utils"
 priority = "optional"
@@ -60,15 +60,15 @@ assets = [
     ["../sitegen/vendor/dist/duckdb-eh.wasm",            "usr/share/watertown/vendor/",     "644"],
     ["../sitegen/vendor/dist/duckdb-browser.mjs",        "usr/share/watertown/vendor/",     "644"],
     ["../sitegen/vendor/dist/duckdb-browser-eh.worker.js","usr/share/watertown/vendor/",    "644"],
-    ["../sitegen/vendor/dist/plot-d3-bundle.mjs",        "usr/share/watertown/vendor/",     "644"],
+    ["../sitegen/vendor/dist/vega-bundle.mjs",           "usr/share/watertown/vendor/",     "644"],
     ["../sitegen/vendor/dist/duckdb-eh.wasm.gz",         "usr/share/watertown/vendor/",     "644"],
     ["../sitegen/vendor/dist/duckdb-browser.mjs.gz",     "usr/share/watertown/vendor/",     "644"],
     ["../sitegen/vendor/dist/duckdb-browser-eh.worker.js.gz","usr/share/watertown/vendor/", "644"],
-    ["../sitegen/vendor/dist/plot-d3-bundle.mjs.gz",     "usr/share/watertown/vendor/",     "644"],
+    ["../sitegen/vendor/dist/vega-bundle.mjs.gz",        "usr/share/watertown/vendor/",     "644"],
     ["../sitegen/vendor/dist/duckdb-eh.wasm.br",         "usr/share/watertown/vendor/",     "644"],
     ["../sitegen/vendor/dist/duckdb-browser.mjs.br",     "usr/share/watertown/vendor/",     "644"],
     ["../sitegen/vendor/dist/duckdb-browser-eh.worker.js.br","usr/share/watertown/vendor/", "644"],
-    ["../sitegen/vendor/dist/plot-d3-bundle.mjs.br",     "usr/share/watertown/vendor/",     "644"],
+    ["../sitegen/vendor/dist/vega-bundle.mjs.br",        "usr/share/watertown/vendor/",     "644"],
     ["../../README.md",                                  "usr/share/doc/watertown/README", "644"],
 ]
 


### PR DESCRIPTION
## Problem
The `build-deb` job added in #105 failed on a clean CI checkout (run 28990205026, both arches) at `cargo deb -p cmd`:

```
error: Can't resolve asset: crates/cmd/../sitegen/vendor/dist/plot-d3-bundle.mjs
  cause: Static file asset path did not match any existing files
```

`[package.metadata.deb]` in `crates/cmd/Cargo.toml` still listed `plot-d3-bundle.mjs` (+ `.gz`/`.br`), but `crates/sitegen/vendor/download.sh` dropped Observable Plot and D3 in favor of a single Vega-Lite bundle (`vega-bundle.mjs`) — the same set `sitegen` `factory.rs::VENDOR_FILES` requires. The earlier native watershop build only passed because a stale `plot-d3-bundle.mjs` lingered in `vendor/dist/` (download.sh recreates the dir but never removes old files); clean CI has only current outputs.

## Fix
Point the three deb asset lines at `vega-bundle.mjs` and correct the now-stale package description (`Observable Plot, D3` → `Vega-Lite`).

## Validation
Ran `make vendor` against a wiped `vendor/dist/` locally; all 12 deb vendor assets now resolve against the produced files (duckdb-eh.wasm, duckdb-browser.mjs, duckdb-browser-eh.worker.js, vega-bundle.mjs — each plus `.gz`/`.br`). TOML parses.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>