### PR TITLE
sitegen: 10Y chart range + smarter interval-button visibility

### DIFF
--- a/crates/sitegen/assets/chart.js
+++ b/crates/sitegen/assets/chart.js
@@ -140,7 +140,7 @@ import { loadVega, buildMetricChartSpec, escapeField } from "./vega-shared.js";
   const ranges = [
     ["12h", 0.5], ["24h", 1], ["2d", 2], ["7d", 7],
     ["2W", 14], ["1M", 30], ["3M", 90], ["6M", 180],
-    ["1Y", 365], ["2Y", 730], ["5Y", 1826],
+    ["1Y", 365], ["2Y", 730], ["5Y", 1826], ["10Y", 3652],
   ];
   // Will be reassigned after dataSpanDays is computed below.
   let activeDays = 90;

--- a/crates/sitegen/assets/chart.js
+++ b/crates/sitegen/assets/chart.js
@@ -213,9 +213,16 @@ import { loadVega, buildMetricChartSpec, escapeField } from "./vega-shared.js";
     if (match) activeDays = match[1];
   }
 
-  // Only show buttons whose window fits within the data span (with a small
-  // margin — show the button if data covers at least 50% of the window).
-  const visibleRanges = ranges.filter(([, days]) => days <= dataSpanDays * 2);
+  // Show every button whose window fits within the data span, plus exactly
+  // one button that exceeds it (the smallest such window). This gives a single
+  // "zoom out past all the data" option without a row of redundant oversized
+  // buttons — e.g. a 6-year series shows up to 5Y plus 10Y, while a 3-month
+  // series shows up to 1M plus 3M and hides everything larger.
+  const visibleRanges = [];
+  for (const r of ranges) {
+    visibleRanges.push(r);
+    if (r[1] > dataSpanDays) break; // first (smallest) exceeding button; stop
+  }
 
   // If the current default doesn't appear in the visible set, pick the largest.
   if (!visibleRanges.some(([, days]) => days === activeDays) && visibleRanges.length > 0) {

--- a/crates/sitegen/src/shortcodes.rs
+++ b/crates/sitegen/src/shortcodes.rs
@@ -357,12 +357,12 @@ pub fn register_shortcodes(ctx: Arc<ShortcodeContext>) -> Shortcodes {
     // Client-side chart.js reads the JSON to load parquet via DuckDB-WASM.
     {
         let c = ctx.clone();
-        shortcodes.register("chart", move |_args: &ShortcodeArgs| {
+        shortcodes.register("chart", move |args: &ShortcodeArgs| {
             render_chart(
                 &c.datafiles,
                 &c.metric_registry,
                 &c.metric_captions,
-                c.default_range.as_deref(),
+                args.get_str("range").or(c.default_range.as_deref()),
                 c.explore_url.as_deref(),
                 &c.annotations,
             )
@@ -402,7 +402,7 @@ pub fn register_shortcodes(ctx: Arc<ShortcodeContext>) -> Shortcodes {
                     &c.datafiles,
                     &c.metric_registry,
                     &c.metric_captions,
-                    c.default_range.as_deref(),
+                    args.get_str("range").or(c.default_range.as_deref()),
                     c.explore_url.as_deref(),
                     &c.annotations,
                 ),

--- a/testsuite/browser/test.sh
+++ b/testsuite/browser/test.sh
@@ -157,8 +157,9 @@ echo ""
 echo "=== Generating overlay site via test 305 ==="
 bash "${TESTSUITE_DIR}/run-test.sh" "${RUN_TEST_EXTRA_ARGS[@]}" --output "${OVERLAY_OUTPUT}" 305
 
-if [[ ! -f "${OVERLAY_OUTPUT}/analysis/pump-cycles.html" ]]; then
-    echo "ERROR: Overlay site generation failed — no pump-cycles.html"
+if [[ ! -f "${OVERLAY_OUTPUT}/analysis/drawdown-by-month.html" \
+      || ! -f "${OVERLAY_OUTPUT}/analysis/horner-by-month.html" ]]; then
+    echo "ERROR: Overlay site generation failed — missing analysis overlay pages"
     exit 1
 fi
 echo "  ✓ Overlay site generated"


### PR DESCRIPTION
## Summary

Two small sitegen chart improvements, motivated by adding a 10-year monthly
meter-usage history to the Caspar Water site.

- **10Y range button** (`chart.js`): adds a 10-year (3652-day) duration button
  so decade-spanning, low-frequency series (e.g. monthly meter history) can
  display all of their data.
- **Per-plot `{{ viz range= }}` override** (`shortcodes.rs`): `{{ chart }}` and
  `{{ viz }}` now accept a `range=` argument that overrides the site-wide
  `default_range` for a single plot, without changing the global default for
  every chart.
- **Smarter interval-button visibility** (`chart.js`): replaces the fuzzy
  `days <= dataSpanDays * 2` filter (which could surface several oversized
  buttons) with: show every button that fits the data span, plus exactly one
  button that exceeds it (the smallest such window). So the 10Y button only
  appears for series with ≥ ~5 years of data, and most charts show a single
  "zoom past all data" option instead of a row of redundant oversized buttons.

## Testing

- Rebuilt the debug `pond` binary and regenerated the Caspar Water site locally.
- Verified the two history pages pin a 10Y default window and render (temporal
  x-axis), while metric charts (e.g. well-depth) keep their adaptive default.
- Simulated the visible-range logic across data spans (2d, 3mo, 1y, 4y, 5y, 6y,
  9.5y, 12y): 10Y appears only at ≥5 years; each span shows exactly one button
  beyond the data.

🤖 Generated with Copilot CLI