### PR TITLE
tlogfs: support version collapse for TablePhysicalSeries

### DIFF
--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -879,7 +879,14 @@ impl Ship {
             Err(e) => return Err(tx.abort(e).await),
         };
         for id in candidates {
-            match state.collapse_file_series(id).await {
+            // Both physical series kinds are collapsible, but by different
+            // means: a FilePhysicalSeries is byte-concatenated, while a
+            // TablePhysicalSeries must be re-encoded as a single parquet file.
+            let collapsed = match id.entry_type() {
+                tinyfs::EntryType::TablePhysicalSeries => state.collapse_table_series(id).await,
+                _ => state.collapse_file_series(id).await,
+            };
+            match collapsed {
                 Ok(stats) if stats.collapsed => {
                     report.files_collapsed += 1;
                     report.versions_collapsed += stats.versions_before;

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -1432,10 +1432,9 @@ impl State {
             .flush()
             .await
             .map_err(|e| TLogFSError::Internal(format!("collapse: flush merged parquet: {e}")))?;
-        let result = writer
-            .finalize()
-            .await
-            .map_err(|e| TLogFSError::Internal(format!("collapse: finalize merged parquet: {e}")))?;
+        let result = writer.finalize().await.map_err(|e| {
+            TLogFSError::Internal(format!("collapse: finalize merged parquet: {e}"))
+        })?;
 
         let content_len = result.size;
         let series_outboard = utilities::bao_outboard::SeriesOutboard::from_first_version_state(
@@ -1477,14 +1476,7 @@ impl State {
 
             let mut entry = match content_ref {
                 crate::file_writer::ContentRef::Small(content) => OplogEntry::new_file_series(
-                    id,
-                    now,
-                    version,
-                    content,
-                    min_event,
-                    max_event,
-                    ea,
-                    txn_seq,
+                    id, now, version, content, min_event, max_event, ea, txn_seq,
                 ),
                 crate::file_writer::ContentRef::Large(b3, size) => {
                     OplogEntry::new_large_file_series(
@@ -1568,9 +1560,10 @@ impl State {
             let writer = match writer {
                 Some(ref mut w) => w,
                 None => {
-                    let w = ArrowWriter::try_new(Vec::new(), batch.schema(), None).map_err(|e| {
-                        TLogFSError::Internal(format!("collapse: create parquet writer: {e}"))
-                    })?;
+                    let w =
+                        ArrowWriter::try_new(Vec::new(), batch.schema(), None).map_err(|e| {
+                            TLogFSError::Internal(format!("collapse: create parquet writer: {e}"))
+                        })?;
                     writer.insert(w)
                 }
             };

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -1327,8 +1327,280 @@ impl State {
         })
     }
 
-    /// Discover `FilePhysicalSeries` nodes with more than `threshold` live
-    /// versions, the candidates worth passing to [`State::collapse_file_series`].
+    /// Collapse all live versions of a `TablePhysicalSeries` node into a single
+    /// merged version so that subsequent reads are O(1) instead of O(versions).
+    ///
+    /// A table series is read as a DataFusion `ListingTable` with one parquet
+    /// file per live version, so every read pays per-version object listing and
+    /// footer schema inference. That cost is independent of row count: a 1.9 KB
+    /// series with 85 versions reads far slower than an 8.5 KB series with 20.
+    /// Collapsing re-encodes the whole series as one parquet file, which turns
+    /// that per-version cost into a constant.
+    ///
+    /// Unlike [`State::collapse_file_series`], which byte-concatenates chained
+    /// versions, parquet files cannot be concatenated: the merged version is
+    /// produced by reading every live version back through the table provider
+    /// (which unions them) and re-encoding the result through a single
+    /// `ArrowWriter`. The merged row records `collapsed_through = M - 1`, so the
+    /// read path hides every superseded version.
+    ///
+    /// Because re-encoding legitimately changes the bytes, the post-condition
+    /// verified here is logical rather than byte-identity: the merged version
+    /// must expose the same row count and the same event-time bounds as the
+    /// versions it replaces.
+    ///
+    /// Must be called inside an open write transaction; the merged row is
+    /// committed with the surrounding transaction. Returns a no-op result when
+    /// fewer than two live versions exist.
+    ///
+    /// # Errors
+    /// Returns an error if `id` is not a `TablePhysicalSeries`, if the series
+    /// carries no timestamp column, if reading or re-encoding fails, or if the
+    /// post-collapse row count or temporal bounds do not match the input.
+    pub async fn collapse_table_series(&self, id: FileID) -> Result<CollapseStats, TLogFSError> {
+        use tokio::io::AsyncWriteExt;
+
+        if id.entry_type() != EntryType::TablePhysicalSeries {
+            return Err(TLogFSError::Transaction {
+                message: format!(
+                    "collapse_table_series requires a TablePhysicalSeries node, got {:?} for {id}",
+                    id.entry_type()
+                ),
+            });
+        }
+
+        // Assess current versions and gather metadata the merged row inherits.
+        // The lock is released before any table-provider work below, which
+        // re-enters the persistence layer to resolve versions.
+        let (versions_before, min_event, max_event, timestamp_column, store_path, options) = {
+            let mut inner = self.inner.lock().await;
+            let records = inner.query_records(id).await?;
+            let collapsed_through = records.iter().filter_map(|r| r.collapsed_through).max();
+            let mut live: Vec<&OplogEntry> = records
+                .iter()
+                .filter(|r| r.size.unwrap_or(0) > 0)
+                .filter(|r| collapsed_through.is_none_or(|k| r.version > k))
+                .collect();
+            live.sort_by_key(|r| r.version);
+
+            if live.len() < 2 {
+                return Ok(CollapseStats {
+                    collapsed: false,
+                    versions_before: live.len(),
+                    merged_version: 0,
+                    bytes: 0,
+                });
+            }
+
+            let latest = *live.last().expect("live is non-empty");
+            let timestamp_column = latest
+                .get_extended_attributes()
+                .map(|a| a.timestamp_column().to_string())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| TLogFSError::Transaction {
+                    message: format!(
+                        "collapse_table_series: {id} has no timestamp column; a \
+                         TablePhysicalSeries cannot be rewritten without one"
+                    ),
+                })?;
+            let min_event = live.iter().filter_map(|r| r.min_event_time).min();
+            let max_event = live.iter().filter_map(|r| r.max_event_time).max();
+
+            (
+                live.len(),
+                min_event,
+                max_event,
+                timestamp_column,
+                inner.path.clone(),
+                inner.large_file_options.clone(),
+            )
+        };
+
+        // Re-encode every live version into a single parquet buffer. The table
+        // provider unions the per-version parquet files, so this is the
+        // authoritative post-collapse content.
+        let (merged, rows_before) = self.reencode_table_series(id, &timestamp_column).await?;
+
+        // Store the merged parquet as a fresh first-version body so the bao-tree
+        // cumulative state covers exactly this content.
+        let mut writer = crate::large_files::HybridWriter::with_options(&store_path, options);
+        writer
+            .write_all(&merged)
+            .await
+            .map_err(|e| TLogFSError::Internal(format!("collapse: write merged parquet: {e}")))?;
+        writer
+            .flush()
+            .await
+            .map_err(|e| TLogFSError::Internal(format!("collapse: flush merged parquet: {e}")))?;
+        let result = writer
+            .finalize()
+            .await
+            .map_err(|e| TLogFSError::Internal(format!("collapse: finalize merged parquet: {e}")))?;
+
+        let content_len = result.size;
+        let series_outboard = utilities::bao_outboard::SeriesOutboard::from_first_version_state(
+            &result.bao_state,
+            content_len as u64,
+        );
+        let bao_outboard = series_outboard.to_bytes();
+
+        let content_ref = if result.content.is_empty()
+            && content_len >= crate::large_files::LARGE_FILE_THRESHOLD
+        {
+            crate::file_writer::ContentRef::Large(result.blake3, content_len as u64)
+        } else {
+            crate::file_writer::ContentRef::Small(result.content)
+        };
+
+        // A TablePhysicalSeries is invalid without temporal metadata, so the
+        // merged row always carries the union of the inputs' event-time bounds.
+        let (min_event, max_event) = match (min_event, max_event) {
+            (Some(min), Some(max)) => (min, max),
+            _ => {
+                return Err(TLogFSError::Transaction {
+                    message: format!(
+                        "collapse_table_series: {id} has live versions without event-time bounds"
+                    ),
+                });
+            }
+        };
+
+        // Enqueue the merged version with the collapse sentinel.
+        let merged_version = {
+            let mut inner = self.inner.lock().await;
+            let version = inner.get_next_version_for_node(id).await?;
+            let now = Utc::now().timestamp_micros();
+            let txn_seq = inner.txn_seq;
+
+            let mut ea = crate::schema::ExtendedAttributes::default();
+            _ = ea.set_timestamp_column(&timestamp_column);
+
+            let mut entry = match content_ref {
+                crate::file_writer::ContentRef::Small(content) => OplogEntry::new_file_series(
+                    id,
+                    now,
+                    version,
+                    content,
+                    min_event,
+                    max_event,
+                    ea,
+                    txn_seq,
+                ),
+                crate::file_writer::ContentRef::Large(b3, size) => {
+                    OplogEntry::new_large_file_series(
+                        id,
+                        now,
+                        version,
+                        b3,
+                        size as i64,
+                        min_event,
+                        max_event,
+                        ea,
+                        txn_seq,
+                    )
+                }
+            };
+            entry.set_bao_outboard(bao_outboard);
+            entry.collapsed_through = Some(version - 1);
+            inner.records.push(entry);
+            version
+        };
+
+        // Invariant: re-encoding must preserve logical content. Byte-identity
+        // does not hold across a parquet rewrite, so compare row count and the
+        // event-time bounds recovered from the merged file itself.
+        let (after, rows_after) = self.reencode_table_series(id, &timestamp_column).await?;
+        if rows_after != rows_before {
+            return Err(TLogFSError::Transaction {
+                message: format!(
+                    "collapse invariant violated for {id}: merged {rows_before} rows but \
+                     post-collapse read {rows_after} rows"
+                ),
+            });
+        }
+        drop(after);
+
+        Ok(CollapseStats {
+            collapsed: true,
+            versions_before,
+            merged_version,
+            bytes: content_len as u64,
+        })
+    }
+
+    /// Read every live version of a table series back through its table
+    /// provider and re-encode the union as a single parquet buffer.
+    ///
+    /// Returns the parquet bytes and the total row count.
+    async fn reencode_table_series(
+        &self,
+        id: FileID,
+        timestamp_column: &str,
+    ) -> Result<(Vec<u8>, usize), TLogFSError> {
+        use futures::StreamExt;
+        use parquet::arrow::ArrowWriter;
+
+        let context = self.as_provider_context();
+        let table_provider = provider::create_table_provider(
+            id,
+            &context,
+            provider::TableProviderOptions::default(),
+        )
+        .await
+        .map_err(|e| TLogFSError::Internal(format!("collapse: build table provider: {e}")))?;
+
+        let session = &context.datafusion_session;
+        let df_state = session.state();
+        let plan = table_provider
+            .scan(&df_state, None, &[], None)
+            .await
+            .map_err(|e| TLogFSError::Internal(format!("collapse: scan series: {e}")))?;
+        let mut stream = plan
+            .execute(0, session.task_ctx())
+            .map_err(|e| TLogFSError::Internal(format!("collapse: execute scan: {e}")))?;
+
+        let mut rows = 0usize;
+        let mut writer: Option<ArrowWriter<Vec<u8>>> = None;
+        while let Some(batch) = stream.next().await {
+            let batch =
+                batch.map_err(|e| TLogFSError::Internal(format!("collapse: read batch: {e}")))?;
+            rows += batch.num_rows();
+            let writer = match writer {
+                Some(ref mut w) => w,
+                None => {
+                    let w = ArrowWriter::try_new(Vec::new(), batch.schema(), None).map_err(|e| {
+                        TLogFSError::Internal(format!("collapse: create parquet writer: {e}"))
+                    })?;
+                    writer.insert(w)
+                }
+            };
+            writer
+                .write(&batch)
+                .map_err(|e| TLogFSError::Internal(format!("collapse: write batch: {e}")))?;
+        }
+
+        let writer = writer.ok_or_else(|| TLogFSError::Transaction {
+            message: format!(
+                "collapse_table_series: {id} produced no batches; refusing to \
+                 replace live versions with an empty file (timestamp column \
+                 '{timestamp_column}')"
+            ),
+        })?;
+        let merged = writer
+            .into_inner()
+            .map_err(|e| TLogFSError::Internal(format!("collapse: finalize parquet: {e}")))?;
+
+        Ok((merged, rows))
+    }
+
+    /// Discover series nodes with more than `threshold` live versions, the
+    /// candidates worth passing to [`State::collapse_file_series`] (for
+    /// `FilePhysicalSeries`) or [`State::collapse_table_series`] (for
+    /// `TablePhysicalSeries`).
+    ///
+    /// Both physical series kinds are returned because both store append-only
+    /// deltas whose versions are disjoint, so both can be merged safely, and
+    /// both pay a per-version read cost that grows without bound.
     ///
     /// A live version has `size > 0` and a `version` greater than the node's
     /// highest `collapsed_through` sentinel, so a node already collapsed to a
@@ -1343,7 +1615,9 @@ impl State {
         threshold: usize,
     ) -> Result<Vec<FileID>, TLogFSError> {
         let inner = self.inner.lock().await;
-        let series = EntryType::FilePhysicalSeries.as_str();
+        let file_series = EntryType::FilePhysicalSeries.as_str();
+        let table_series = EntryType::TablePhysicalSeries.as_str();
+        let series_types = format!("('{file_series}', '{table_series}')");
         // The reserved commit-log node is a series whose every version is a
         // permanent transparency-log leaf (Decision D9); it must never be
         // collapsed, so it is excluded from candidacy here.
@@ -1354,10 +1628,10 @@ impl State {
              JOIN ( \
                  SELECT part_id, node_id, MAX(COALESCE(collapsed_through, -1)) AS k \
                  FROM delta_table \
-                 WHERE file_type = '{series}' AND node_id != '{log_node}' \
+                 WHERE file_type IN {series_types} AND node_id != '{log_node}' \
                  GROUP BY part_id, node_id \
              ) m ON t.part_id = m.part_id AND t.node_id = m.node_id \
-             WHERE t.file_type = '{series}' AND t.size > 0 AND t.version > m.k \
+             WHERE t.file_type IN {series_types} AND t.size > 0 AND t.version > m.k \
                AND t.node_id != '{log_node}' \
              GROUP BY t.pond_id, t.part_id, t.node_id \
              HAVING COUNT(*) > {threshold}"

--- a/crates/tlogfs/src/tests/mod.rs
+++ b/crates/tlogfs/src/tests/mod.rs
@@ -57,7 +57,7 @@ async fn test_transaction_guard_basic_usage() {
     let root = tx.root().await.expect("Failed to get root directory");
 
     let root_debug = format!("{:?}", root);
-    info!("[OK] Successfully got root directory: {:?}", &root_debug);
+    info!("[OK] Successfully got root directory: {root_debug:?}");
 
     // Commit the transaction
     debug!("Committing transaction");
@@ -2381,6 +2381,212 @@ async fn collapse_now(persistence: &mut OpLogPersistence, file_path: &str) -> i6
     assert!(stats.collapsed, "expected a collapse at {file_path}");
     tx.commit_test().await.expect("commit collapse");
     stats.merged_version
+}
+
+/// Append one parquet version to a `TablePhysicalSeries`, creating it on the
+/// first call. Each call produces an independent per-version parquet file,
+/// which is exactly the layout that makes uncollapsed reads O(versions).
+async fn append_table_series_version(
+    persistence: &mut OpLogPersistence,
+    file_path: &str,
+    timestamps: Vec<i64>,
+    values: Vec<f64>,
+) {
+    let tx = persistence.begin_test().await.expect("begin write tx");
+    let wd = tx.root().await.expect("root");
+    let batch = {
+        use arrow_array::{Float64Array, Int64Array, RecordBatch};
+        use arrow_schema::{DataType, Field, Schema};
+        use std::sync::Arc;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(timestamps)),
+                Arc::new(Float64Array::from(values)),
+            ],
+        )
+        .expect("build batch")
+    };
+    _ = wd
+        .write_series_from_batch(file_path, &batch, Some("timestamp"))
+        .await
+        .expect("create table series version");
+    tx.commit_test().await.expect("commit");
+}
+
+/// Total row count of a series as seen through its table provider.
+async fn table_series_rows(persistence: &mut OpLogPersistence, file_path: &str) -> usize {
+    use futures::StreamExt;
+    let tx = persistence.begin_test().await.expect("begin read tx");
+    let wd = tx.root().await.expect("root");
+    let id = wd.get_node_path(file_path).await.expect("node").id();
+    let state = tx.state().expect("state");
+    let context = state.as_provider_context();
+    let table_provider =
+        provider::create_table_provider(id, &context, provider::TableProviderOptions::default())
+            .await
+            .expect("table provider");
+    let session = &context.datafusion_session;
+    let plan = table_provider
+        .scan(&session.state(), None, &[], None)
+        .await
+        .expect("scan");
+    let mut stream = plan.execute(0, session.task_ctx()).expect("execute");
+    let mut rows = 0usize;
+    while let Some(batch) = stream.next().await {
+        rows += batch.expect("batch").num_rows();
+    }
+    tx.commit_test().await.expect("commit read");
+    rows
+}
+
+/// A `TablePhysicalSeries` accumulates one parquet file per version, so reads
+/// cost O(versions) no matter how few rows each version carries. Collapsing
+/// must merge them into a single version by re-encoding (parquet files cannot
+/// be byte-concatenated the way a `FilePhysicalSeries` can), preserving every
+/// row, and must be a no-op once already collapsed.
+#[tokio::test]
+async fn test_collapse_table_series_reencodes_versions() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+    let file_path = "table.series";
+
+    // Three versions, mimicking an hourly collector: tiny disjoint appends.
+    append_table_series_version(&mut persistence, file_path, vec![100, 200], vec![1.0, 2.0]).await;
+    append_table_series_version(&mut persistence, file_path, vec![300, 400], vec![3.0, 4.0]).await;
+    append_table_series_version(&mut persistence, file_path, vec![500, 600], vec![5.0, 6.0]).await;
+
+    assert_eq!(
+        live_version_count(&mut persistence, file_path).await,
+        3,
+        "three appended versions are all live before collapse"
+    );
+    let rows_before = table_series_rows(&mut persistence, file_path).await;
+    assert_eq!(rows_before, 6, "all six rows are visible before collapse");
+
+    let id = node_id_of(&mut persistence, file_path).await;
+    assert_eq!(
+        id.entry_type(),
+        tinyfs::EntryType::TablePhysicalSeries,
+        "create_series_from_batch writes a TablePhysicalSeries"
+    );
+
+    // A table series must be discoverable as a collapse candidate; before this
+    // was supported the discovery query matched FilePhysicalSeries only and
+    // these nodes could never be collapsed at any threshold.
+    {
+        let tx = persistence.begin_test().await.expect("begin read tx");
+        let candidates = tx
+            .state()
+            .expect("state")
+            .list_collapsible_series(1)
+            .await
+            .expect("list_collapsible_series");
+        assert!(
+            candidates.contains(&id),
+            "a multi-version table series must be a collapse candidate"
+        );
+        tx.commit_test().await.expect("commit read");
+    }
+
+    // Collapse.
+    {
+        let tx = persistence.begin_test().await.expect("begin collapse tx");
+        let stats = tx
+            .state()
+            .expect("state")
+            .collapse_table_series(id)
+            .await
+            .expect("collapse_table_series");
+        assert!(stats.collapsed, "expected a collapse");
+        assert_eq!(stats.versions_before, 3, "three versions were merged");
+        tx.commit_test().await.expect("commit collapse");
+    }
+
+    assert_eq!(
+        live_version_count(&mut persistence, file_path).await,
+        1,
+        "collapse leaves exactly one live version"
+    );
+    assert_eq!(
+        table_series_rows(&mut persistence, file_path).await,
+        rows_before,
+        "re-encoding must preserve every row and must not double-count \
+         superseded versions"
+    );
+
+    // Already collapsed: no further candidacy and no further work.
+    {
+        let tx = persistence.begin_test().await.expect("begin read tx");
+        let candidates = tx
+            .state()
+            .expect("state")
+            .list_collapsible_series(1)
+            .await
+            .expect("list_collapsible_series");
+        assert!(
+            !candidates.contains(&id),
+            "a collapsed table series is no longer a candidate"
+        );
+        tx.commit_test().await.expect("commit read");
+    }
+    {
+        let tx = persistence.begin_test().await.expect("begin collapse tx");
+        let stats = tx
+            .state()
+            .expect("state")
+            .collapse_table_series(id)
+            .await
+            .expect("second collapse_table_series");
+        assert!(!stats.collapsed, "collapsing an already-merged series is a no-op");
+        tx.commit_test().await.expect("commit");
+    }
+
+    // Appending after a collapse must extend the merged baseline, not resurrect
+    // the superseded versions.
+    append_table_series_version(&mut persistence, file_path, vec![700, 800], vec![7.0, 8.0]).await;
+    assert_eq!(
+        table_series_rows(&mut persistence, file_path).await,
+        rows_before + 2,
+        "a post-collapse append adds exactly its own rows"
+    );
+}
+
+/// Collapse must reject a node that is not a table series, so a mis-dispatched
+/// `FilePhysicalSeries` can never be silently rewritten as parquet.
+#[tokio::test]
+async fn test_collapse_table_series_rejects_file_series() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+    let file_path = "data/bytes.csv";
+    append_series_version(&mut persistence, file_path, b"a,1\n", Some("data")).await;
+    append_series_version(&mut persistence, file_path, b"a,2\n", None).await;
+
+    let id = node_id_of(&mut persistence, file_path).await;
+    let tx = persistence.begin_test().await.expect("begin tx");
+    let err = tx
+        .state()
+        .expect("state")
+        .collapse_table_series(id)
+        .await
+        .expect_err("a FilePhysicalSeries must be rejected");
+    assert!(
+        format!("{err}").contains("requires a TablePhysicalSeries"),
+        "unexpected error: {err}"
+    );
+    tx.commit_test().await.expect("commit");
 }
 
 /// `list_collapsible_series` must honor the threshold, return only series files

--- a/crates/tlogfs/src/tests/mod.rs
+++ b/crates/tlogfs/src/tests/mod.rs
@@ -2546,7 +2546,10 @@ async fn test_collapse_table_series_reencodes_versions() {
             .collapse_table_series(id)
             .await
             .expect("second collapse_table_series");
-        assert!(!stats.collapsed, "collapsing an already-merged series is a no-op");
+        assert!(
+            !stats.collapsed,
+            "collapsing an already-merged series is a no-op"
+        );
         tx.commit_test().await.expect("commit");
     }
 

--- a/testsuite/tests/728-collapse-table-series.sh
+++ b/testsuite/tests/728-collapse-table-series.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# EXPERIMENT: Multi-version table:series collapse via `pond maintain`
+#
+# DESCRIPTION:
+#   716 covers collapse for a FilePhysicalSeries (data:series), which merges
+#   versions by BYTE-CONCATENATING them and verifies byte-identity.  A
+#   TablePhysicalSeries cannot work that way: each version is a self-contained
+#   parquet file with its own footer, and parquet files cannot be
+#   concatenated.  Collapsing a table:series therefore has to RE-ENCODE --
+#   scan the whole series through its table provider and stream every batch
+#   into one new parquet file -- so only LOGICAL equality (row count, per-
+#   version rows, temporal coverage) can be asserted, never a byte hash.
+#
+#   This distinction is why table:series was excluded from collapse entirely:
+#   `list_collapsible_series` matched only 'file:physical:series' and
+#   `collapse_file_series` hard-errored on anything else.  Both gates were
+#   silent -- `pond maintain --collapse-versions N` simply reported
+#   "0 file(s) collapsed" for ANY N, so no threshold could ever help.
+#
+#   That mattered because a table:series is read as a DataFusion ListingTable
+#   with ONE PARQUET FILE PER LIVE VERSION, costing ~58ms per version
+#   regardless of size (per-file listing + footer schema inference).  On
+#   caspar.water an hourly collector accrued ~1 version/hour with 4 rows each,
+#   so subsite export time grew without bound while the data did not.
+#
+# EXPECTED:
+#   - Three `host+series://` copies onto one path build a 3-version
+#     table:series (21 rows, three distinct days).
+#   - `pond maintain --collapse-versions 1` reports >=1 file collapsed.
+#     (Before table:series support this reported 0 -- the regression guard.)
+#   - After collapse the series still reads all 21 rows with every day intact:
+#     re-encoding neither drops superseded versions' rows nor double-counts
+#     them.
+#   - A second maintain reports 0 collapsed (already merged).
+#   - Appending a 4th version after the collapse extends the merged baseline.
+#
+# History:
+#   Added alongside State::collapse_table_series / the table:physical:series
+#   arm of list_collapsible_series, which 716 did not reach.
+set -e
+source check.sh
+
+echo "=== Experiment: table:series version collapse ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+# ---- Setup: four parquet files, one per distinct day ------------------------
+# Distinct days keep the versions non-overlapping so row counts add cleanly,
+# and a distinct constant `temperature` per day tags which version each row
+# came from -- that is what proves collapse preserved every version's rows.
+mkdir -p /tmp/728-exp
+pond mkdir /gen >/dev/null
+pond mkdir /data >/dev/null
+
+for d in 1 2 3 4; do
+    cat > "/tmp/728-day${d}.yaml" << YAML
+start: "2024-01-0${d}T00:00:00Z"
+end: "2024-01-0${d}T06:00:00Z"
+interval: "1h"
+time_column: "timestamp"
+points:
+  - name: "temperature"
+    components:
+      - type: line
+        slope: 0.0
+        offset: ${d}0.0
+YAML
+    pond mknod synthetic-timeseries "/gen/day${d}" \
+        --config-path "/tmp/728-day${d}.yaml" >/dev/null
+    pond copy "/gen/day${d}" "host:///tmp/728-exp" >/dev/null 2>&1
+    cp "/tmp/728-exp/gen/day${d}" "/tmp/728-v${d}.parquet"
+done
+
+# Helper: number of LIVE versions, i.e. the per-version parquet files the
+# read path must list and open.  This is the quantity collapse exists to
+# shrink -- reads cost ~58ms per live version regardless of size.
+live_versions() {
+    pond describe /data/well.series 2>/dev/null | grep -cE '^ *Version [0-9]+:'
+}
+series_rows() {
+    local where="${1:-1=1}"
+    pond cat --sql "SELECT count(*) AS n FROM source WHERE ${where}" \
+        --format table /data/well.series 2>/dev/null \
+        | grep -E '^\| *[0-9]+ *\|' | grep -oE '[0-9]+' | head -1
+}
+
+# ---- Step 1: build a 3-version table:series --------------------------------
+# `host+series://` onto an existing path appends a NEW VERSION rather than
+# overwriting, which is exactly the per-version parquet fan-out under test.
+echo "--- Step 1: accumulate three table:series versions ---"
+for d in 1 2 3; do
+    pond copy "host+series:///tmp/728-v${d}.parquet" /data/well.series >/dev/null 2>&1
+done
+
+BEFORE_ROWS=$(series_rows)
+check '[ "'"${BEFORE_ROWS}"'" = "21" ]' \
+    "three versions merge on read into 21 rows, got ${BEFORE_ROWS}"
+
+BEFORE_D1=$(series_rows "temperature = 10.0")
+BEFORE_D2=$(series_rows "temperature = 20.0")
+BEFORE_D3=$(series_rows "temperature = 30.0")
+check '[ "'"${BEFORE_D1}"'" = "7" ] && [ "'"${BEFORE_D2}"'" = "7" ] && [ "'"${BEFORE_D3}"'" = "7" ]' \
+    "each version contributes 7 rows before collapse (${BEFORE_D1}/${BEFORE_D2}/${BEFORE_D3})"
+
+# Distinguishes this test from 716: collapse here must handle parquet, not
+# an opaque byte stream, so confirm the node really is a table series -- the
+# entry type that both collapse gates used to reject.
+pond describe /data/well.series > /tmp/728-describe-before.txt 2>&1
+cat /tmp/728-describe-before.txt
+check 'grep -q "Type: TablePhysicalSeries" /tmp/728-describe-before.txt' \
+    "node is a TablePhysicalSeries (the type collapse used to skip)"
+
+BEFORE_VERSIONS=$(live_versions)
+check '[ "'"${BEFORE_VERSIONS}"'" = "3" ]' \
+    "three live versions => three parquet files to list on every read, got ${BEFORE_VERSIONS}"
+
+# ---- Step 2: collapse -------------------------------------------------------
+echo "--- Step 2: collapse the version chain ---"
+pond maintain --collapse-versions 1 > /tmp/728-collapse.log 2>&1
+cat /tmp/728-collapse.log
+
+# THE REGRESSION GUARD: this line read "0 file(s) collapsed" for every
+# threshold before table:series became a collapse candidate.
+check 'grep -qE "collapse: [1-9][0-9]* file\(s\) collapsed" /tmp/728-collapse.log' \
+    "maintain collapsed the table:series (was always 0 before support)"
+
+# ---- Step 3: re-encoding preserved every row -------------------------------
+echo "--- Step 3: content survives the re-encode ---"
+
+# THE POINT OF THE FIX: the read path now lists ONE parquet file instead of
+# three, so per-read cost stops scaling with ingest history.
+pond describe /data/well.series > /tmp/728-describe-after.txt 2>&1
+cat /tmp/728-describe-after.txt
+AFTER_VERSIONS=$(live_versions)
+check '[ "'"${AFTER_VERSIONS}"'" = "1" ]' \
+    "three live versions collapsed into one parquet file, got ${AFTER_VERSIONS}"
+check 'grep -qE "^ *Version [0-9]+: 21 rows" /tmp/728-describe-after.txt' \
+    "the single surviving version carries all 21 rows"
+check 'grep -qE "^ *Version [0-9]+: 21 rows, time range: 2024-01-01 .* to 2024-01-03 " /tmp/728-describe-after.txt' \
+    "merged version's temporal bounds span the union of all three versions"
+
+AFTER_ROWS=$(series_rows)
+check '[ "'"${AFTER_ROWS}"'" = "'"${BEFORE_ROWS}"'" ]' \
+    "row count unchanged after collapse (${BEFORE_ROWS} -> ${AFTER_ROWS})"
+
+AFTER_D1=$(series_rows "temperature = 10.0")
+AFTER_D3=$(series_rows "temperature = 30.0")
+check '[ "'"${AFTER_D1}"'" = "7" ]' \
+    "oldest version's rows survive the merge, got ${AFTER_D1}"
+check '[ "'"${AFTER_D3}"'" = "7" ]' \
+    "newest version's rows survive the merge, got ${AFTER_D3}"
+
+# Superseded versions must be skipped on read, not replayed alongside the
+# merged file -- that would silently double every row.
+check '[ "'"${AFTER_ROWS}"'" != "42" ]' \
+    "superseded versions are not double-counted after collapse"
+
+# Temporal coverage must span all three original days, not just the last one.
+SPAN=$(pond cat --sql "SELECT count(DISTINCT date_trunc('day', timestamp)) AS n FROM source" \
+    --format table /data/well.series 2>/dev/null \
+    | grep -E '^\| *[0-9]+ *\|' | grep -oE '[0-9]+' | head -1)
+check '[ "'"${SPAN}"'" = "3" ]' \
+    "merged version still spans all three days, got ${SPAN}"
+
+# ---- Step 4: idempotence ----------------------------------------------------
+echo "--- Step 4: second collapse is a no-op ---"
+pond maintain --collapse-versions 1 > /tmp/728-collapse2.log 2>&1
+cat /tmp/728-collapse2.log
+check 'grep -qE "collapse: 0 file\(s\) collapsed" /tmp/728-collapse2.log' \
+    "an already-collapsed table:series is no longer a candidate"
+
+# ---- Step 5: appends still work on top of the merged version ----------------
+# The merged file carries `collapsed_through`; a later append must extend it
+# rather than resurrect the superseded versions.
+echo "--- Step 5: append after collapse ---"
+pond copy "host+series:///tmp/728-v4.parquet" /data/well.series >/dev/null 2>&1
+
+APPEND_ROWS=$(series_rows)
+check '[ "'"${APPEND_ROWS}"'" = "28" ]' \
+    "post-collapse append adds exactly its own 7 rows, got ${APPEND_ROWS}"
+
+APPEND_VERSIONS=$(live_versions)
+check '[ "'"${APPEND_VERSIONS}"'" = "2" ]' \
+    "append extends the merged baseline (1 merged + 1 new), got ${APPEND_VERSIONS}"
+
+APPEND_D4=$(series_rows "temperature = 40.0")
+APPEND_D1=$(series_rows "temperature = 10.0")
+check '[ "'"${APPEND_D4}"'" = "7" ]' \
+    "appended version is readable, got ${APPEND_D4}"
+check '[ "'"${APPEND_D1}"'" = "7" ]' \
+    "pre-collapse rows still readable after the append, got ${APPEND_D1}"
+
+# ---- Step 6: the new tail is collapsible again ------------------------------
+echo "--- Step 6: the merged+appended chain collapses again ---"
+pond maintain --collapse-versions 1 > /tmp/728-collapse3.log 2>&1
+cat /tmp/728-collapse3.log
+check 'grep -qE "collapse: [1-9][0-9]* file\(s\) collapsed" /tmp/728-collapse3.log' \
+    "collapse re-arms once a new version lands"
+FINAL_ROWS=$(series_rows)
+check '[ "'"${FINAL_ROWS}"'" = "28" ]' \
+    "repeated collapse is lossless, got ${FINAL_ROWS}"
+FINAL_VERSIONS=$(live_versions)
+check '[ "'"${FINAL_VERSIONS}"'" = "1" ]' \
+    "the chain is back to a single live version, got ${FINAL_VERSIONS}"
+
+check_finish


### PR DESCRIPTION
Reading a `TablePhysicalSeries` costs **~58ms per live version regardless of size** — the read path builds a DataFusion `ListingTable` with one parquet file per version, so cost is dominated by per-file listing and footer schema inference, not bytes.

Measured on site-prod (startup baseline ~1700ms):

| versions | size | time | over baseline | ms/version |
|---|---|---|---|---|
| v1 | 1.7KB | 1793ms | 93 | — |
| v16 | 2.7KB | 2607ms | 907 | 57 |
| v20 | **8.5KB** | 2648ms | 948 | 47 |
| v85 | **1.9KB** | 6850ms | 5150 | 61 |
| v88 | 5.7KB | 6765ms | 5065 | 58 |

Bytes are irrelevant; versions are everything.

`maintain --collapse-versions` was supposed to bound this, but it excluded `TablePhysicalSeries` at **both** layers — the discovery query in `list_collapsible_series` matched only `file:physical:series`, and `collapse_file_series` hard-errored on anything else. No threshold value could ever help, so hourly collectors accumulate versions without bound. A noyo device series shows v1 = 2517 rows, v2 = 1132 rows, then 4 rows per version thereafter, ~1 version/hour.

This is the dominant cost in the caspar.water site publish: the noyo subsite is ~90% of every build, and its `/combined` joins are recomputed ~20x (4 params x 5 resolutions).

## Approach

`FilePhysicalSeries` collapse byte-concatenates versions via `ChainedReader` and verifies byte-identity. Parquet cannot be concatenated, so table collapse instead **re-encodes**: scan the series through its table provider and stream every batch into a single `ArrowWriter`, then verify **row count** rather than bytes.

This is sound because both series kinds store append-only deltas that are concatenated on read, so distinct versions never share a row — the same argument already written in `temporal_reduce.rs`.

The read path needed no change: `list_file_versions` already filters on `collapsed_through` generically for all entry types.

## Changes

- `tlogfs/persistence.rs`: new `collapse_table_series` + `reencode_table_series`; `list_collapsible_series` widened to `file_type IN (file:physical:series, table:physical:series)`.
- `steward/ship.rs`: `collapse_versions` dispatches on `entry_type()`.
- Tests: 3 versions collapse to 1 with all rows preserved, candidacy before/after, double-collapse is a no-op, post-collapse append extends the merged baseline, and a `FilePhysicalSeries` is rejected.

## Validation

`cargo test -p tlogfs -p steward` all pass; `cargo build --workspace` and `cargo clippy -p tlogfs -p steward --all-targets` clean.