### PR TITLE
sitegen: fix false-yellow selfmon self-card (overdue threshold)

### DIFF
--- a/crates/sitegen/src/factory.rs
+++ b/crates/sitegen/src/factory.rs
@@ -725,6 +725,7 @@ async fn run_status_grid_queries(
             status.last_err_us,
             status.timer_active,
             status.timer_interval_s,
+            status.run_wall_s,
         );
 
         statuses.push(status);
@@ -806,6 +807,26 @@ async fn populate_perf_fields(
     }
     .await;
 
+    // `run.wall_s` was added to measure-pond.sh after the other perf
+    // fields, so a perf series written by an older probe lacks the
+    // column entirely and this SELECT would fail schema resolution.
+    // Query it separately and best-effort so that during a deploy the
+    // established liveness fields above are never lost -- a missing
+    // `run.wall_s` just falls the staleness threshold back to
+    // `2 * timer_interval_s`.
+    let run_wall_result = async {
+        let df = ctx
+            .sql(&format!(
+                "SELECT \"run.wall_s\" AS run_wall_s \
+                 FROM {} \
+                 ORDER BY timestamp DESC LIMIT 1",
+                perf_table
+            ))
+            .await?;
+        df.collect().await
+    }
+    .await;
+
     let _ = ctx.deregister_table(datafusion::sql::TableReference::bare(perf_table.as_str()));
 
     let batches = match result {
@@ -816,25 +837,32 @@ async fn populate_perf_fields(
         }
     };
 
-    let get_i64 = |col: usize| -> Option<i64> {
-        batches.iter().find_map(|b| {
-            if b.num_rows() == 0 {
-                return None;
-            }
-            let arr = b.column(col).as_any().downcast_ref::<Int64Array>()?;
-            if arr.is_null(0) {
-                None
-            } else {
-                Some(arr.value(0))
-            }
-        })
-    };
+    let scalar_i64 =
+        |batches: &[datafusion::arrow::array::RecordBatch], col: usize| -> Option<i64> {
+            batches.iter().find_map(|b| {
+                if b.num_rows() == 0 {
+                    return None;
+                }
+                let arr = b.column(col).as_any().downcast_ref::<Int64Array>()?;
+                if arr.is_null(0) {
+                    None
+                } else {
+                    Some(arr.value(0))
+                }
+            })
+        };
+
+    let get_i64 = |col: usize| -> Option<i64> { scalar_i64(&batches, col) };
 
     if let Some(v) = get_i64(0) {
         status.timer_active = Some(v != 0);
     }
     status.last_run_seconds_ago = get_i64(1);
     status.timer_interval_s = get_i64(2).filter(|&v| v > 0);
+    status.run_wall_s = run_wall_result
+        .ok()
+        .and_then(|b| scalar_i64(&b, 0))
+        .filter(|&v| v > 0);
 }
 
 /// Run the per-unit DataFusion queries for the status grid.
@@ -967,6 +995,7 @@ async fn query_pond_status(
         timer_active: None,
         last_run_seconds_ago: None,
         timer_interval_s: None,
+        run_wall_s: None,
         health: Health::Unknown,
     })
 }

