### PR TITLE
ci: green main again (check-job disk headroom + clippy 1.97 lints)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -26,10 +26,15 @@ jobs:
       
       - name: Free up disk space
         run: |
+          df -h
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo docker image prune -a -f || true
           df -h
       
       - name: Setup Rust toolchain


### PR DESCRIPTION
Two independent things were keeping `Rust CI` on `main` red. This PR fixes both.

## 1. Check job ran out of disk (run 28992951956)
`Check, Build & Test` failed while *linking* the `pond` test binary:
```
rustc-LLVM ERROR: IO failure on output stream: No space left on device
```
The `check` job's disk cleanup was lighter than the build jobs' — it omitted `/usr/local/lib/android` (~9 GB), `.ghcup`, the CodeQL toolcache, and `docker image prune`. Brought it to parity with `build-container`. (Confirmed fixed: the follow-up run got past tests.)

## 2. Clippy 1.97 lints (run 29025732625)
With tests passing, `Run clippy` then failed: `dtolnay/rust-toolchain@stable` advanced to 1.97.0, which enforces two lints the tree trips:
- `useless_borrows_in_formatting` — redundant `&` on log-macro format args (cmd, provider, steward, tlogfs)
- `question_mark` — `crates/utilities/src/glob.rs`

Mechanical, behavior-preserving fixes (mostly `cargo clippy --fix`). Verified locally on stable **1.97.0**: `cargo fmt --all -- --check` and `cargo clippy --workspace --all-features -- -D warnings` both clean.

Note: `build-container` and `build-deb` were passing throughout, so the `pond-deb` OCI artifact has been publishing fine — these fixes just get the `check` gate green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>