### PR TITLE
ci: build deb on Ubuntu 22.04 for bookworm glibc compatibility

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -211,9 +211,13 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
           - arch: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
+    # The deb is installed on Debian 12 bookworm hosts, which ship glibc 2.36.
+    # Building on Ubuntu 22.04 links the binary against glibc 2.35, a safe floor
+    # that runs on bookworm. Ubuntu 24.04 links against glibc 2.39 and produces a
+    # binary that fails at load time on bookworm with "GLIBC_2.39 not found".
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -264,6 +268,24 @@ jobs:
           # matches the deb version.
           WATERTOWN_VERSION: ${{ needs.version.outputs.version }}
         run: cargo deb -p cmd --deb-version "${{ needs.version.outputs.version }}"
+
+      - name: Verify binary glibc requirement is bookworm-compatible
+        run: |
+          set -euo pipefail
+          # The deb is deployed on Debian 12 bookworm (glibc 2.36). Fail hard if
+          # the built binary requires a newer glibc than bookworm provides, so a
+          # runner-image bump can never silently ship an unloadable binary again.
+          MAX_GLIBC="2.36"
+          BIN=target/release/pond
+          NEED=$(objdump -T "$BIN" \
+            | grep -oE 'GLIBC_[0-9]+\.[0-9]+' \
+            | sed 's/GLIBC_//' \
+            | sort -V | tail -1)
+          echo "max glibc required by pond: ${NEED} (target ceiling ${MAX_GLIBC})"
+          if [ "$(printf '%s\n%s\n' "$MAX_GLIBC" "$NEED" | sort -V | tail -1)" != "$MAX_GLIBC" ]; then
+            echo "::error::pond requires glibc ${NEED} > ${MAX_GLIBC}; it will not load on Debian 12 bookworm" >&2
+            exit 1
+          fi
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
## Problem
The new `0.<pr>.<build>` version scheme (#110) let the selfmon auto-updater finally install a CI-built deb, replacing the older hand-built `0.52.0-1`. The CI deb builds on **Ubuntu 24.04 (glibc 2.39)**, but watershop is **Debian 12 bookworm (glibc 2.36)**, so the native `pond` binary fails at load:

```
/usr/bin/pond: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

This broke selfmon (native deb) on every tick. Site-staging (container image, self-contained userspace built in `rust:1.88`/bookworm) is unaffected — only the native deb depends on host glibc.

The incompatibility was latent: the CI deb always linked 2.39, but the static `0.52.0-1` version-gate blocked it from installing until now.

## Fix
- Build the deb on **Ubuntu 22.04 (glibc 2.35)** — a safe floor that runs on bookworm and above.
- Add a hard guard step that inspects the built binary and **fails the build** if it requires a glibc newer than bookworm's 2.36, so a future runner-image bump can never silently ship an unloadable binary again.

## Verification
- `build-container` label added so the deb builds in this PR's CI.
- After merge, the first main build publishes a glibc-2.35 deb; the watershop selfmon auto-updater will install it and recover.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>