--- a/crates/sitegen/src/shortcodes.rs
+++ b/crates/sitegen/src/shortcodes.rs
@@ -113,10 +113,19 @@ pub struct PondStatus {
     /// it as a "Last run" row but the health classifier ignores it.
     pub last_run_seconds_ago: Option<i64>,
     /// Latest value of `timer.interval_s` from the perf series
-    /// (`OnUnitActiveSec` in seconds).  Drives the staleness threshold
-    /// (`2 * timer_interval_s`) for the yellow/green boundary.  `None`
-    /// or `Some(0)` keeps the card at `Health::Unknown` for staleness.
+    /// (`OnUnitActiveSec` in seconds).  Combined with `run_wall_s` it
+    /// drives the staleness threshold for the yellow/green boundary.
+    /// `None` or `Some(0)` keeps the card at `Health::Unknown` for
+    /// staleness.
     pub timer_interval_s: Option<i64>,
+    /// Latest value of `run.wall_s` from the perf series -- the full
+    /// wall-clock duration of the unit's most recent service run
+    /// (`ExecMainExitTimestamp - ExecMainStartTimestamp`), in seconds.
+    /// The staleness threshold is `2 * (timer_interval_s + run_wall_s)`
+    /// so a unit whose run takes longer than its timer interval is not
+    /// misreported as overdue.  `None` or `Some(0)` falls back to a
+    /// threshold of `2 * timer_interval_s`.
+    pub run_wall_s: Option<i64>,
     /// Computed health classification (green/yellow/red/unknown).
     /// Assigned by `factory::run_status_grid_queries` from `classify`.
     pub health: Health,
@@ -131,11 +140,12 @@ pub struct PondStatus {
 /// background per state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Health {
-    /// Last successful run is recent (within `2 * timer_interval_s`)
-    /// and there is no fresher failure.
+    /// Last successful run is recent (within the staleness threshold,
+    /// `2 * (timer_interval_s + run_wall_s)`) and there is no fresher
+    /// failure.
     Green,
-    /// Last successful run is older than `2 * timer_interval_s` --
-    /// the unit is overdue.
+    /// Last successful run is older than the staleness threshold,
+    /// `2 * (timer_interval_s + run_wall_s)` -- the unit is overdue.
     Yellow,
     /// Most recent terminal event was a failure
     /// (`last_err_us > last_ok_us` or no `last_ok_us` at all), or the
@@ -173,7 +183,12 @@ impl Health {
 ///      None or `last_err_us > last_ok_us` (most recent terminal
 ///      event was a failure).
 ///   3. `Yellow` when we know the interval and `last_ok_us` is older
-///      than `2 * timer_interval_s` ("overdue").
+///      than the staleness threshold `2 * (timer_interval_s +
+///      run_wall_s)` ("overdue").  Including the run's own wall-clock
+///      duration keeps a unit whose run takes longer than its timer
+///      interval from being misreported as overdue, since with
+///      `OnUnitActiveSec` the true period between successful runs is
+///      `interval + run duration`.
 ///   4. `Green` when we have a `last_ok_us` and a positive
 ///      `timer_interval_s` and the staleness check above passed.
 ///   5. `Unknown` otherwise (e.g. perf data missing, no successful
@@ -184,6 +199,7 @@ pub fn classify(
     last_err_us: Option<i64>,
     timer_active: Option<bool>,
     timer_interval_s: Option<i64>,
+    run_wall_s: Option<i64>,
 ) -> Health {
     if matches!(timer_active, Some(false)) {
         return Health::Red;
@@ -199,7 +215,13 @@ pub fn classify(
     let Some(ok_us) = last_ok_us else {
         return Health::Unknown;
     };
-    let stale_threshold_us = interval_s.saturating_mul(2).saturating_mul(1_000_000);
+    // True period between successful runs under `OnUnitActiveSec` is
+    // `interval + run duration`; allow two periods before overdue.
+    let run_wall_s = run_wall_s.filter(|&s| s > 0).unwrap_or(0);
+    let stale_threshold_us = interval_s
+        .saturating_add(run_wall_s)
+        .saturating_mul(2)
+        .saturating_mul(1_000_000);
     if now_us.saturating_sub(ok_us) > stale_threshold_us {
         Health::Yellow
     } else {
@@ -2411,6 +2433,7 @@ mod tests {
             None,
             Some(true),
             Some(600), // 10min interval -> 20min stale threshold
+            None,
         );
         assert_eq!(h, Health::Green);
     }
@@ -2423,6 +2446,38 @@ mod tests {
             None,
             Some(true),
             Some(600), // 20min threshold
+            None,
+        );
+        assert_eq!(h, Health::Yellow);
+    }
+
+    #[test]
+    fn classify_green_when_run_wall_extends_threshold() {
+        // interval 60s alone -> 2min threshold would flag this 3min-old
+        // ok as overdue, but a 120s run wall extends the period to
+        // interval+run=180s and the threshold to 2*180s=6min -> Green.
+        let h = classify(
+            NOW_US,
+            Some(NOW_US - 3 * ONE_MIN_US), // last_ok 3min ago
+            None,
+            Some(true),
+            Some(60),  // 1min interval
+            Some(120), // 2min run wall
+        );
+        assert_eq!(h, Health::Green);
+    }
+
+    #[test]
+    fn classify_yellow_ignores_zero_run_wall() {
+        // With run_wall 0, threshold is the plain 2*interval; a 3min-old
+        // ok against a 1min interval (2min threshold) is overdue.
+        let h = classify(
+            NOW_US,
+            Some(NOW_US - 3 * ONE_MIN_US),
+            None,
+            Some(true),
+            Some(60),
+            Some(0),
         );
         assert_eq!(h, Health::Yellow);
     }
@@ -2435,6 +2490,7 @@ mod tests {
             Some(NOW_US - ONE_MIN_US),
             Some(true),
             Some(600),
+            None,
         );
         assert_eq!(h, Health::Red);
     }
@@ -2447,6 +2503,7 @@ mod tests {
             Some(NOW_US - ONE_MIN_US),
             Some(true),
             Some(600),
+            None,
         );
         assert_eq!(h, Health::Red);
     }
@@ -2459,25 +2516,40 @@ mod tests {
             None,
             Some(false),
             Some(600),
+            None,
         );
         assert_eq!(h, Health::Red);
     }
 
     #[test]
     fn classify_unknown_without_interval() {
-        let h = classify(NOW_US, Some(NOW_US - ONE_MIN_US), None, Some(true), None);
+        let h = classify(
+            NOW_US,
+            Some(NOW_US - ONE_MIN_US),
+            None,
+            Some(true),
+            None,
+            None,
+        );
         assert_eq!(h, Health::Unknown);
     }
 
     #[test]
     fn classify_unknown_with_zero_interval() {
-        let h = classify(NOW_US, Some(NOW_US - ONE_MIN_US), None, Some(true), Some(0));
+        let h = classify(
+            NOW_US,
+            Some(NOW_US - ONE_MIN_US),
+            None,
+            Some(true),
+            Some(0),
+            None,
+        );
         assert_eq!(h, Health::Unknown);
     }
 
     #[test]
     fn classify_unknown_without_last_ok() {
-        let h = classify(NOW_US, None, None, Some(true), Some(600));
+        let h = classify(NOW_US, None, None, Some(true), Some(600), None);
         assert_eq!(h, Health::Unknown);
     }
 
@@ -2491,6 +2563,7 @@ mod tests {
             None,
             Some(false),
             Some(600),
+            None,
         );
         assert_eq!(h, Health::Red);
     }
@@ -2510,6 +2583,7 @@ mod tests {
             timer_active: Some(true),
             last_run_seconds_ago: Some(30),
             timer_interval_s: Some(60),
+            run_wall_s: Some(30),
             health,
         }
     }


