### PR TITLE
sitegen: zero-anchored, always-rendered y-axis for rate metrics

### DIFF
--- a/crates/sitegen/assets/chart.js
+++ b/crates/sitegen/assets/chart.js
@@ -34,10 +34,11 @@ import { loadVega, buildMetricChartSpec, escapeField } from "./vega-shared.js";
 
   // Optional metric instrument-kind registry, emitted by sitegen alongside
   // the chart-data manifest.  Keys are `<param>.<unit>` (chart-grouping
-  // suffix); values are "counter" | "updowncounter" | "gauge".  Counter
-  // metrics are plotted as a first-difference rate per scope; everything
-  // else is plotted as-is.  Missing or empty registry => all metrics treated
-  // as gauges (no transforms), matching legacy behaviour.
+  // suffix); values are "counter" | "updowncounter" | "gauge" | "rate".
+  // Counter metrics are plotted as a first-difference rate per scope; "rate"
+  // metrics plot as-is but with a zero-anchored, always-rendered y-axis;
+  // everything else is plotted as-is.  Missing or empty registry => all
+  // metrics treated as gauges (no transforms), matching legacy behaviour.
   const registryEl = document.querySelector('script.chart-registry[type="application/json"]');
   let metricKinds = {};
   if (registryEl) {
@@ -1137,6 +1138,10 @@ import { loadVega, buildMetricChartSpec, escapeField } from "./vega-shared.js";
       // reflects current activity (events/second).  Updowncounters and
       // gauges plot as-is.
       const isCounter = kindFor(chartKey) === "counter";
+      // Rate/flow gauges (e.g. usage.gpm): plotted as-is like any gauge, but
+      // zero is a meaningful baseline, so anchor the y-axis at 0 and keep it
+      // rendered even when only one line has data in the window.
+      const yZero = kindFor(chartKey) === "rate";
       const allCols = [];
       for (const s of series) {
         if (s.avg) allCols.push(s.avg);
@@ -1197,6 +1202,7 @@ import { loadVega, buildMetricChartSpec, escapeField } from "./vega-shared.js";
         yLabel,
         height: chartHeight,
         byteAxis: isBytes,
+        yZero,
         theme: chartTheme,
         annotations: annotationBands,
       });

--- a/crates/sitegen/assets/vega-shared.js
+++ b/crates/sitegen/assets/vega-shared.js
@@ -116,12 +116,36 @@ export function buildMetricChartSpec(opts) {
     yLabel,
     height = 300,
     byteAxis = false,
+    yZero = false,
     theme,
     annotations = [],
   } = opts;
   const yAxis = { grid: true, title: yLabel || null };
   if (byteAxis) yAxis.format = "~s";
+  // For rate/flow metrics (`yZero`), zero is a meaningful baseline, so anchor
+  // the y scale at 0 for every series mapped to it.  Other charts plot
+  // arbitrary-scale readings and keep the fitted-extent default (zero: false).
+  const yScale = yZero ? { zero: true } : null;
   const layers = [];
+
+  // Dedicated invisible layer that always carries the y-axis (and, for rate
+  // charts, pins 0 into the shared domain).  Without it the axis is bound to
+  // the first data layer, so it vanishes whenever that series has no points in
+  // the visible window (e.g. a short recent window where only one of two lines
+  // has data) -- taking the zero reference with it.  This layer always has one
+  // datum, so the axis renders regardless of which series is populated.  Only
+  // emitted for `yZero` charts to avoid forcing 0 onto arbitrary-scale charts.
+  let yAssigned = false;
+  if (yZero) {
+    layers.push({
+      data: { values: [{ __axis0: 0 }] },
+      mark: { type: "rule", opacity: 0, clip: true },
+      encoding: {
+        y: { field: "__axis0", type: "quantitative", scale: yScale, axis: yAxis },
+      },
+    });
+    yAssigned = true;
+  }
 
   // Optional annotation bands: a secondary interval dataset (e.g. pump state /
   // leak risk periods) drawn as full-height shaded rects behind the series.
@@ -143,13 +167,12 @@ export function buildMetricChartSpec(opts) {
     });
   }
 
-  let yAssigned = false;
   for (const s of series) {
     if (s.min && s.max) {
       layers.push({
         mark: { type: "area", color: s.color, opacity: 0.15, clip: true, invalid: null },
         encoding: {
-          y: { field: escapeField(s.min), type: "quantitative", axis: yAssigned ? null : yAxis },
+          y: { field: escapeField(s.min), type: "quantitative", axis: yAssigned ? null : yAxis, ...(yScale ? { scale: yScale } : {}) },
           y2: { field: escapeField(s.max) },
         },
       });
@@ -159,7 +182,7 @@ export function buildMetricChartSpec(opts) {
       layers.push({
         mark: { type: "line", color: s.color, strokeWidth: 1.5, clip: true, invalid: null },
         encoding: {
-          y: { field: escapeField(s.avg), type: "quantitative", axis: yAssigned ? null : yAxis },
+          y: { field: escapeField(s.avg), type: "quantitative", axis: yAssigned ? null : yAxis, ...(yScale ? { scale: yScale } : {}) },
         },
       });
       yAssigned = true;

--- a/crates/sitegen/src/config.rs
+++ b/crates/sitegen/src/config.rs
@@ -92,6 +92,9 @@ pub struct SiteConfig {
     ///   counter         -> first-difference per scope, plot rate
     ///   updowncounter   -> plot value as-is (today; future: sum
     ///                       across scopes for spatial aggregation)
+    ///   rate            -> plot value as-is, but with a zero-anchored,
+    ///                       always-rendered y-axis (for flow/rate gauges
+    ///                       such as `usage.gpm` where 0 is meaningful)
     ///   gauge / missing -> plot value as-is (latest/avg)
     ///
     /// The canonical source of truth for each project should be a


### PR DESCRIPTION
Add a "rate" metric-registry instrument kind. Rate/flow gauges (e.g. usage.gpm) plot as-is like any gauge, but zero is a meaningful baseline, so buildMetricChartSpec now emits an invisible, always-present layer that carries the y-axis and pins 0 into the shared y domain.

This keeps the y-axis and its zero reference rendered even when only one of several lines has data in the visible window (e.g. a short recent window where the monthly metered read has not landed yet but the daily modeled estimate has). Previously the axis was bound to the first data layer and vanished whenever that series was empty, taking the zero reference with it.

Non-rate charts (arbitrary-scale depth/pressure readings) are unchanged.