### PR DESCRIPTION
## Problem
The status-grid self-card for `pond-selfmon@…` renders **yellow ("overdue")** even though every run reports `outcome=ok`.

`classify()` marks a unit overdue when the last successful run is older than **`2 * timer_interval_s`**. But with systemd `OnUnitActiveSec`, the next run is scheduled *interval seconds after the previous one finishes*, so the true period between successful runs is **`interval + run duration`**. selfmon has a ~1 min interval but a ~2.4 min cycle (journal-ingest + caddy-access + site rebuild/copy), so its `last_ok` is always older than the 2 min threshold → structurally always yellow.

## Fix
- Add a `run.wall_s` perf field = full service run duration (`ExecMainExitTimestamp - ExecMainStartTimestamp`), emitted by `measure-pond.sh`.
- Compute the staleness threshold as **`2 * (timer_interval_s + run_wall_s)`**, falling back to `2 * timer_interval_s` when `run.wall_s` is absent.
- The `run.wall_s` lookup is a **separate best-effort query** so a perf series written by an older `measure-pond.sh` (no column) can't wipe the other liveness fields mid-deploy.

## Companion
Requires the perf-field emitter: **jmacd/caspar.water#31** (branch `jmacd/selfmon-overdue-cadence`). The two deploy independently thanks to the resilient query.

## Tests
Added `classify_green_when_run_wall_extends_threshold` and `classify_yellow_ignores_zero_run_wall`; all 11 classify tests + render test pass; clippy + fmt clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>