### PR TITLE
Size-tiered collapse, reclamation, and the correctness bugs that came with them

### DIFF
--- a/SELFMON-FINDINGS.md
+++ b/SELFMON-FINDINGS.md
@@ -1,0 +1,626 @@
+# Selfmon findings — storage amplification and coverage gaps
+
+**Status: TEMPORARY working notes. Not intended to be committed as-is.**
+Investigated 2026-07-25/26 against the live `watershop-selfmon` instance.
+Every number below is measured on the host, not estimated.
+Updated 2026-07-26: items 1-3 are implemented (§8, §9, item 3) and two
+findings not in the original audit were added (§10, §11). **Nothing here is
+deployed yet** — the watertown work is unpushed and the submodule pointer has
+not moved.
+
+Selfmon exists to exercise watertown and surface its inefficiencies. It did.
+This is what it found.
+
+---
+
+## TL;DR
+
+| Finding | Severity | Status |
+|---|---|---|
+| **Collapse output is an O(N²) write amplifier** — superseded blobs never GC'd | **high** | **fixed** §8, item 1 |
+| No GC for superseded `_large_files` blobs — 8.2 GB unreclaimable | **high** | **fixed** §9, item 2 |
+| **Collapse blinds both read-pruning predicates** — bounded reads silently become full-history reads (§7) | **high** | **fixed** by tiering (§7 "Consequence") |
+| **Reading a collapsed series double-counts every row** (§10) | **high** | **fixed**, not previously known |
+| Selfmon has no `TablePhysicalSeries`, so that collapse path is never exercised | **high** (coverage) | **fixed** in config; NOT YET DEPLOYED |
+| **Tick steps failed silently, and a failed read published as a fast read** (§11) | **high** | **fixed** in caspar.water |
+| `logfile-ingest` silently truncates a series when its active file is rotated (§11) | medium | open, latent |
+| Stale format-cache parquets are never pruned (§10) | low | open (disk only) |
+| `libpod-conmon-*` journal files unbounded in count; one is 165.8 MB | medium | open (item 4) |
+| `pond copy` versions identical content — 9,769 versions of a 19-byte file | medium | open (item 5) |
+| `_minio-admin.env` measured as if it were a pond (duplicate + dead data) | low | open (item 7) |
+| `interval = "1min"` is unachievable; ticks take ~3 min | low | open (item 9) |
+
+Compaction itself is **working correctly** — see below. The problem is that
+compaction reaches only 0.5% of the pond.
+
+---
+
+## 1. Compaction is working; it just can't reach most of the pond
+
+Per-tick `maintain --compact --prune --collapse-versions 100` holds the
+compaction-reachable surface at:
+
+| area | size | files |
+|---|---|---|
+| live data parquet | **50.4 MB** | **18** |
+| control | 37 MB | — |
+| tlog | 6.2 MB | — |
+
+18 files / 50 MB for a pond committing ~2.2×/min for a month is a good steady
+state. The recurring `Compaction committed (+4/-14 files)` and
+`Compacted control (+1/-37)` log lines are it doing its job. **No action needed
+on compaction.**
+
+But the pond on disk is 11 GB:
+
+| area | size | files | reachable by maintenance? |
+|---|---|---|---|
+| `data/_large_files` | **8.2 GB** | 34,076 | **no — no GC exists** |
+| `data/_delta_log` | 2.7 GB | 461 checkpoints | yes (retention works) |
+| `cache/jsonlogs_*` | 96 MB | 21,659 | n/a (derived cache) |
+| compaction-reachable | 50 MB | 18 | yes |
+
+### `_delta_log` is fine — do not "fix" it
+
+Checkpoint size across the retained 24 h window is flat, slightly declining:
+
+```
+5.87 → 5.86 → 5.84 → 5.82 → 5.80 → 5.78 MB   (oldest → newest)
+```
+
+`maintenance.data_log_retention_minutes = 1440` is enforced to the minute
+(oldest entry is exactly 24 h old). A plausible-sounding theory — "checkpoints
+inflate as `_large_files` grows" — is **wrong**; checkpoints do not enumerate the
+blob store.
+
+Still worth questioning separately: a **5.8 MB checkpoint for 50 MB of live
+data**, written once per tick, is ~2.6 GB/day of write amplification. The cause
+is the version count, see §3.
+
+---
+
+## 2. `_large_files`: 8.2 GB for 386.6 MB of live content (~21× amplification)
+
+**These are not series.** Every one is a plain `[FILE]` entry.
+
+Mechanism: in tlogfs each write creates a new version of the **whole file**, and
+any version whose content exceeds the large-file threshold is externalized as
+its own immutable content-addressed parquet blob under `data/_large_files`.
+Superseded versions' blobs are never reclaimed. `pond maintain --help` confirms
+there is no GC option; `--compact` / `--prune` / `--collapse-versions` all
+operate on delta-log-tracked data only.
+
+Measured totals:
+
+```
+live file content     386.6 MB   (2,220 files, 94,419 versions)
+_large_files on disk    8.2 GB   (34,076 blobs)
+```
+
+### Source 1 — **collapse output is the O(N²) engine** (the main finding)
+
+The `/logs/journal/<unit>.jsonl` and `/measure/*.jsonl` entries are
+`FilePhysicalSeries` (confirmed via `pond describe`; `pond list` renders them as
+`[FILE]`, which is misleading). Each ingest appends a **version** holding only
+the new bytes — that is why `journal_ingest` logs
+`Writing 175 entries (219525 bytes)` while the entry's `Size:` stays at 113 KB.
+
+The loop:
+
+1. Every tick appends ~1 version to each active series.
+2. When a series passes **100 live versions** (`--collapse-versions 100`),
+   `collapse_file_series` merges **all** live versions into one new version
+   containing the **entire series history**.
+3. That merged object is the whole accumulated file — for the busiest series
+   it is now **96.3 MB**, and it grows ~1.0 MB per collapse cycle.
+4. It is written to `_large_files` as a new content-addressed blob, and the
+   **previous collapse's blob is never reclaimed**.
+5. Cadence: 100 versions ÷ ~1 per tick ÷ ~3 min per tick ≈ **5.3 h**.
+
+The measured blob timestamps match that cadence exactly, and the sizes form a
+clean arithmetic progression — successive collapse outputs of the same series:
+
+```
+Jul 21 14:58   74.74 MB      Jul 24 06:20   86.82 MB
+Jul 21 20:14   75.73 MB      Jul 24 12:05   87.87 MB
+Jul 22 01:33   76.73 MB      Jul 24 17:30   88.93 MB
+Jul 22 06:57   77.75 MB      Jul 24 22:39   89.95 MB
+Jul 22 12:21   78.76 MB      Jul 25 04:07   91.05 MB
+Jul 22 17:45   79.82 MB      Jul 25 09:09   92.12 MB
+Jul 22 23:07   80.86 MB      Jul 25 14:16   93.19 MB
+Jul 23 04:14   81.84 MB      Jul 25 19:32   94.23 MB
+Jul 23 09:21   82.84 MB      Jul 26 00:52   95.24 MB
+Jul 23 14:31   83.82 MB      Jul 26 06:15   96.30 MB
+Jul 23 19:44   84.83 MB
+Jul 24 01:01   85.83 MB
+```
+
+**The math.** If a series grows by δ per collapse cycle, then after N collapses
+the store holds δ(1 + 2 + … + N) = **δN²/2** bytes, while live content is only
+δN. Amplification is therefore **N/2** and grows without bound.
+
+Measured: those 22 retained outputs alone sum to **~1.9 GB** for a series whose
+live size is 96.3 MB. Extrapolating over the pond's life (~122 collapse cycles
+since Jun 29) gives ~5.9 GB — i.e. the bulk of the 8.2 GB.
+
+Corroborating aggregate — blob *count* per day is flat while average blob *size*
+(and thus bytes/day) doubled in 11 days:
+
+| day | files/day | MB/day | avg blob |
+|---|---|---|---|
+| Jul 15 | 1,004 | 298 | 304 KB |
+| Jul 20 | 1,238 | 555 | 459 KB |
+| Jul 25 | 1,182 | 612 | 531 KB |
+| Jul 26 | — | — | 626 KB |
+
+Growth rate is itself growing ~30 MB/day/day → ~1.5 GB/day within a month.
+
+> **The counter-intuitive part:** *lowering* `--collapse-versions` makes this
+> **worse**, because it triggers more frequent full rewrites. Collapse is a
+> read-side optimisation that costs O(N²) on the write side whenever its
+> superseded outputs are not GC'd. This compounds the already-known coupling
+> that caused the Jul 25 sealed-bucket outage — the threshold is dangerous in
+> *both* directions, and neither bound is enforced in code.
+
+Note the feedback loop: `user-pond-selfmon@watershop-selfmon.service.jsonl` is
+selfmon ingesting **its own** log output.
+
+### Source 2 — one-shot giant blobs, one per *container run*
+
+podman gives every container run its own transient systemd scope
+`user-libpod-conmon-<sha>.scope`, so journal ingest creates a **new file per
+container run** and writes it once:
+
+```
+conmon: 617 files, 645 versions, 373.1 MB  (97% of live bytes)
+
+165.8 MB  user-libpod-conmon-830c5b87....scope.jsonl   v1   ← one site-prod
+ 63.8 MB  user-libpod-conmon-c5553a3f....scope.jsonl   v1     sitegen container
+ 49.6 MB  user-libpod-conmon-a0c0b377....scope.jsonl   v1
+ 24.1 MB / 15.5 MB / 7.5 MB / 7.4 MB / 5.6 MB ...
+```
+
+This set is **unbounded in file count** — one more file forever, per container
+run, never rotated, never expired. And the more verbose watertown's container
+logging becomes, the more selfmon permanently stores.
+
+### Source 3 — `pond copy` versions identical content
+
+`config/scripts/run-selfmon.sh` (caspar.water) unconditionally re-copies the
+site templates into the pond every tick, with no change detection:
+
+```
+/system/site/sidebar.md    19 BYTES   v9769    content: "{{ content_nav /}}"
+/system/site/metrics.md      539 B    v9769
+/system/site/status.md       738 B    v9768
+```
+
+~29,000 versions carrying zero information. Too small to be externalized, so
+this does not feed `_large_files` — but it is a third of all version rows, and
+therefore a third of the metadata written into every 5.8 MB checkpoint.
+
+---
+
+## 3. Why a tick costs ~3 minutes
+
+`interval = "1min"` is configured, but measured wall time over 7 consecutive
+runs was `3m15s, 3m26s, 3m00s, 2m49s, 2m57s, 2m55s, 3m06s`, at 3m23s–4m03s CPU
+each. The service therefore **never idles** — it finishes and systemd
+immediately restarts it, ~100% duty cycle, ~1.2 of the host's 12 cores.
+(Host load 2.16, 62 GB RAM — tolerable, but it does compete with the site
+builds, and is a plausible contributor to the long-unexplained "site-prod is
+~2.3× slower than noyo-prod on byte-identical inputs".)
+
+Phase budget of a 175 s tick (self-recorded in
+`/var/log/watertown-selfmon/watershop-selfmon/{.sitegen-last.json,_self.jsonl}`):
+
+| phase | time | share |
+|---|---|---|
+| sitegen build | ~62 s | 35 % |
+| logfile-ingest ×11 (one `pond run` process each) | ~53 s | 30 % |
+| measure fan-out ×10 (2× `find` + `du -sb` + `pond list` + `pond log`) | ~35 s | 20 % |
+| maintain (pre-tick) | ~14 s | 8 % |
+| journal + caddy ingest | ~10 s | 6 % |
+
+sitegen is stable at 60–66 s with 1.37 GB peak RSS.
+
+The scaling factor is that **selfmon's own pond dwarfs everything it monitors**:
+
+| pond | list.s | parquet files | size |
+|---|---|---|---|
+| **watershop-selfmon** | **2.57** | **56,245** | **11.7 GB** |
+| site-staging | 0.71 | 3,420 | 1.0 GB |
+| site-prod | 0.38 | 1,758 | 1.0 GB |
+| water-staging | 0.54 | 1,754 | 0.6 GB |
+| water-prod | 0.56 | 854 | 0.4 GB |
+| septic/noyo ×4 | 0.22–0.46 | 251–525 | ~0.1 GB |
+
+---
+
+## 4. Coverage: `FilePhysicalSeries` collapse **is** exercised; `TablePhysicalSeries` is not
+
+Selfmon runs `FilePhysicalSeries` collapse constantly — measured over 24 h:
+
+```
+433 ticks   collapse: 0 file(s) collapsed  (0 candidates)
+ 16 ticks   collapse: 1 file(s) collapsed, 101 version(s) superseded
+  1 tick    collapse: 2 file(s) collapsed, 202 version(s) superseded
+```
+
+i.e. **18 file-collapses/day**. So the "0 candidate(s)" seen on most ticks is
+just the threshold self-gating between cycles, not an idle code path.
+
+What selfmon has **none** of is `TablePhysicalSeries`. Its 12 `[SER]` entries are
+all `v1` dynamic/derived (`sql-derived-series`, `timeseries-join`), computed at
+read time; every *physical* series it owns is a `FilePhysicalSeries`.
+
+**That asymmetry is why the `TablePhysicalSeries` version-collapse bug (#121)
+survived undetected until noyo hit it in production.** The file-series path was
+continuously exercised here; the table-series path never was.
+
+Fix (**done in config, not yet deployed** — see item 3): a `materialize-series`
+factory pins the `/derived/perf` join into a real `TablePhysicalSeries` at
+`/metrics/perf.series`, fed by the per-tick metrics, so both collapse paths are
+exercised continuously. Until the submodule pointer is bumped, **this asymmetry
+still exists in production**.
+
+---
+
+## 5. Minor: `_minio-admin` is measured as if it were a pond
+
+`run-selfmon.sh` loops over `env/*.env`, which includes `_minio-admin.env` —
+a file holding only S3 credentials, **no `POND`**. It is not skipped, because
+`run-selfmon.sh` exports `POND` (its own) earlier, so `measure-pond.sh`'s
+`: "${POND:?}"` guard passes on the *inherited* value.
+
+Proof from the emitted data: `_minio-admin.jsonl` reports
+`size.bytes: 11673469731` (11.7 GB) and `committed.txn_ids: 70871` — i.e. it is a
+mislabeled **duplicate measurement of the selfmon pond itself**, which is the
+single most expensive probe (2.33 s `pond list` + 3 tree walks over 56 k files),
+run every tick.
+
+It is also entirely dead: there is no `/system/etc/measure/_minio-admin` mknod,
+so the resulting 2.0 MB jsonl is never ingested.
+
+Fix (caspar.water): skip `_*.env` in both loops in `run-selfmon.sh`, or require
+`POND` to come from the env file itself rather than being inherited.
+
+---
+
+## 6. Unrelated housekeeping found along the way
+
+`/home/jmacd/pond-watershop-selfmon-staging` is **32 GB**, last written
+2026-04-27. Fully orphaned: no systemd unit, no env file, not in
+`local.instances` (terraform calls it a retired name).
+`cleanup-stale-pond-units.sh` reaps retired *units*, but nothing reclaims native
+selfmon *data dirs* — they live at `/home/jmacd/pond-<name>`, outside podman
+volume management. Disk is not tight (894 GB, 30 % used) but retiring a selfmon
+instance currently strands its data forever.
+
+---
+
+## 7. Collapse destroys the metadata that read-pruning depends on
+
+Distinct from the O(N²) write problem in §2, and undocumented. Found by asking
+what happens to per-version byte ranges after a merge.
+
+### What is lost
+
+The merged row records a single `size`/`blake3`, a single `version` (`V`, the
+highest), and temporal bounds taken as `min()`/`max()` **across all absorbed
+versions** (`crates/tlogfs/src/persistence.rs:1201-1203`). Per-version
+boundaries within the byte stream are not retained anywhere.
+
+### Why it matters
+
+`SeriesReadBounds::retains` (`crates/tinyfs/src/file.rs:70`) prunes using
+exactly the two things collapse erases:
+
+```rust
+let event_time_ok = max_event_time.is_none_or(|max_ts| max_ts >= lo);
+let version_ok = version > watermark;
+```
+
+After a collapse both degrade to "retain everything":
+
+- **`version_gt = K`** for any `K < V`: the merged row's version is `V`, so
+  `V > K` holds and the row is returned **whole**.
+- **`event_time_lo = lo`**: the merged row's `max_event_time` is the global
+  maximum, so it is retained for essentially any bound.
+
+So a bounded, incremental read silently becomes a full-history read.
+`crates/sitegen/src/factory.rs:840` (the status_grid fold) is exactly that
+consumer: once per collapse, per series — every ~5.3 h — it re-reads the entire
+series through DataFusion instead of the ~1 MB of new data it asked for.
+
+### It is a cost bug, not a correctness bug
+
+The re-read does **not** double-count. `status_summary::merge` is an idempotent
+semilattice: every scalar field is latest-by-timestamp via `keep_later`, and
+tails dedupe on `(ts_us, msg)`. Re-folding already-folded data is a no-op.
+
+Note however that the doc comment on `processed_version`
+(`crates/sitegen/src/status_summary.rs:62-64`) claims *"every version is
+processed exactly once"* — that is **false** after a collapse. It is harmless
+only because the fold happens to be idempotent, i.e. an undocumented invariant
+is load-bearing for a property it was never designed to provide.
+
+### Consequence for the fix
+
+This is a second, independent argument for range-based (`[lo, hi]`) collapse
+runs beyond write amplification: each run carries its own version range *and*
+its own `min`/`max_event_time`, so pruning survives at run granularity instead
+of being all-or-nothing.
+
+The shape is also right. Under tiered collapse, recent versions stay loose and
+unmerged, so full per-version resolution is preserved precisely where
+incremental readers operate — the tail — and only cold history is coarsened,
+which nobody prunes into. Today's scheme does the opposite: it coarsens
+everything, including the hot tail that `version_gt` depends on.
+
+---
+
+## Recommended order
+
+**watertown**
+
+1. ~~**Range-based (tiered) collapse.**~~ **DONE** (branch `jmacd/analysis8`,
+   uncommitted). `collapsed_through` is now paired with `collapsed_from` to form
+   the range `[lo, hi]` a merged row supersedes, and `collapse_file_series`
+   merges a bounded window of same-size-class versions
+   (`COLLAPSE_FANOUT = 10`) instead of the whole history. Write volume goes from
+   `O(N^2)` to `O(N log N)`, and per-run `min`/`max_event_time` keeps the read
+   pruning of §7 alive. Implementation notes:
+   - Version numbers are never reassigned, so **version order is no longer byte
+     order**. Three readers were ordering by version and are fixed:
+     `async_file_reader_series`, `metadata()` (was returning the highest-version
+     row, which after tiering is a *mid-stream* run, so appends resumed from the
+     wrong bao prefix), and `read_pending_bytes` (walked version numbers
+     backward, interleaving runs with loose versions).
+   - A merged run inherits the cumulative bao outboard of the newest version it
+     absorbs, verbatim. Collapse only regroups an unchanged byte stream, so the
+     prefix through `hi` is byte-identical; recomputing it as a fresh first
+     version is correct only for a run starting at v1.
+   - ~~`TablePhysicalSeries` still merges the full live set.~~ Superseded by
+     §8: it was tiered too, via a version-bounded provider.
+2. ~~**GC for superseded `_large_files` blobs.**~~ **DONE** (see §9). Collapse
+   now deletes the rows it superseded and sweeps the blobs they were the last
+   referrers of. This is what reclaims Source 1's ~5.9 GB.
+3. ~~Give selfmon a `TablePhysicalSeries` so that collapse path is exercised
+   too.~~ **DONE in config, NOT YET DEPLOYED.** A new `materialize-series`
+   factory pins the `/derived/perf` join into a real `TablePhysicalSeries` at
+   `/metrics/perf.series` (caspar.water `1f587f3`). **The coverage gap that let
+   #121 ship stays open in production until watertown merges and the submodule
+   pointer is bumped** — the deployed `pond` has no such factory.
+4. Filter or aggregate `libpod-conmon-*` scope logs at ingest — storing a
+   166 MB container log verbatim is not what selfmon is for, and the file set
+   is unbounded in count.
+5. Make `pond copy` a no-op when the content hash is unchanged (fixes §2
+   Source 3 generically, not just here).
+6. Document/enforce the `--collapse-versions` bounds: it is bounded **below** by
+   `allowed_lateness` (rewrite depth → sealed-bucket outages) and **above** by
+   read cost (~58 ms/version), and lowering it *increases* O(N²) write
+   amplification. Neither bound is enforced in code today. Note that tiering
+   (1) largely retires this hazard: merges touch only old, sealed windows and
+   never reach back toward the `allowed_lateness` horizon.
+
+**caspar.water**
+
+7. Skip `_*.env` in `run-selfmon.sh`.
+8. Reclaim the 32 GB orphan; teach cleanup to reap native pond dirs.
+9. Revisit `interval = "1min"` once the above land.
+
+## 8. Tiering extended to `TablePhysicalSeries` (done)
+
+`collapse_table_series` had the same whole-history defect as the file path, for
+a different reason: `reencode_table_series` scanned the series through
+`create_table_provider(id, .., TableProviderOptions::default())`, whose default
+`VersionSelection::AllVersions` means *the entire series*. Every trigger
+re-encoded every row ever written.
+
+The missing primitive already existed: `TableProviderOptions::additional_urls`
+takes explicit per-version URLs and still runs `infer_schema`, so schema merging
+across versions is preserved. Windowing therefore needed no new
+`VersionSelection` variant and no object-store change --
+`reencode_table_versions(id, &[versions], ts_col)` builds one
+`TinyFsPathBuilder::url_specific_version` per window row.
+
+Three changes:
+- window selection via the same `choose_collapse_window(&live, max_live)` as the
+  file path (parquet byte sizes feed `size_class` naturally);
+- `lo`/`hi` and the event-time bounds now come from the *window*, not all live
+  rows, so `SeriesReadBounds::retains` keeps its pruning resolution;
+- verification is window-local: it re-scans only the merged version and compares
+  its row count to the window's, instead of re-scanning the whole series (that
+  check was itself an O(N) read on every collapse).
+
+The read path needed nothing: `tinyfs_object_store` enumerates versions via
+`list_file_versions`, which already honors collapse ranges.
+
+Note the file path's ordering hazard does *not* apply here. Table versions are
+unioned rather than byte-concatenated, so a merged run's position in version
+order is irrelevant to content; only its range matters, for supersession and
+pruning.
+
+## 9. Reclamation: the second half of collapse (done)
+
+Tiering (§7, item 1) fixed the *rate* at which blobs are stranded; it could not
+return a byte. Collapse appended a merged run but left the rows it superseded in
+the table, and **a superseded row still references its blob**, so the blob stayed
+pinned. A blob sweep alone would therefore have freed nothing — the rows have to
+go first.
+
+Reclamation runs inside `Ship::collapse_versions`, with no new flag or command,
+because it is not a separate feature: without it collapse is only half an
+operation.
+
+1. Delete superseded series rows from the data Delta table.
+2. Mark-sweep `_large_files`, deleting every blob whose blake3 no longer appears
+   in any remaining row.
+
+**The order cannot be inverted.** `pond fsck`'s content pass reads *every* row —
+including superseded ones — and requires each large-file blob to exist, so
+sweeping while the rows survive turns a healthy pond into a failing one.
+Reclaiming *after* the collapse transaction commits is what makes it crash-safe:
+an interruption leaves the superseded rows in place, which is exactly the
+pre-reclaim state, whereas deleting first could lose content if the merged run
+never landed.
+
+**Supersession is decided by `live_series_versions`** — the same definition the
+read path uses — and never by a watermark or a range test. A merged run carries a
+fresh highest version while standing for content in the middle of the stream, so
+a run's own version can fall *inside a later run's range*. Both "everything below
+K" and "anything inside a range" would delete live runs. This is the same hazard
+that produced six separate silent corruptions during the tiering work.
+
+**The sweep is a mark-sweep by hash, global over all `pond_id`s**, because blobs
+are content-addressed: one file backs many rows across many nodes and ponds
+(cross-pond imports mirror rows verbatim), so a per-row delete would free a blob
+another row still needs. It runs under the pond write lock, which is the only
+thing that distinguishes garbage from a blob a concurrent writer has staged but
+not yet committed.
+
+Deleting these rows is **Merkle-neutral**: steward's content fold already prunes
+them, so `root_tree_hash` is unchanged and mirrors — which never received them —
+stay converged. Testsuite 717/718/726/727 (push/pull, fsck replica equality,
+incremental mirror pull) pass unchanged, which is the real proof.
+
+`pond maintain` now collapses **before** `ship.maintain()`, mirroring the
+existing `--prune` placement, so the delete's tombstones are reclaimed by the
+same checkpoint + vacuum pass.
+
+### What this does and does not reclaim
+
+- **Source 1 (~5.9 GB, the bulk):** reclaimed. Despite `pond list` rendering them
+  `[FILE]`, these are `FilePhysicalSeries` versions, and the stranded collapse
+  outputs are precisely the superseded rows reclamation deletes.
+- **Source 2 (~373 MB of conmon logs):** *not* reclaimed, and correctly so —
+  those are live `v1` content. Bounding them is an ingest-filtering / retention
+  decision (item 4), not garbage collection.
+- **Source 3 (~29,000 no-op `pond copy` versions):** unaffected; they are too
+  small to be externalized and never touch `_large_files`. They remain a third of
+  all version rows and thus of every checkpoint (item 5).
+
+Still unreclaimed by anything: `FilePhysicalVersion` / `TablePhysicalVersion`
+files (the 21,659 `cache/jsonlogs_*` population) are never collapse candidates at
+all, so they have no supersession relation and accumulate without bound.
+
+---
+
+## 10. Reading a collapsed series double-counted every row
+
+Found while extending testsuite coverage, not from the disk audit. It was
+**not** on the original list and is the most serious correctness defect here.
+
+`listing_table_from_cache` built its ListingTable by **globbing** the node's
+cache directory:
+
+```
+{cache}/{scheme}_{node_id}/*.parquet
+```
+
+That is correct only while "every parquet ever written" equals "every version
+that is live". Collapse breaks exactly that equality: it replaces a run of
+versions with one merged version holding the same bytes, and the superseded
+versions' parquets stay on disk. The glob returned both, so every row appeared
+twice — then four times after the next collapse.
+
+Reproduced in isolation and pinned as testsuite `731`: a derived read returns
+**9 rows before `pond maintain --collapse-versions`, 18 after**.
+
+### Why it went unnoticed
+
+`pond cat` reads the pond directly and stayed correct throughout, so the raw
+file looked fine while every *derived* read doubled. The corruption scales with
+collapse activity, so it was worst on exactly the ponds that ingest the most.
+
+It affects **every external-format read** — `jsonlogs`, `oteljson`, `csv`,
+`weblog`, `excelhtml` — i.e. every ingest pipeline in selfmon and noyo.
+
+### The fix
+
+The bounded read path was already correct: it names each live version's file
+explicitly. It simply delegated to the globbing variant whenever bounds were
+`NONE`, which is the common case. Both paths now name live version files
+explicitly (`SeriesReadBounds::NONE.retains()` is true for everything, so the
+merge is safe), and schema merging was scoped to the retained files via a new
+`merge_parquet_schemas()`.
+
+### Still open: nothing prunes the stale cache parquets
+
+Reclamation (§9) does not help. It deletes superseded rows and blobs *inside*
+the pond; the format cache is a separate host-side artifact keyed by version +
+content hash, and nothing sweeps it. Now a disk-waste issue rather than a
+correctness one — the 21,659 `cache/jsonlogs_*` files in §1's table are this
+population. Natural home is `pond maintain`.
+
+---
+
+## 11. Silent failures in the tick itself
+
+Selfmon exists to surface watertown's problems. Its own driver was hiding its.
+
+### Three classes, in `run-selfmon.sh`
+
+1. **Truly silent.** The per-pond metric ingests ran under `2>/dev/null || true`,
+   discarding the exit code *and* the error text. This is the pipeline feeding
+   every chart: had it failed, the dataset would simply stop advancing while the
+   page kept rendering the last good data as if nothing were wrong — with
+   nothing, anywhere, to say otherwise.
+2. **Worse than silent — actively misleading.** The read benchmark timed
+   `pond cat` under `|| true` and published the elapsed time *regardless*. A read
+   that errored out in 5 ms was recorded as a 200x speed-up: a failure that
+   looked like the best tick we ever had.
+3. **Semi-silent.** Steps that echoed `WARNING:` to a journal nobody reads.
+
+Non-fatal remains the right policy — aborting mid-tick is what historically
+wedged the pond — but non-fatal must not mean invisible.
+
+### Fixed (caspar.water `4692a56`)
+
+Every non-fatal step now runs through a `step` wrapper that lets the tick
+continue while recording the failure in three channels:
+
+| channel | catches |
+|---|---|
+| stderr | lands in the journal |
+| `.tick-status.json`, written from an **EXIT trap** | clean step failures *and* aborts / OOM kills |
+| a **`tick.failures` metric** in `_self.jsonl` | reaches the dashboard |
+
+The third is the point: failures belong on the chart the operator already
+watches. `tick.failures` and `read.ok` flow through `/derived/p-_self` ->
+`/metrics/perf.series` -> `/reduced`, verified end to end. `tick.failures` lags
+one tick for the same reason `sitegen.seconds` does — the record is written
+before those steps have run.
+
+The tick also now exits non-zero when any step failed, so systemd marks the run
+failed. Reporting success after five failed steps is itself a silent failure.
+Safe because it happens in the EXIT trap, after all work is done, on a
+timer-driven one-shot unit.
+
+Schema compatibility was verified rather than assumed: the live `_self.jsonl`
+predates both new fields, and `logfile-ingest` widens the schema on append, so
+old rows read back as `NULL` instead of failing the `CAST` and taking down the
+whole join.
+
+### Open, latent: `logfile-ingest` truncates a rotated series
+
+Found while testing the above. If the active log is **rotated** rather than
+appended to — the old file renamed to match `archived_pattern`, a fresh active
+file created — ingest reports:
+
+```
+Logfile ingestion complete: 1 new (260 bytes), 0 appended, 1 unchanged
+outcome=ok
+```
+
+...and **silently discards the previously ingested content**. Three pre-rotation
+rows vanished; `pond describe` showed `Version: 1`, `Size: 260 bytes`. Exit
+status is 0 and nothing is logged above INFO.
+
+Not reachable today — nothing rotates these files, so every mknod's
+`archived_pattern` currently matches zero files. But the patterns exist in the
+config precisely because rotation is anticipated, so this is armed for whenever
+someone adds logrotate. Worth a testsuite case regardless of whether the
+behaviour is judged wrong: silently returning `ok` while dropping data is not an
+acceptable outcome either way.

--- a/SELFMON-FINDINGS.md
+++ b/SELFMON-FINDINGS.md
@@ -1,12 +1,17 @@
 # Selfmon findings — storage amplification and coverage gaps
 
-**Status: TEMPORARY working notes. Not intended to be committed as-is.**
-Investigated 2026-07-25/26 against the live `watershop-selfmon` instance.
-Every number below is measured on the host, not estimated.
-Updated 2026-07-26: items 1-3 are implemented (§8, §9, item 3) and two
-findings not in the original audit were added (§10, §11). **Nothing here is
-deployed yet** — the watertown work is unpushed and the submodule pointer has
-not moved.
+**Status: working notes, committed for traceability rather than as
+documentation.** Investigated 2026-07-25/26 against the live
+`watershop-selfmon` instance. Every number below is measured on the host, not
+estimated.
+
+Updated 2026-07-26: items 1-3 implemented (§8, §9, item 3); two findings not in
+the original audit added (§10, §11).
+
+Updated 2026-07-27 after a review of the whole branch, which found that §10 had
+been fixed in only one of two identical caches and that four further defects
+had no test. See §12. **Nothing here is deployed yet** — the watertown work is
+unpushed and the submodule pointer has not moved.
 
 Selfmon exists to exercise watertown and surface its inefficiencies. It did.
 This is what it found.
@@ -19,12 +24,17 @@ This is what it found.
 |---|---|---|
 | **Collapse output is an O(N²) write amplifier** — superseded blobs never GC'd | **high** | **fixed** §8, item 1 |
 | No GC for superseded `_large_files` blobs — 8.2 GB unreclaimable | **high** | **fixed** §9, item 2 |
-| **Collapse blinds both read-pruning predicates** — bounded reads silently become full-history reads (§7) | **high** | **fixed** by tiering (§7 "Consequence") |
-| **Reading a collapsed series double-counts every row** (§10) | **high** | **fixed**, not previously known |
+| **Collapse blinds both read-pruning predicates** — bounded reads silently become full-history reads (§7) | **high** | **partly fixed** by tiering: event-time pruning survives, `version_gt` does not (§7 "Consequence") |
+| **Reading a collapsed series double-counts every row** (§10) | **high** | **fixed** in the format cache; the same bug in the rollup cache was live until §12 |
+| **Rollup partials double-counted a collapsed window** (§12) | **high** | **fixed** §12, testsuite 733 |
+| reclaim's delete commits replayed as duplicate transactions by `pond rebuild` (§12) | medium | **fixed** §12 |
+| reclaim deleted rows and swept blobs with no content-root check (§12) | medium | **fixed** §12 |
+| A corrupt bao outboard silently produced a wrong collapse baseline (§12) | medium | **fixed** §12 |
+| The collapse backstop rewrote the largest run, defeating tiering (§12) | medium | **fixed** §12 |
 | Selfmon has no `TablePhysicalSeries`, so that collapse path is never exercised | **high** (coverage) | **fixed** in config; NOT YET DEPLOYED |
 | **Tick steps failed silently, and a failed read published as a fast read** (§11) | **high** | **fixed** in caspar.water |
 | `logfile-ingest` silently truncates a series when its active file is rotated (§11) | medium | open, latent |
-| Stale format-cache parquets are never pruned (§10) | low | open (disk only) |
+| Stale format-cache parquets are never pruned (§10) | low | **fixed** §12 (rollup); format cache still leaks disk only |
 | `libpod-conmon-*` journal files unbounded in count; one is 165.8 MB | medium | open (item 4) |
 | `pond copy` versions identical content — 9,769 versions of a 19-byte file | medium | open (item 5) |
 | `_minio-admin.env` measured as if it were a pond (duplicate + dead data) | low | open (item 7) |
@@ -352,6 +362,16 @@ runs beyond write amplification: each run carries its own version range *and*
 its own `min`/`max_event_time`, so pruning survives at run granularity instead
 of being all-or-nothing.
 
+**Only half of this was actually delivered.** Tiering restored *event-time*
+pruning at run granularity, as described below. It did **not** restore
+`version_gt` pruning: a merged run still takes a fresh highest version number
+while standing in for mid-stream content, so version order no longer matches
+byte order and an incremental reader keyed on `version_gt` still cannot prune —
+it degrades from `O(N)` to `O(fanout)` rather than to `O(1)`. The rule that
+fixes this exists (`CollapseRange` / `is_superseded` in `tlogfs::schema`) but is
+confined to tlogfs; `tinyfs::FileVersionInfo` never gained the collapse range,
+so nothing above tinyfs can apply it. See §12 "Still open".
+
 The shape is also right. Under tiered collapse, recent versions stay loose and
 unmerged, so full per-version resolution is preserved precisely where
 incremental readers operate — the tail — and only cold history is coarsened,
@@ -546,13 +566,20 @@ explicitly (`SeriesReadBounds::NONE.retains()` is true for everything, so the
 merge is safe), and schema merging was scoped to the retained files via a new
 `merge_parquet_schemas()`.
 
-### Still open: nothing prunes the stale cache parquets
+### Still open: nothing prunes the stale format-cache parquets
 
 Reclamation (§9) does not help. It deletes superseded rows and blobs *inside*
 the pond; the format cache is a separate host-side artifact keyed by version +
-content hash, and nothing sweeps it. Now a disk-waste issue rather than a
+content hash, and nothing sweeps it. A disk-waste issue rather than a
 correctness one — the 21,659 `cache/jsonlogs_*` files in §1's table are this
 population. Natural home is `pond maintain`.
+
+### Wrong scope: this section claimed more coverage than it had
+
+The fix above covered `format_cache`. It did **not** cover `rollup_cache`,
+which is a near-identical copy of the same code and had the same defect —
+with the worse consequence that it silently *double-counted* rather than
+merely re-read. That is §12.
 
 ---
 
@@ -624,3 +651,109 @@ config precisely because rotation is anticipated, so this is armed for whenever
 someone adds logrotate. Worth a testsuite case regardless of whether the
 behaviour is judged wrong: silently returning `ok` while dropping data is not an
 acceptable outcome either way.
+
+---
+
+## 12. Branch review: one live corruption and four untested defects
+
+Added 2026-07-27 after reviewing the whole `jmacd/analysis8` branch rather than
+each change in isolation. The review was prompted by the sense that details did
+not add up; they did not.
+
+### 12.1 The same bug, fixed in one of two copies (the live corruption)
+
+§10 fixed version-collapse double-counting in `format_cache`. `rollup_cache` is
+a near-identical copy of that module — one of its functions was even documented
+as *"Mirrors `format_cache::cache_version_path` keying exactly"* — and it still
+had the defect.
+
+The mechanism: `find_uncached_members` only ever **added** partials named
+`{node}_v{version}_{blake3}.parquet`, and the read side **globbed the
+directory**. After `maintain --collapse-versions`, the merged version got a new
+partial while the superseded versions' partials stayed. The merge is
+`SUM(__p_sum_i), SUM(__p_count_i) GROUP BY bucket`, so every row in the
+collapsed window was summed twice — and again on each later collapse.
+
+Scope: the rollup cache engages only when the input scheme has a
+`FormatProvider` (`oteljson`, `jsonlogs`, `csv`). Builtin `series:///`,
+`file:///`, `table:///` bypass it, so selfmon's own
+`materialize-series → temporal-reduce` pipeline was **not** affected.
+`water.yaml` / `septic.yaml` reading `oteljson:///ingest/*.json` **were**, with
+`config/scripts/run.sh` running `maintain --compact --collapse-versions 100`
+hourly.
+
+**Why it hid for a year.** Testsuite `050` already ran the exact sequence —
+collapse, then an oteljson temporal-reduce — but asserted only on `avg` and
+bucket count. `avg` is `SUM(sum)/SUM(count)`, unchanged when both double; the
+`GROUP BY` re-collapses duplicate buckets so the count is unchanged too. Both
+assertions are invariant under precisely this corruption. `temporal_reduce.rs`
+also explicitly skips its sequentiality guard for series inputs, justified on
+the grounds that *"distinct versions never share a row"* — the one invariant
+collapse breaks.
+
+Pinned red by testsuite `733` (96 → 192), now green.
+
+### 12.2 The fix: name the abstraction instead of patching the copy
+
+Patching `rollup_cache` would have left two copies of a shape that had already
+proven it silently diverges. Both modules are the same thing: a directory of
+per-version Parquet sidecars that must be a projection of a node's **live**
+versions. `crates/provider/src/version_cache.rs` now names it once, with three
+barriers chosen so the bug class is unwritable rather than merely fixed:
+
+1. **`LiveVersions`** — a version list is a node-scoped type, not a bare `Vec`,
+   so "did the caller pass the live set?" is a type question, not a review one.
+2. **`SidecarDir::reconcile`** — both **adds** missing sidecars and **removes**
+   stale ones. A cache that only adds is how a superseded sidecar survives to be
+   counted twice.
+3. **`CachedSet`** — the only route to a `TableProvider`, carrying explicit file
+   paths. There is deliberately **no** `fn(&Path) -> TableProvider` in the
+   module, because every instance of this bug has been exactly that function.
+
+`SidecarNaming::NodeScoped` guards the rollup directory, which is shared by
+every node one `*` pattern matched: reconciliation there must never delete a
+sibling node's partials.
+
+**Behaviour change.** With superseded partials now deleted, a sealed run built
+on them is no longer a valid incremental base, so the level is **rebuilt** from
+the live partials instead of hard-failing with *"backfills an already-sealed
+bucket"*. That error was the site-staging outage. Raising `allowed_lateness` to
+14d only suppressed it — and left the silent doubling in its place.
+
+**Migration.** Reconciliation fixes future reads only. Water/septic sealed runs
+already froze doubled values and need a one-time `--rebuild` or a `cfg_hash`
+bump.
+
+### 12.3 Four defects with no test
+
+- **reclaim's delete commits were replayed as transactions.** They stamped the
+  collapse's `txn_seq` under `pond_txn`, and `reconstruct_txn_history` yields one
+  transaction per such commit, so `pond rebuild` replayed N+1 duplicate lifecycle
+  records at one sequence. Now stamped `pond_maintenance`.
+- **reclaim asserted nothing about what it deleted.** The strictly safer
+  `compact` verifies its `root_tree_hash`; reclaim, which deletes rows and sweeps
+  blobs permanently, did not. It now checks the content root either side of the
+  deletes **before** the sweep — deleted rows are recoverable from Delta history
+  or a mirror, a swept blob is not.
+- **A corrupt bao outboard silently produced a wrong baseline.** `.ok()`
+  conflated "no outboard" with "unparseable outboard", falling back to the
+  first-version baseline that the adjacent comment says is wrong for any later
+  run. Now a hard error.
+- **The collapse backstop rewrote the largest run.** It merged `0..FANOUT`, and
+  after any previous collapse index 0 *is* the accumulated run — the `O(N²)`
+  behaviour tiering exists to prevent. It fires far more often than it looks,
+  because callers pass the same number as both the candidacy threshold and
+  `max_live`, making `live.len() > max_live` true by construction. It now merges
+  the cheapest window of the same width.
+
+### Still open
+
+- **`version_gt` pruning is still blind after collapse** (§7). The fix is to
+  plumb `collapsed_from` / `collapsed_through` onto `tinyfs::FileVersionInfo`
+  and make raw `version` unusable for ordering, which would kill this class at
+  compile time. Two known sites order on raw `version`:
+  `format_cache` pruning and `tinyfs_object_store`'s `max_by_key(|v| v.version)`.
+- **Water/septic need a one-time `--rebuild`** before their reduced series can
+  be trusted (§12.2).
+- **The format cache still leaks stale parquets to disk** (§10). Correctness is
+  fine — reads name live files explicitly — but nothing sweeps them.

--- a/SELFMON-FINDINGS.md
+++ b/SELFMON-FINDINGS.md
@@ -746,6 +746,40 @@ bump.
   `max_live`, making `live.len() > max_live` true by construction. It now merges
   the cheapest window of the same width.
 
+### 12.4 A second review pass, after the fixes above
+
+The branch was then reviewed as a whole rather than change by change. That
+found one more piece of **silent data loss**, in the same family as §12.1 —
+something collapse destroys without saying so.
+
+`set-temporal-bounds` stores manual bounds on a dedicated **zero-byte**
+version. Collapse filters zero-byte rows out of its merge window, since they
+contribute no content — but the merged run's `[lo, hi]` range still **spans**
+their version numbers, so `is_superseded` retired them anyway. The bounds were
+deleted without ever being carried anywhere, and because a missing override
+maps to `(i64::MIN, i64::MAX)`, the series silently reverted to *unbounded*
+filtering: it re-admitted exactly the rows the operator had excluded. The
+lookup was independently wrong in the same way, selecting the override row by
+`max_by_key(version)` — the flavour-2 bug named in §12 — which after a collapse
+picks the merged run, which carries no override. Both halves had to be fixed;
+either alone still loses the bounds.
+
+Two smaller ones: reclaim scanned **every** `pond_id` for deletion candidates
+while its content-root guard only covers the local pond, so a foreign row was
+in scope for deletion but invisible to the check that is supposed to make
+deletion safe (latent — nothing currently lands a foreign superseded row
+locally); and `reconcile`, which runs on the **read** path where no write lock
+is held, aborted the whole query with `ENOENT` when a concurrent reader deleted
+the same stale sidecar first.
+
+The review also found that the test named for the reclaim content-root
+invariant did not actually pin it: a single collapse round leaves the merged
+run holding the highest version, so range containment and a watermark select
+the same rows and the test passed under both rules. Worth stating plainly,
+because it is the same failure mode as testsuite 050 in §12.1 — **a test that
+runs the right scenario but asserts something invariant under the bug.** That
+is now the second time on this branch, and it is the thing to watch for.
+
 ### Still open
 
 - **`version_gt` pruning is still blind after collapse** (§7). The fix is to

--- a/crates/cmd/src/commands/maintain.rs
+++ b/crates/cmd/src/commands/maintain.rs
@@ -15,6 +15,8 @@ use log::info;
 /// When `prune` is true, first deletes replicated control-table lifecycle
 /// history at or below a safe horizon so the subsequent checkpoint +
 /// vacuum reclaims it in the SAME pass (no extra ship open / read txn).
+/// Collapse likewise runs before the checkpoint + vacuum, since its
+/// reclamation phase deletes the rows that collapse superseded.
 pub async fn maintain_command(
     ship_context: &ShipContext,
     compact: bool,
@@ -44,8 +46,9 @@ pub async fn maintain_command(
         None
     };
 
-    let report = ship.maintain(true, compact).await;
-
+    // Collapse BEFORE maintain, for the same reason as prune above: collapse's
+    // reclamation phase deletes superseded rows, and those tombstones are only
+    // turned back into free space by the checkpoint + vacuum that follows.
     let collapse_report = if collapse_versions > 0 {
         Some(
             ship.collapse_versions(collapse_versions)
@@ -55,6 +58,8 @@ pub async fn maintain_command(
     } else {
         None
     };
+
+    let report = ship.maintain(true, compact).await;
 
     // Print results to stdout
     #[allow(clippy::print_stdout)]

--- a/crates/cmd/src/commands/temporal.rs
+++ b/crates/cmd/src/commands/temporal.rs
@@ -124,14 +124,17 @@ async fn detect_overlaps_impl(
             .map_err(|e| anyhow!("Failed to get records for {}: {}", path_str, e))?;
 
         // Filter out empty versions (size == 0) to avoid Parquet parsing errors,
-        // and versions superseded by a collapse merge row (collapsed_through).
-        let collapsed_through = records.iter().filter_map(|r| r.collapsed_through).max();
+        // and rows superseded by a collapse merge row's version range.
+        let live: std::collections::HashSet<i64> = tlogfs::schema::live_series_entries(&records)
+            .into_iter()
+            .map(|r| r.version)
+            .collect();
         let versions: Vec<_> = records
             .into_iter()
             .filter(|r| {
                 !matches!(r.format, tlogfs::schema::StorageFormat::Inline)
                     && r.size.unwrap_or(0) > 0
-                    && collapsed_through.is_none_or(|k| r.version > k)
+                    && live.contains(&r.version)
             })
             .collect();
 

--- a/crates/provider/src/factory/materialize_series.rs
+++ b/crates/provider/src/factory/materialize_series.rs
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Materialize a derived series into a physical `TablePhysicalSeries`.
+//!
+//! Watertown's typed signals are normally *derived*: `sql-derived-series` and
+//! `timeseries-join` nodes recompute their output from the underlying ingested
+//! bytes on every read.  That is the right default -- it costs no storage and
+//! can never go stale -- but it means the cost of a query grows with the whole
+//! history, and it means a pond built only from log ingest contains no
+//! `TablePhysicalSeries` at all.
+//!
+//! This factory turns such a signal into a stored one.  Each run it asks the
+//! target series how far it has already been materialized, selects only the
+//! source rows beyond that watermark, and appends them as ONE new version.
+//! The result is an append-only physical series with one version per tick --
+//! the same shape `hydrovu` produces, and therefore the same shape the
+//! collapse/reclaim path operates on.
+//!
+//! It is deliberately incremental rather than a snapshot-and-replace: a
+//! rewrite-everything materializer would reintroduce exactly the `O(N^2)` write
+//! amplification that size-tiered collapse exists to remove.
+
+use crate::{ExecutionContext, FactoryContext, register_executable_factory};
+use arrow::compute::concat_batches;
+use clap::{Parser, Subcommand};
+use datafusion::prelude::{SessionConfig, SessionContext, col, lit};
+use datafusion::scalar::ScalarValue;
+use log::{debug, info};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+use tinyfs::Result as TinyFSResult;
+use tinyfs::ResultExt;
+use tinyfs::arrow::parquet::ParquetExt;
+
+/// Subcommands, mirroring the ingest factories so `pond run <node> push`
+/// works uniformly across everything a tick invokes.
+#[derive(Debug, Parser)]
+struct MaterializeCommand {
+    #[command(subcommand)]
+    command: Option<MaterializeSubcommand>,
+}
+
+#[derive(Debug, Subcommand)]
+enum MaterializeSubcommand {
+    /// Append any source rows beyond the target's watermark (the default).
+    Push,
+    /// Accepted for uniformity; materialization only ever flows one way.
+    Pull,
+}
+
+fn parse_command(ctx: ExecutionContext) -> Result<MaterializeCommand, tinyfs::Error> {
+    let args: Vec<String> = std::iter::once("factory".to_string())
+        .chain(ctx.args().iter().cloned())
+        .collect();
+    MaterializeCommand::try_parse_from(args)
+        .map_err(|e| tinyfs::Error::Other(format!("Command parse error: {}", e)))
+}
+
+/// Configuration for the materialize-series factory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MaterializeSeriesConfig {
+    /// URL of the signal to materialize, e.g.
+    /// `series:///derived/p-water-prod`.  Anything the provider can turn into
+    /// a table works, so a derived node, a physical series, or a raw log read
+    /// through a format scheme are all valid sources.
+    pub source: crate::Url,
+
+    /// Pond path of the `TablePhysicalSeries` to append to.  Created on the
+    /// first run.
+    pub target: String,
+
+    /// Event-time column, present in the source and used both as the
+    /// watermark and as the series' temporal index.
+    pub time_column: String,
+}
+
+impl MaterializeSeriesConfig {
+    fn validate(&self) -> TinyFSResult<()> {
+        if self.target.is_empty() {
+            return Err(tinyfs::Error::Other(
+                "materialize-series: `target` must not be empty".to_string(),
+            ));
+        }
+        if self.time_column.is_empty() {
+            return Err(tinyfs::Error::Other(
+                "materialize-series: `time_column` must not be empty".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_config(config: &[u8]) -> TinyFSResult<Value> {
+    let config: MaterializeSeriesConfig =
+        serde_yaml::from_slice(config).map_other_context("Invalid config YAML")?;
+    config.validate()?;
+    serde_json::to_value(&config).map_other_context("Failed to serialize config")
+}
+
+async fn initialize(_config: Value, _context: FactoryContext) -> Result<(), tinyfs::Error> {
+    // The target series is created lazily by the first append, so there is
+    // nothing to set up.
+    Ok(())
+}
+
+/// A private session that can still resolve `tinyfs:///` URLs.
+///
+/// Reading a *physical* series goes through a `ListingTable` over `tinyfs://`
+/// paths, which only resolves if the tinyfs object store is registered -- and
+/// it is registered on the persistence layer's own session, not on a fresh
+/// one.  Borrowing that session's `RuntimeEnv` inherits the object-store
+/// registry while keeping a private catalog, so the table names used here
+/// cannot collide with anything else running in the transaction.
+fn scratch_session(context: &FactoryContext) -> SessionContext {
+    SessionContext::new_with_config_rt(
+        SessionConfig::new(),
+        context.context.datafusion_session.runtime_env(),
+    )
+}
+
+/// Build a DataFusion table for `url` in this pond's context.
+async fn table_for(
+    context: &FactoryContext,
+    url: &str,
+    ctx: &SessionContext,
+) -> Result<Arc<dyn datafusion::catalog::TableProvider>, tinyfs::Error> {
+    let fs = context.context.filesystem();
+    let mut provider =
+        crate::Provider::with_context(Arc::new(fs), Arc::new(context.context.clone()));
+    if let Ok(root) = context.root().await {
+        provider = provider.with_root(root);
+    }
+    provider
+        .create_table_provider(url, ctx)
+        .await
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: source '{url}': {e}")))
+}
+
+/// The largest event time already materialized into `target`, or `None` when
+/// the target does not exist yet.
+///
+/// Deliberately `max()` over the WHOLE target rather than a peek at its newest
+/// version: once size-tiered collapse has run, the highest version number is a
+/// merged run standing for content in the MIDDLE of the stream, so "latest
+/// version" is not "latest data".  Reading a stale watermark that way would
+/// silently re-append rows that are already stored.  DataFusion answers this
+/// from parquet statistics, so it does not decode row groups.
+async fn read_watermark(
+    context: &FactoryContext,
+    config: &MaterializeSeriesConfig,
+) -> Result<Option<ScalarValue>, tinyfs::Error> {
+    let root = context.root().await?;
+    if !root.exists(&config.target).await {
+        return Ok(None);
+    }
+
+    let url = format!("series://{}", config.target);
+    let ctx = scratch_session(context);
+    let table = table_for(context, &url, &ctx).await?;
+    let _previous = ctx
+        .register_table("target", table)
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: register target: {e}")))?;
+
+    let batches = ctx
+        .sql(&format!(
+            "SELECT max(\"{}\") AS watermark FROM target",
+            config.time_column
+        ))
+        .await
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: watermark sql: {e}")))?
+        .collect()
+        .await
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: watermark scan: {e}")))?;
+
+    for batch in &batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let scalar = ScalarValue::try_from_array(batch.column(0), 0).map_err(|e| {
+            tinyfs::Error::Other(format!("materialize-series: watermark decode: {e}"))
+        })?;
+        if !scalar.is_null() {
+            return Ok(Some(scalar));
+        }
+    }
+    Ok(None)
+}
+
+/// Append the source rows beyond the target's watermark as one new version.
+pub async fn execute(
+    config: Value,
+    context: FactoryContext,
+    ctx: ExecutionContext,
+) -> Result<(), tinyfs::Error> {
+    let config: MaterializeSeriesConfig =
+        serde_json::from_value(config).map_other_context("Invalid config")?;
+    config.validate()?;
+
+    if let Some(MaterializeSubcommand::Pull) = parse_command(ctx)?.command {
+        info!("materialize-series: 'pull' is a no-op (rows only flow source -> target)");
+        return Ok(());
+    }
+
+    let watermark = read_watermark(&context, &config).await?;
+
+    let session = scratch_session(&context);
+    let source = table_for(&context, &config.source.to_string(), &session).await?;
+    let _previous = session
+        .register_table("source", source)
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: register source: {e}")))?;
+
+    let mut frame = session
+        .table("source")
+        .await
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: read source: {e}")))?;
+
+    // Strictly greater-than: the watermark row is already stored, and the
+    // target is append-only, so re-emitting it would duplicate rather than
+    // update.
+    if let Some(ref bound) = watermark {
+        frame = frame
+            .filter(col(&config.time_column).gt(lit(bound.clone())))
+            .map_err(|e| tinyfs::Error::Other(format!("materialize-series: filter: {e}")))?;
+    }
+    let frame = frame
+        .sort_by(vec![col(&config.time_column)])
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: sort: {e}")))?;
+
+    let schema: arrow::datatypes::SchemaRef = Arc::new(frame.schema().as_arrow().clone());
+    let batches = frame
+        .collect()
+        .await
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: collect: {e}")))?;
+
+    let rows: usize = batches
+        .iter()
+        .map(arrow::array::RecordBatch::num_rows)
+        .sum();
+    if rows == 0 {
+        // The common case on a tick with no new source data.  Writing an empty
+        // version would burn a version number and a parquet file for nothing.
+        debug!(
+            "materialize-series: {} is up to date (watermark {:?})",
+            config.target, watermark
+        );
+        return Ok(());
+    }
+
+    // One version per run, not one per batch: versions are the unit collapse
+    // works on, so a run that emitted several would multiply the very count
+    // that triggers collapse.
+    let batch = concat_batches(&schema, &batches)
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: concat: {e}")))?;
+
+    let root = context.root().await?;
+    let (min_time, max_time) = root
+        .write_series_from_batch(&config.target, &batch, Some(&config.time_column))
+        .await?;
+
+    info!(
+        "materialize-series: appended {} row(s) to {} covering [{}, {}]",
+        rows, config.target, min_time, max_time
+    );
+    Ok(())
+}
+
+register_executable_factory!(
+    name: "materialize-series",
+    description: "Incrementally materialize a derived signal into a physical table series",
+    validate: validate_config,
+    initialize: initialize,
+    execute: execute
+);

--- a/crates/provider/src/factory/materialize_series.rs
+++ b/crates/provider/src/factory/materialize_series.rs
@@ -25,7 +25,7 @@
 use crate::{ExecutionContext, FactoryContext, register_executable_factory};
 use arrow::compute::concat_batches;
 use clap::{Parser, Subcommand};
-use datafusion::prelude::{SessionConfig, SessionContext, col, lit};
+use datafusion::prelude::{SessionContext, col, lit};
 use datafusion::scalar::ScalarValue;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
@@ -107,18 +107,15 @@ async fn initialize(_config: Value, _context: FactoryContext) -> Result<(), tiny
     Ok(())
 }
 
-/// A private session that can still resolve `tinyfs:///` URLs.
+/// A table name that is unique to this node.
 ///
-/// Reading a *physical* series goes through a `ListingTable` over `tinyfs://`
-/// paths, which only resolves if the tinyfs object store is registered -- and
-/// it is registered on the persistence layer's own session, not on a fresh
-/// one.  Borrowing that session's `RuntimeEnv` inherits the object-store
-/// registry while keeping a private catalog, so the table names used here
-/// cannot collide with anything else running in the transaction.
-fn scratch_session(context: &FactoryContext) -> SessionContext {
-    SessionContext::new_with_config_rt(
-        SessionConfig::new(),
-        context.context.datafusion_session.runtime_env(),
+/// Registrations go on the pond's shared session, so a bare name like
+/// "source" would collide with another materialize-series node running in the
+/// same transaction.  `sql_derived` qualifies its table names the same way.
+fn table_name(context: &FactoryContext, role: &str) -> String {
+    format!(
+        "materialize_{role}_{}",
+        context.file_id.node_id().to_string().replace('-', "")
     )
 }
 
@@ -159,15 +156,16 @@ async fn read_watermark(
     }
 
     let url = format!("series://{}", config.target);
-    let ctx = scratch_session(context);
-    let table = table_for(context, &url, &ctx).await?;
+    let ctx = &context.context.datafusion_session;
+    let table = table_for(context, &url, ctx).await?;
+    let name = table_name(context, "target");
     let _previous = ctx
-        .register_table("target", table)
+        .register_table(name.as_str(), table)
         .map_err(|e| tinyfs::Error::Other(format!("materialize-series: register target: {e}")))?;
 
     let batches = ctx
         .sql(&format!(
-            "SELECT max(\"{}\") AS watermark FROM target",
+            "SELECT max(\"{}\") AS watermark FROM \"{name}\"",
             config.time_column
         ))
         .await
@@ -175,6 +173,12 @@ async fn read_watermark(
         .collect()
         .await
         .map_err(|e| tinyfs::Error::Other(format!("materialize-series: watermark scan: {e}")))?;
+
+    // The shared session outlives this call, and the target grows a version
+    // every tick, so a registration left behind would be a stale view.
+    let _registered = ctx
+        .deregister_table(name.as_str())
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: deregister: {e}")))?;
 
     for batch in &batches {
         if batch.num_rows() == 0 {
@@ -207,14 +211,15 @@ pub async fn execute(
 
     let watermark = read_watermark(&context, &config).await?;
 
-    let session = scratch_session(&context);
-    let source = table_for(&context, &config.source.to_string(), &session).await?;
+    let session = &context.context.datafusion_session;
+    let source = table_for(&context, &config.source.to_string(), session).await?;
+    let source_name = table_name(&context, "source");
     let _previous = session
-        .register_table("source", source)
+        .register_table(source_name.as_str(), source)
         .map_err(|e| tinyfs::Error::Other(format!("materialize-series: register source: {e}")))?;
 
     let mut frame = session
-        .table("source")
+        .table(source_name.as_str())
         .await
         .map_err(|e| tinyfs::Error::Other(format!("materialize-series: read source: {e}")))?;
 
@@ -235,6 +240,10 @@ pub async fn execute(
         .collect()
         .await
         .map_err(|e| tinyfs::Error::Other(format!("materialize-series: collect: {e}")))?;
+
+    let _registered = session
+        .deregister_table(source_name.as_str())
+        .map_err(|e| tinyfs::Error::Other(format!("materialize-series: deregister: {e}")))?;
 
     let rows: usize = batches
         .iter()

--- a/crates/provider/src/factory/mod.rs
+++ b/crates/provider/src/factory/mod.rs
@@ -8,6 +8,7 @@ pub mod dynamic_dir;
 pub mod journal_ingest;
 mod lazy_sql_file;
 pub mod logfile_ingest;
+pub mod materialize_series;
 pub mod sql_derived;
 pub mod synthetic_timeseries;
 pub mod temporal_reduce;

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -478,6 +478,13 @@ impl TemporalReduceSqlFile {
         // and write the same finest-resolution partials.
         let site_node_id = id.part_id().to_node_id();
         let glob_dir = crate::rollup_cache::glob_dir(&cache_dir, &cfg_hash, &site_node_id);
+        let partials = crate::rollup_cache::partials_dir(&cache_dir, &cfg_hash, &site_node_id);
+        // Accumulated across source nodes: the partials of every source node's
+        // LIVE versions, named explicitly. Reading this instead of listing
+        // `glob_dir` is what keeps a version-collapse leftover out of the
+        // merge, where it would be summed a second time (testsuite 733).
+        let mut live_partials =
+            crate::version_cache::CachedSet::empty_in(partials.path().to_path_buf());
 
         let fs = self.context.context.filesystem();
         let mut provider_api =
@@ -514,8 +521,23 @@ impl TemporalReduceSqlFile {
                 EntryType::FilePhysicalSeries | EntryType::TablePhysicalSeries
             );
 
-            let mut uncached =
-                crate::rollup_cache::find_uncached_members(&glob_dir, &source_node_id, &versions);
+            let live =
+                crate::version_cache::LiveVersions::from_persistence(source_node_id, versions);
+            // Reconcile before writing: this both reports which live versions
+            // still need a partial and DELETES the partials of versions that a
+            // collapse superseded. A cache that only ever added is how those
+            // leftovers survived to be double-counted.
+            let reconciled = partials.reconcile(&live).map_other()?;
+            if !reconciled.removed.is_empty() {
+                log::info!(
+                    "temporal-reduce rollup: source node {} dropped {} partial(s) whose \
+                     versions are no longer live (version collapse); any sealed run built \
+                     on them will be rebuilt from the live partials",
+                    source_node_id,
+                    reconciled.removed.len()
+                );
+            }
+            let mut uncached = reconciled.missing;
             uncached.sort_by_key(|v| v.version);
             let mut frontier =
                 crate::rollup_cache::read_frontier(&glob_dir, &source_node_id).map_other()?;
@@ -569,6 +591,11 @@ impl TemporalReduceSqlFile {
                     }
                 }
             }
+
+            // Collected after the writes above, so newly written partials are
+            // included. Node scoped: a sibling source node's partials in this
+            // shared directory belong to its own live set, not this one's.
+            live_partials.extend(partials.cached_set(&live, |_| true));
         }
 
         let ctx = &context.datafusion_session;
@@ -596,9 +623,7 @@ impl TemporalReduceSqlFile {
             .collect();
         let partials_table = format!("__rollup_partials_{}_{}", cfg_hash, sanitized_id);
         if !ctx.table_exist(partials_table.as_str()).unwrap_or(false) {
-            let provider = crate::rollup_cache::listing_table_from_dir(&glob_dir, ctx)
-                .await
-                .map_other()?;
+            let provider = live_partials.table_provider().await.map_other()?;
             _ = ctx
                 .register_table(partials_table.as_str(), provider)
                 .map_other()?;
@@ -1317,15 +1342,10 @@ impl TemporalReduceSqlFile {
 
         let schema = stream.schema();
         let mapped = stream.map(|r| r.map_err(|e| crate::error::Error::Arrow(e.to_string())));
-        _ = crate::rollup_cache::write_glob_member(
-            glob_dir,
-            source_node_id,
-            version,
-            schema,
-            Box::pin(mapped),
-        )
-        .await
-        .map_other()?;
+        _ = crate::rollup_cache::partials_dir_at(glob_dir)
+            .write_sidecar(source_node_id, version, schema, Box::pin(mapped))
+            .await
+            .map_other()?;
         Ok(())
     }
 

--- a/crates/provider/src/format_cache.rs
+++ b/crates/provider/src/format_cache.rs
@@ -16,22 +16,17 @@
 //! - Returns `ListingTable` over cached Parquet files for full DataFusion pushdown.
 
 use arrow::datatypes::SchemaRef;
-use arrow::record_batch::RecordBatch;
 use datafusion::catalog::TableProvider;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
 use datafusion::execution::context::SessionContext;
-use datafusion::parquet::basic::Compression;
-use datafusion::parquet::file::properties::WriterProperties;
-use futures::StreamExt;
-use futures::stream::Stream;
-use parquet::arrow::AsyncArrowWriter;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::sync::Arc;
 use tinyfs::FileVersionInfo;
+
+use crate::version_cache::{LiveVersions, SidecarDir, SidecarNaming};
 
 /// Result type for format cache operations
 type Result<T> = std::result::Result<T, crate::error::Error>;
@@ -44,13 +39,21 @@ pub fn cache_node_dir(cache_dir: &Path, scheme: &str, node_id: &tinyfs::NodeID) 
     cache_dir.join(format!("{}_{}", scheme, node_id))
 }
 
+/// This node's cached versions, as a [`SidecarDir`].
+///
+/// [`SidecarNaming::NodeOwned`]: the directory holds exactly one node's
+/// versions, so every Parquet in it belongs to that node.
+#[must_use]
+pub fn node_sidecars(cache_dir: &Path, scheme: &str, node_id: &tinyfs::NodeID) -> SidecarDir {
+    SidecarDir::new(
+        cache_node_dir(cache_dir, scheme, node_id),
+        SidecarNaming::NodeOwned,
+    )
+}
+
 /// Path for a single version's cached Parquet file.
 ///
 /// Returns `{cache_dir}/{scheme}_{node_id}/v{version}_{blake3}.parquet`
-///
-/// # Panics
-/// Panics if `version.blake3` is `None` -- format providers only operate on
-/// file data, which always has a blake3 hash.
 #[must_use]
 pub fn cache_version_path(
     cache_dir: &Path,
@@ -58,19 +61,10 @@ pub fn cache_version_path(
     node_id: &tinyfs::NodeID,
     version: &FileVersionInfo,
 ) -> PathBuf {
-    // Physical files use blake3 content hash for cache invalidation.
-    // Dynamic files use their NodeID short string instead — the NodeID is
-    // already deterministic (derived from content identity, e.g., git blob OID).
-    let key = match version.blake3.as_deref() {
-        Some(hash) => hash.to_string(),
-        None => node_id.to_short_string(),
-    };
-    cache_node_dir(cache_dir, scheme, node_id).join(format!("v{}_{}.parquet", version.version, key))
+    node_sidecars(cache_dir, scheme, node_id).sidecar_path(node_id, version)
 }
 
-/// Check which versions are missing from the cache.
-///
-/// Returns the subset of versions whose cached Parquet files do not exist on disk.
+/// Check which of a node's live versions are missing from the cache.
 #[must_use]
 pub fn find_uncached_versions(
     cache_dir: &Path,
@@ -78,88 +72,26 @@ pub fn find_uncached_versions(
     node_id: &tinyfs::NodeID,
     versions: &[FileVersionInfo],
 ) -> Vec<FileVersionInfo> {
-    versions
-        .iter()
-        .filter(|v| {
-            let path = cache_version_path(cache_dir, scheme, node_id, v);
-            !path.exists()
-        })
-        .cloned()
-        .collect()
+    let live = LiveVersions::from_persistence(*node_id, versions.to_vec());
+    node_sidecars(cache_dir, scheme, node_id).missing(&live)
 }
 
 /// Write a single version's format output to cache as Parquet.
 ///
-/// Streams batches from the format provider through `AsyncArrowWriter` to
-/// disk.  Does NOT collect into memory.  Uses atomic write (write to `.tmp`
-/// then rename) to prevent partial files on crash.
+/// Streams batches from the format provider to disk without collecting them,
+/// and writes atomically so a crash cannot leave a truncated file that a later
+/// run would mistake for a complete cached version.
 pub async fn cache_write_version(
     cache_dir: &Path,
     scheme: &str,
     node_id: &tinyfs::NodeID,
     version: &FileVersionInfo,
     schema: SchemaRef,
-    stream: Pin<
-        Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
-    >,
+    stream: crate::version_cache::BatchStream,
 ) -> Result<PathBuf> {
-    let dir = cache_node_dir(cache_dir, scheme, node_id);
-    tokio::fs::create_dir_all(&dir).await?;
-
-    let final_path = cache_version_path(cache_dir, scheme, node_id, version);
-
-    // Atomic write: write to .tmp then rename to prevent partial files on crash
-    let tmp_path = final_path.with_extension("parquet.tmp");
-
-    let file = tokio::fs::File::create(&tmp_path).await?;
-
-    let props = WriterProperties::builder()
-        .set_compression(Compression::ZSTD(parquet::basic::ZstdLevel::default()))
-        .build();
-    let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props))
-        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-
-    let mut stream = stream;
-    while let Some(batch) = stream.next().await {
-        let batch = batch?;
-        writer
-            .write(&batch)
-            .await
-            .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-    }
-    let _metadata = writer
-        .close()
+    node_sidecars(cache_dir, scheme, node_id)
+        .write_sidecar(node_id, version, schema, stream)
         .await
-        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-
-    // Atomic rename: .tmp -> final
-    tokio::fs::rename(&tmp_path, &final_path).await?;
-
-    log::debug!("[SAVE] Format cache: wrote {}", final_path.display());
-
-    Ok(final_path)
-}
-
-/// Build a `ListingTable` over all cached version Parquet files for a node.
-///
-/// Assumes all versions are already cached (call `cache_write_version` for any
-/// uncached versions first).
-pub async fn listing_table_from_cache(
-    cache_dir: &Path,
-    scheme: &str,
-    node_id: &tinyfs::NodeID,
-    versions: &[FileVersionInfo],
-    ctx: &SessionContext,
-) -> Result<Arc<dyn TableProvider>> {
-    listing_table_from_cache_bounded(
-        cache_dir,
-        scheme,
-        node_id,
-        versions,
-        &tinyfs::SeriesReadBounds::NONE,
-        ctx,
-    )
-    .await
 }
 
 /// Extract a series version's recorded `max_event_time` (epoch µs) from its
@@ -179,10 +111,16 @@ fn version_max_event_time(v: &FileVersionInfo) -> Option<i64> {
 /// `bounds` (per-version event-time / watermark prune), so a bounded reader
 /// scans only the hot files instead of all cached history.
 ///
-/// When `bounds` is [`tinyfs::SeriesReadBounds::NONE`] this is equivalent to
-/// [`listing_table_from_cache`] (all versions). When the bounds retain no
-/// version, an empty table over the merged cache schema is returned (0 rows),
-/// never a silent full scan.
+/// When `bounds` is [`tinyfs::SeriesReadBounds::NONE`] this covers every live
+/// version. When the bounds retain no version, an empty table over the merged
+/// cache schema is returned (0 rows), never a silent full scan.
+///
+/// `versions` must be the node's LIVE versions. The scan names their files
+/// explicitly rather than listing the cache directory, which accumulates a
+/// Parquet per version ever written: version collapse replaces a run of
+/// versions with one merged version carrying the same content, so a listing
+/// would return both the merged version and the superseded ones it stands for,
+/// silently double-counting every row.
 pub async fn listing_table_from_cache_bounded(
     cache_dir: &Path,
     scheme: &str,
@@ -191,49 +129,13 @@ pub async fn listing_table_from_cache_bounded(
     bounds: &tinyfs::SeriesReadBounds,
     _ctx: &SessionContext,
 ) -> Result<Arc<dyn TableProvider>> {
-    // Collect the retained versions' Parquet paths (only those present on disk).
-    //
-    // These paths are named EXPLICITLY rather than by globbing the node's
-    // cache directory.  The directory accumulates a Parquet per version ever
-    // written, but `versions` is the set of versions that are currently LIVE.
-    // Version collapse breaks the assumption that those two sets agree: it
-    // replaces a run of versions with one merged version carrying the same
-    // content, so a glob would return both the merged version and the
-    // superseded ones it stands for, silently double-counting every row.
-    let mut paths: Vec<ListingTableUrl> = Vec::new();
-    let mut files: Vec<PathBuf> = Vec::new();
-    for v in versions {
-        if !bounds.retains(version_max_event_time(v), v.version as i64) {
-            continue;
-        }
-        let p = cache_version_path(cache_dir, scheme, node_id, v);
-        if p.exists() {
-            paths.push(ListingTableUrl::parse(format!("file://{}", p.display()))?);
-            files.push(p);
-        }
-    }
-
-    // Merge schemas from the retained files only, for the same reason: a
-    // superseded version's cached schema must not shape the read.
-    let merged_schema =
-        merge_parquet_schemas(&files, &cache_node_dir(cache_dir, scheme, node_id)).await?;
-
-    if paths.is_empty() {
-        // Every version pruned: return an empty table over the cache schema so
-        // the query yields 0 rows rather than erroring or scanning everything.
-        // MemTable requires at least one partition (a partition with no batches).
-        let table = datafusion::datasource::MemTable::try_new(merged_schema, vec![vec![]])?;
-        return Ok(Arc::new(table));
-    }
-
-    let listing_options =
-        ListingOptions::new(Arc::new(ParquetFormat::default())).with_file_extension(".parquet");
-    let config = ListingTableConfig::new_with_multi_paths(paths)
-        .with_listing_options(listing_options)
-        .with_schema(merged_schema);
-
-    let table = ListingTable::try_new(config)?;
-    Ok(Arc::new(table))
+    let live = LiveVersions::from_persistence(*node_id, versions.to_vec());
+    node_sidecars(cache_dir, scheme, node_id)
+        .cached_set(&live, |v| {
+            bounds.retains(version_max_event_time(v), v.version as i64)
+        })
+        .table_provider()
+        .await
 }
 
 /// Directory for a glob-scoped unified cache (all files matching a pattern).
@@ -331,7 +233,7 @@ pub async fn listing_table_from_glob_cache(
     // DataFusion's infer_schema only samples a subset of files, which loses
     // columns that appear in later files (e.g., sensors added over time).
     // This is the glob-cache equivalent of UNION ALL BY NAME's schema merge.
-    let merged_schema = merge_parquet_schemas_in_dir(glob_dir).await?;
+    let merged_schema = crate::version_cache::merge_parquet_schemas_in_dir(glob_dir).await?;
 
     let config = ListingTableConfig::new(table_url)
         .with_listing_options(listing_options)
@@ -341,87 +243,14 @@ pub async fn listing_table_from_glob_cache(
     Ok(Arc::new(table))
 }
 
-/// Read the Arrow schema from every `.parquet` file under `dir` and merge
-/// them via `Schema::try_merge`.  This gives UNION-ALL-BY-NAME semantics:
-/// columns that appear in any file are present in the result, and files
-/// missing a column will produce NULLs when read through the ListingTable.
-/// Merge the schemas of an explicit list of cached Parquet files.
-///
-/// `context_dir` is used only to describe the error when the list is empty.
-async fn merge_parquet_schemas(files: &[PathBuf], context_dir: &Path) -> Result<SchemaRef> {
-    use arrow::datatypes::Schema;
-
-    let mut schemas = Vec::new();
-    for path in files {
-        let file = tokio::fs::File::open(path).await?;
-        let reader = parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder::new(file)
-            .await
-            .map_err(|e| {
-                crate::error::Error::Arrow(format!(
-                    "Failed to read parquet metadata from '{}': {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-        schemas.push(reader.schema().as_ref().clone());
-    }
-
-    if schemas.is_empty() {
-        // No live version is cached yet.  Fall back to whatever the directory
-        // holds so the caller gets an empty table with a usable schema rather
-        // than an error.
-        return merge_parquet_schemas_in_dir(context_dir).await;
-    }
-
-    let merged = Schema::try_merge(schemas).map_err(|e| {
-        crate::error::Error::Arrow(format!("Failed to merge parquet schemas: {}", e))
-    })?;
-
-    Ok(Arc::new(merged))
-}
-
-async fn merge_parquet_schemas_in_dir(dir: &Path) -> Result<SchemaRef> {
-    use arrow::datatypes::Schema;
-
-    let mut schemas = Vec::new();
-    let mut entries = tokio::fs::read_dir(dir).await?;
-
-    while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "parquet") {
-            let file = tokio::fs::File::open(&path).await?;
-            let reader = parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder::new(file)
-                .await
-                .map_err(|e| {
-                    crate::error::Error::Arrow(format!(
-                        "Failed to read parquet metadata from '{}': {}",
-                        path.display(),
-                        e
-                    ))
-                })?;
-            schemas.push(reader.schema().as_ref().clone());
-        }
-    }
-
-    if schemas.is_empty() {
-        return Err(crate::error::Error::Arrow(format!(
-            "No parquet files found in glob cache dir '{}'",
-            dir.display()
-        )));
-    }
-
-    let merged = Schema::try_merge(schemas).map_err(|e| {
-        crate::error::Error::Arrow(format!("Failed to merge parquet schemas: {}", e))
-    })?;
-
-    Ok(Arc::new(merged))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use arrow::array::{Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use futures::stream::Stream;
+    use std::pin::Pin;
     use std::sync::Arc;
 
     fn test_schema() -> SchemaRef {
@@ -578,9 +407,16 @@ mod tests {
 
         // Build ListingTable and verify
         let ctx = SessionContext::new();
-        let table = listing_table_from_cache(cache_dir, "csv", &node_id, &versions, &ctx)
-            .await
-            .unwrap();
+        let table = listing_table_from_cache_bounded(
+            cache_dir,
+            "csv",
+            &node_id,
+            &versions,
+            &tinyfs::SeriesReadBounds::NONE,
+            &ctx,
+        )
+        .await
+        .unwrap();
 
         // Should have the correct schema
         let table_schema = table.schema();

--- a/crates/provider/src/format_cache.rs
+++ b/crates/provider/src/format_cache.rs
@@ -148,26 +148,18 @@ pub async fn listing_table_from_cache(
     cache_dir: &Path,
     scheme: &str,
     node_id: &tinyfs::NodeID,
-    _ctx: &SessionContext,
+    versions: &[FileVersionInfo],
+    ctx: &SessionContext,
 ) -> Result<Arc<dyn TableProvider>> {
-    let dir = cache_node_dir(cache_dir, scheme, node_id);
-    let dir_url = format!("file://{}/", dir.display());
-
-    let table_url = ListingTableUrl::parse(&dir_url)?;
-    let listing_options =
-        ListingOptions::new(Arc::new(ParquetFormat::default())).with_file_extension(".parquet");
-
-    // Merge schemas from all cached parquet versions.  Format providers like
-    // oteljson produce variable schemas (columns appear/disappear across
-    // lines), so even a single file's cached versions can differ.
-    let merged_schema = merge_parquet_schemas_in_dir(&dir).await?;
-
-    let config = ListingTableConfig::new(table_url)
-        .with_listing_options(listing_options)
-        .with_schema(merged_schema);
-
-    let table = ListingTable::try_new(config)?;
-    Ok(Arc::new(table))
+    listing_table_from_cache_bounded(
+        cache_dir,
+        scheme,
+        node_id,
+        versions,
+        &tinyfs::SeriesReadBounds::NONE,
+        ctx,
+    )
+    .await
 }
 
 /// Extract a series version's recorded `max_event_time` (epoch µs) from its
@@ -197,17 +189,19 @@ pub async fn listing_table_from_cache_bounded(
     node_id: &tinyfs::NodeID,
     versions: &[FileVersionInfo],
     bounds: &tinyfs::SeriesReadBounds,
-    ctx: &SessionContext,
+    _ctx: &SessionContext,
 ) -> Result<Arc<dyn TableProvider>> {
-    if *bounds == tinyfs::SeriesReadBounds::NONE {
-        return listing_table_from_cache(cache_dir, scheme, node_id, ctx).await;
-    }
-
-    let dir = cache_node_dir(cache_dir, scheme, node_id);
-    let merged_schema = merge_parquet_schemas_in_dir(&dir).await?;
-
     // Collect the retained versions' Parquet paths (only those present on disk).
+    //
+    // These paths are named EXPLICITLY rather than by globbing the node's
+    // cache directory.  The directory accumulates a Parquet per version ever
+    // written, but `versions` is the set of versions that are currently LIVE.
+    // Version collapse breaks the assumption that those two sets agree: it
+    // replaces a run of versions with one merged version carrying the same
+    // content, so a glob would return both the merged version and the
+    // superseded ones it stands for, silently double-counting every row.
     let mut paths: Vec<ListingTableUrl> = Vec::new();
+    let mut files: Vec<PathBuf> = Vec::new();
     for v in versions {
         if !bounds.retains(version_max_event_time(v), v.version as i64) {
             continue;
@@ -215,8 +209,14 @@ pub async fn listing_table_from_cache_bounded(
         let p = cache_version_path(cache_dir, scheme, node_id, v);
         if p.exists() {
             paths.push(ListingTableUrl::parse(format!("file://{}", p.display()))?);
+            files.push(p);
         }
     }
+
+    // Merge schemas from the retained files only, for the same reason: a
+    // superseded version's cached schema must not shape the read.
+    let merged_schema =
+        merge_parquet_schemas(&files, &cache_node_dir(cache_dir, scheme, node_id)).await?;
 
     if paths.is_empty() {
         // Every version pruned: return an empty table over the cache schema so
@@ -345,6 +345,41 @@ pub async fn listing_table_from_glob_cache(
 /// them via `Schema::try_merge`.  This gives UNION-ALL-BY-NAME semantics:
 /// columns that appear in any file are present in the result, and files
 /// missing a column will produce NULLs when read through the ListingTable.
+/// Merge the schemas of an explicit list of cached Parquet files.
+///
+/// `context_dir` is used only to describe the error when the list is empty.
+async fn merge_parquet_schemas(files: &[PathBuf], context_dir: &Path) -> Result<SchemaRef> {
+    use arrow::datatypes::Schema;
+
+    let mut schemas = Vec::new();
+    for path in files {
+        let file = tokio::fs::File::open(path).await?;
+        let reader = parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder::new(file)
+            .await
+            .map_err(|e| {
+                crate::error::Error::Arrow(format!(
+                    "Failed to read parquet metadata from '{}': {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+        schemas.push(reader.schema().as_ref().clone());
+    }
+
+    if schemas.is_empty() {
+        // No live version is cached yet.  Fall back to whatever the directory
+        // holds so the caller gets an empty table with a usable schema rather
+        // than an error.
+        return merge_parquet_schemas_in_dir(context_dir).await;
+    }
+
+    let merged = Schema::try_merge(schemas).map_err(|e| {
+        crate::error::Error::Arrow(format!("Failed to merge parquet schemas: {}", e))
+    })?;
+
+    Ok(Arc::new(merged))
+}
+
 async fn merge_parquet_schemas_in_dir(dir: &Path) -> Result<SchemaRef> {
     use arrow::datatypes::Schema;
 
@@ -522,8 +557,10 @@ mod tests {
         let schema = test_schema();
 
         // Write two versions
+        let mut versions = Vec::new();
         for i in 1_i64..=2 {
             let version = test_version(i as u64, &format!("hash{}", i));
+            versions.push(version.clone());
             let batch = test_batch(&schema, &[i * 1000], &[&format!("val{}", i)]);
             let stream: Pin<
                 Box<
@@ -541,7 +578,7 @@ mod tests {
 
         // Build ListingTable and verify
         let ctx = SessionContext::new();
-        let table = listing_table_from_cache(cache_dir, "csv", &node_id, &ctx)
+        let table = listing_table_from_cache(cache_dir, "csv", &node_id, &versions, &ctx)
             .await
             .unwrap();
 

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -21,6 +21,7 @@ mod table_provider_options;
 mod tinyfs_object_store;
 mod tinyfs_path;
 mod url_pattern_matcher;
+pub mod version_cache;
 mod version_selection;
 
 pub use error::{Error, Result};

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -36,7 +36,6 @@ use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
-use datafusion::execution::context::SessionContext;
 use datafusion::parquet::basic::Compression;
 use datafusion::parquet::file::properties::WriterProperties;
 use futures::StreamExt;
@@ -47,7 +46,6 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use tinyfs::FileVersionInfo;
 
 /// Result type for rollup cache operations.
 type Result<T> = std::result::Result<T, crate::error::Error>;
@@ -82,44 +80,13 @@ pub fn cache_node_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID
     cache_dir.join(format!("rollup_{}_{}", cfg_hash, node_id))
 }
 
-/// Cache key for an input version: its blake3 content hash, or -- for dynamic
-/// inputs that carry no blake3 -- the node's short id (already content derived).
-///
-/// Mirrors [`crate::format_cache::cache_version_path`] keying exactly.
-fn version_key(node_id: &tinyfs::NodeID, version: &FileVersionInfo) -> String {
-    match version.blake3.as_deref() {
-        Some(hash) => hash.to_string(),
-        None => node_id.to_short_string(),
-    }
-}
-
-/// Build a `ListingTable` over every `.parquet` partials file directly under
-/// `dir`, merging their schemas (UNION-ALL-BY-NAME across versions/sources).
-pub async fn listing_table_from_dir(
-    dir: &Path,
-    _ctx: &SessionContext,
-) -> Result<Arc<dyn TableProvider>> {
-    let dir_url = format!("file://{}/", dir.display());
-
-    let table_url = ListingTableUrl::parse(&dir_url)?;
-    let listing_options =
-        ListingOptions::new(Arc::new(ParquetFormat::default())).with_file_extension(".parquet");
-
-    let merged_schema = merge_parquet_schemas_in_dir(dir).await?;
-
-    let config = ListingTableConfig::new(table_url)
-        .with_listing_options(listing_options)
-        .with_schema(merged_schema);
-
-    let table = ListingTable::try_new(config)?;
-    Ok(Arc::new(table))
-}
-
-// A `ListingTable` reads all partials in the glob dir together. There is one
-// partial file per (source node, input version). The source pattern can match
-// many rotated input files, each its own node with its own versions; keying the
-// partial filename by the source node id keeps them collision-free while all
-// partials still merge in a single `ListingTable`.
+// A rollup glob dir is a `SidecarNaming::NodeScoped` [`crate::version_cache::SidecarDir`]:
+// one partial file per (source node, input version). The source pattern can
+// match many rotated input files, each its own node with its own versions, so
+// the directory is shared and reconciliation there must be node scoped. The
+// naming, writing, reconciling and reading of those partials lives in
+// `version_cache`; this module keeps only what is genuinely rollup specific
+// (the sequentiality frontier, sealed runs, and namespace drops).
 
 /// Directory holding all per-source-version partials for one temporal-reduce
 /// node and config namespace: `{cache_dir}/rollup_{cfg_hash}_{tr_node_id}/`.
@@ -128,73 +95,26 @@ pub fn glob_dir(cache_dir: &Path, cfg_hash: &str, tr_node_id: &tinyfs::NodeID) -
     cache_node_dir(cache_dir, cfg_hash, tr_node_id)
 }
 
-/// Path for one source node's input version partial within the glob dir:
-/// `{glob_dir}/{source_node}_v{version}_{key}.parquet`.
+/// Wrap an already-resolved partials directory path as a sidecar dir.
 #[must_use]
-pub fn glob_member_path(
-    glob_dir: &Path,
-    source_node_id: &tinyfs::NodeID,
-    version: &FileVersionInfo,
-) -> PathBuf {
-    let key = version_key(source_node_id, version);
-    glob_dir.join(format!(
-        "{}_v{}_{}.parquet",
-        source_node_id, version.version, key
-    ))
+pub fn partials_dir_at(glob_dir: &Path) -> crate::version_cache::SidecarDir {
+    crate::version_cache::SidecarDir::new(
+        glob_dir.to_path_buf(),
+        crate::version_cache::SidecarNaming::NodeScoped,
+    )
 }
 
-/// Return the subset of a source node's versions whose partials are not yet
-/// present in the glob dir.
+/// The partials directory of one temporal-reduce node, as a sidecar dir.
 #[must_use]
-pub fn find_uncached_members(
-    glob_dir: &Path,
-    source_node_id: &tinyfs::NodeID,
-    versions: &[FileVersionInfo],
-) -> Vec<FileVersionInfo> {
-    versions
-        .iter()
-        .filter(|v| !glob_member_path(glob_dir, source_node_id, v).exists())
-        .cloned()
-        .collect()
-}
-
-/// Write one source-version partials stream into the glob dir (atomic).
-pub async fn write_glob_member(
-    glob_dir: &Path,
-    source_node_id: &tinyfs::NodeID,
-    version: &FileVersionInfo,
-    schema: SchemaRef,
-    stream: Pin<
-        Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
-    >,
-) -> Result<PathBuf> {
-    tokio::fs::create_dir_all(glob_dir).await?;
-    let final_path = glob_member_path(glob_dir, source_node_id, version);
-    let tmp_path = final_path.with_extension("parquet.tmp");
-
-    let file = tokio::fs::File::create(&tmp_path).await?;
-    let props = WriterProperties::builder()
-        .set_compression(Compression::ZSTD(parquet::basic::ZstdLevel::default()))
-        .build();
-    let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props))
-        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-
-    let mut stream = stream;
-    while let Some(batch) = stream.next().await {
-        let batch = batch?;
-        writer
-            .write(&batch)
-            .await
-            .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-    }
-    let _metadata = writer
-        .close()
-        .await
-        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-
-    tokio::fs::rename(&tmp_path, &final_path).await?;
-    log::debug!("[SAVE] Rollup cache: wrote {}", final_path.display());
-    Ok(final_path)
+pub fn partials_dir(
+    cache_dir: &Path,
+    cfg_hash: &str,
+    tr_node_id: &tinyfs::NodeID,
+) -> crate::version_cache::SidecarDir {
+    crate::version_cache::SidecarDir::new(
+        glob_dir(cache_dir, cfg_hash, tr_node_id),
+        crate::version_cache::SidecarNaming::NodeScoped,
+    )
 }
 
 /// Drop a node's entire rollup-cache namespace for one config, forcing all
@@ -340,44 +260,6 @@ pub fn list_glob_members(glob_dir: &Path) -> Result<Vec<PathBuf>> {
     }
     out.sort();
     Ok(out)
-}
-
-/// via `Schema::try_merge`, giving UNION-ALL-BY-NAME semantics across versions.
-async fn merge_parquet_schemas_in_dir(dir: &Path) -> Result<SchemaRef> {
-    use arrow::datatypes::Schema;
-
-    let mut schemas = Vec::new();
-    let mut entries = tokio::fs::read_dir(dir).await?;
-
-    while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "parquet") {
-            let file = tokio::fs::File::open(&path).await?;
-            let reader = parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder::new(file)
-                .await
-                .map_err(|e| {
-                    crate::error::Error::Arrow(format!(
-                        "Failed to read parquet metadata from '{}': {}",
-                        path.display(),
-                        e
-                    ))
-                })?;
-            schemas.push(reader.schema().as_ref().clone());
-        }
-    }
-
-    if schemas.is_empty() {
-        return Err(crate::error::Error::Arrow(format!(
-            "No parquet files found in rollup cache dir '{}'",
-            dir.display()
-        )));
-    }
-
-    let merged = Schema::try_merge(schemas).map_err(|e| {
-        crate::error::Error::Arrow(format!("Failed to merge rollup partial schemas: {}", e))
-    })?;
-
-    Ok(Arc::new(merged))
 }
 
 // --- Sealed-runs merged cache (Phase 2: watermark + immutable runs) ----------
@@ -610,7 +492,7 @@ pub async fn listing_table_for_res_dir(
         .with_file_sort_order(vec![vec![
             datafusion::prelude::col(ts_column).sort(true, false),
         ]]);
-    let merged_schema = merge_parquet_schemas_in_dir(res_dir).await?;
+    let merged_schema = crate::version_cache::merge_parquet_schemas_in_dir(res_dir).await?;
     let config = ListingTableConfig::new(table_url)
         .with_listing_options(listing_options)
         .with_schema(merged_schema);
@@ -623,7 +505,9 @@ mod tests {
     use super::*;
     use arrow::array::{Float64Array, Int64Array};
     use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::execution::context::SessionContext;
     use std::sync::Arc;
+    use tinyfs::FileVersionInfo;
 
     fn partials_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![
@@ -685,50 +569,17 @@ mod tests {
         assert!(dir_str.contains(&node_id.to_string()));
     }
 
-    #[test]
-    fn test_glob_member_path_keys_by_blake3() {
-        let node_id = test_node_id();
-        let version = test_version(3, Some("abc123"));
-        let path = glob_member_path(Path::new("/tmp/pond/cache/rollup_cfg_x"), &node_id, &version);
-        let filename = path.file_name().unwrap().to_str().unwrap();
-        assert_eq!(filename, format!("{}_v3_abc123.parquet", node_id));
-    }
-
-    #[test]
-    fn test_glob_member_path_dynamic_uses_node_id() {
-        let node_id = test_node_id();
-        let version = test_version(1, None);
-        let path = glob_member_path(Path::new("/tmp/pond/cache/rollup_cfg_x"), &node_id, &version);
-        let filename = path.file_name().unwrap().to_str().unwrap();
-        assert!(filename.contains("_v1_"));
-        assert!(filename.contains(&node_id.to_short_string()));
-    }
-
-    #[test]
-    fn test_find_uncached_members() {
-        let tmp = tempfile::tempdir().unwrap();
-        let node_id = test_node_id();
-        let gdir = glob_dir(tmp.path(), "cfg", &node_id);
-        let versions = vec![test_version(1, Some("aaa")), test_version(2, Some("bbb"))];
-
-        // Nothing cached yet.
-        assert_eq!(find_uncached_members(&gdir, &node_id, &versions).len(), 2);
-
-        // Pre-create v1's partial file.
-        let v1 = glob_member_path(&gdir, &node_id, &versions[0]);
-        std::fs::create_dir_all(v1.parent().unwrap()).unwrap();
-        std::fs::write(&v1, b"fake").unwrap();
-
-        let uncached = find_uncached_members(&gdir, &node_id, &versions);
-        assert_eq!(uncached.len(), 1);
-        assert_eq!(uncached[0].version, 2);
-    }
-
+    /// Partials of several input versions merge to exactly the single-pass
+    /// GROUP BY result, including a bucket straddling two versions -- and,
+    /// after a version collapse, the superseded versions' partials are gone
+    /// rather than summed a second time.
     #[tokio::test]
     async fn test_write_and_list_partials_merge() {
+        use crate::version_cache::LiveVersions;
+
         let tmp = tempfile::tempdir().unwrap();
         let node_id = test_node_id();
-        let gdir = glob_dir(tmp.path(), "cfg", &node_id);
+        let dir = partials_dir(tmp.path(), "cfg", &node_id);
         let schema = partials_schema();
 
         // Version 1: bucket 0 sum=10 count=2 ; bucket 1 sum=5 count=1
@@ -737,7 +588,8 @@ mod tests {
         let s1: Pin<
             Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
         > = Box::pin(futures::stream::iter(vec![Ok(b1)]));
-        _ = write_glob_member(&gdir, &node_id, &v1, schema.clone(), s1)
+        _ = dir
+            .write_sidecar(&node_id, &v1, schema.clone(), s1)
             .await
             .unwrap();
 
@@ -747,19 +599,47 @@ mod tests {
         let s2: Pin<
             Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
         > = Box::pin(futures::stream::iter(vec![Ok(b2)]));
-        _ = write_glob_member(&gdir, &node_id, &v2, schema.clone(), s2)
+        _ = dir
+            .write_sidecar(&node_id, &v2, schema.clone(), s2)
             .await
             .unwrap();
 
-        // Incrementality: both versions now cached.
-        assert_eq!(
-            find_uncached_members(&gdir, &node_id, &[v1.clone(), v2.clone()]).len(),
-            0
-        );
+        // Incrementality: both versions now cached, nothing stale.
+        let live = LiveVersions::from_persistence(node_id, vec![v1.clone(), v2.clone()]);
+        let reconciled = dir.reconcile(&live).unwrap();
+        assert!(reconciled.missing.is_empty());
+        assert!(reconciled.removed.is_empty());
 
-        // Merge the partials and verify the boundary bucket reconstructs exactly.
+        let merged = merge_partials(&dir.cached_set(&live, |_| true)).await;
+        assert_eq!(merged, vec![(0, 10.0, 2), (1, 12.0, 2), (2, 4.0, 1)]);
+
+        // Now collapse v1+v2 into a single live v3 covering the same rows. The
+        // superseded partials must be removed, not merged on top of v3's --
+        // that addition is the double-count pinned by testsuite 733.
+        let v3 = test_version(3, Some("v3hash"));
+        let live = LiveVersions::from_persistence(node_id, vec![v3.clone()]);
+        let reconciled = dir.reconcile(&live).unwrap();
+        assert_eq!(reconciled.removed.len(), 2);
+        assert_eq!(reconciled.missing.len(), 1);
+
+        let b3 = partials_batch(&schema, &[0, 1, 2], &[10.0, 12.0, 4.0], &[2, 2, 1]);
+        let s3: Pin<
+            Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
+        > = Box::pin(futures::stream::iter(vec![Ok(b3)]));
+        _ = dir
+            .write_sidecar(&node_id, &v3, schema.clone(), s3)
+            .await
+            .unwrap();
+
+        let merged = merge_partials(&dir.cached_set(&live, |_| true)).await;
+        assert_eq!(merged, vec![(0, 10.0, 2), (1, 12.0, 2), (2, 4.0, 1)]);
+    }
+
+    /// Fold a cached set the way the read path does, returning
+    /// `(time_bucket, sum, count)` rows.
+    async fn merge_partials(set: &crate::version_cache::CachedSet) -> Vec<(i64, f64, i64)> {
         let ctx = SessionContext::new();
-        let table = listing_table_from_dir(&gdir, &ctx).await.unwrap();
+        let table = set.table_provider().await.unwrap();
         _ = ctx.register_table("partials", table).unwrap();
         let df = ctx
             .sql(
@@ -770,7 +650,6 @@ mod tests {
             .unwrap();
         let batches = df.collect().await.unwrap();
         let merged = arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
-
         let bucket = merged
             .column(0)
             .as_any()
@@ -786,15 +665,9 @@ mod tests {
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
-
-        assert_eq!(bucket.values(), &[0, 1, 2]);
-        // Bucket 1 straddles both versions: sum 5+7=12, count 1+1=2.
-        assert_eq!(s.value(0), 10.0);
-        assert_eq!(s.value(1), 12.0);
-        assert_eq!(s.value(2), 4.0);
-        assert_eq!(c.value(0), 2);
-        assert_eq!(c.value(1), 2);
-        assert_eq!(c.value(2), 1);
+        (0..merged.num_rows())
+            .map(|i| (bucket.value(i), s.value(i), c.value(i)))
+            .collect()
     }
 
     #[tokio::test]
@@ -808,15 +681,10 @@ mod tests {
         let s1: Pin<
             Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
         > = Box::pin(futures::stream::iter(vec![Ok(b1)]));
-        _ = write_glob_member(
-            &glob_dir(cache_dir, "cfg", &node_id),
-            &node_id,
-            &v1,
-            schema.clone(),
-            s1,
-        )
-        .await
-        .unwrap();
+        _ = partials_dir(cache_dir, "cfg", &node_id)
+            .write_sidecar(&node_id, &v1, schema.clone(), s1)
+            .await
+            .unwrap();
         assert!(cache_node_dir(cache_dir, "cfg", &node_id).exists());
         drop_node_namespace(cache_dir, "cfg", &node_id).unwrap();
         assert!(!cache_node_dir(cache_dir, "cfg", &node_id).exists());

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -93,99 +93,6 @@ fn version_key(node_id: &tinyfs::NodeID, version: &FileVersionInfo) -> String {
     }
 }
 
-/// Path for a single input version's cached partials Parquet file.
-///
-/// Returns `{cache_dir}/rollup_{cfg_hash}_{node_id}/v{version}_{key}.parquet`.
-#[must_use]
-pub fn cache_version_path(
-    cache_dir: &Path,
-    cfg_hash: &str,
-    node_id: &tinyfs::NodeID,
-    version: &FileVersionInfo,
-) -> PathBuf {
-    let key = version_key(node_id, version);
-    cache_node_dir(cache_dir, cfg_hash, node_id)
-        .join(format!("v{}_{}.parquet", version.version, key))
-}
-
-/// Return the subset of versions whose cached partials do not yet exist on disk.
-#[must_use]
-pub fn find_uncached_versions(
-    cache_dir: &Path,
-    cfg_hash: &str,
-    node_id: &tinyfs::NodeID,
-    versions: &[FileVersionInfo],
-) -> Vec<FileVersionInfo> {
-    versions
-        .iter()
-        .filter(|v| !cache_version_path(cache_dir, cfg_hash, node_id, v).exists())
-        .cloned()
-        .collect()
-}
-
-/// Write a single input version's partials to cache as Parquet.
-///
-/// Streams partial batches through `AsyncArrowWriter` to disk without
-/// collecting into memory.  Uses an atomic write (`.tmp` then rename) so a
-/// crash never leaves a partial file behind that would be mistaken for a
-/// complete cached version.
-pub async fn cache_write_version(
-    cache_dir: &Path,
-    cfg_hash: &str,
-    node_id: &tinyfs::NodeID,
-    version: &FileVersionInfo,
-    schema: SchemaRef,
-    stream: Pin<
-        Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
-    >,
-) -> Result<PathBuf> {
-    let dir = cache_node_dir(cache_dir, cfg_hash, node_id);
-    tokio::fs::create_dir_all(&dir).await?;
-
-    let final_path = cache_version_path(cache_dir, cfg_hash, node_id, version);
-    let tmp_path = final_path.with_extension("parquet.tmp");
-
-    let file = tokio::fs::File::create(&tmp_path).await?;
-    let props = WriterProperties::builder()
-        .set_compression(Compression::ZSTD(parquet::basic::ZstdLevel::default()))
-        .build();
-    let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props))
-        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-
-    let mut stream = stream;
-    while let Some(batch) = stream.next().await {
-        let batch = batch?;
-        writer
-            .write(&batch)
-            .await
-            .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-    }
-    let _metadata = writer
-        .close()
-        .await
-        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-
-    tokio::fs::rename(&tmp_path, &final_path).await?;
-    log::debug!("[SAVE] Rollup cache: wrote {}", final_path.display());
-
-    Ok(final_path)
-}
-
-/// Build a `ListingTable` over all cached per-version partials for a node.
-///
-/// Assumes every version is already cached (call [`cache_write_version`] for
-/// any uncached versions first).  Schemas are merged across versions so columns
-/// that appear only in newer versions are present and back-filled with NULLs
-/// for older ones.
-pub async fn listing_table_from_cache(
-    cache_dir: &Path,
-    cfg_hash: &str,
-    node_id: &tinyfs::NodeID,
-    ctx: &SessionContext,
-) -> Result<Arc<dyn TableProvider>> {
-    listing_table_from_dir(&cache_node_dir(cache_dir, cfg_hash, node_id), ctx).await
-}
-
 /// Build a `ListingTable` over every `.parquet` partials file directly under
 /// `dir`, merging their schemas (UNION-ALL-BY-NAME across versions/sources).
 pub async fn listing_table_from_dir(
@@ -779,45 +686,40 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_version_path_keys_by_blake3() {
-        let cache_dir = Path::new("/tmp/pond/cache");
+    fn test_glob_member_path_keys_by_blake3() {
         let node_id = test_node_id();
         let version = test_version(3, Some("abc123"));
-        let path = cache_version_path(cache_dir, "cfg", &node_id, &version);
+        let path = glob_member_path(Path::new("/tmp/pond/cache/rollup_cfg_x"), &node_id, &version);
         let filename = path.file_name().unwrap().to_str().unwrap();
-        assert_eq!(filename, "v3_abc123.parquet");
+        assert_eq!(filename, format!("{}_v3_abc123.parquet", node_id));
     }
 
     #[test]
-    fn test_cache_version_path_dynamic_uses_node_id() {
-        let cache_dir = Path::new("/tmp/pond/cache");
+    fn test_glob_member_path_dynamic_uses_node_id() {
         let node_id = test_node_id();
         let version = test_version(1, None);
-        let path = cache_version_path(cache_dir, "cfg", &node_id, &version);
+        let path = glob_member_path(Path::new("/tmp/pond/cache/rollup_cfg_x"), &node_id, &version);
         let filename = path.file_name().unwrap().to_str().unwrap();
-        assert!(filename.starts_with("v1_"));
+        assert!(filename.contains("_v1_"));
         assert!(filename.contains(&node_id.to_short_string()));
     }
 
     #[test]
-    fn test_find_uncached_versions() {
+    fn test_find_uncached_members() {
         let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path();
         let node_id = test_node_id();
+        let gdir = glob_dir(tmp.path(), "cfg", &node_id);
         let versions = vec![test_version(1, Some("aaa")), test_version(2, Some("bbb"))];
 
         // Nothing cached yet.
-        assert_eq!(
-            find_uncached_versions(cache_dir, "cfg", &node_id, &versions).len(),
-            2
-        );
+        assert_eq!(find_uncached_members(&gdir, &node_id, &versions).len(), 2);
 
         // Pre-create v1's partial file.
-        let v1 = cache_version_path(cache_dir, "cfg", &node_id, &versions[0]);
+        let v1 = glob_member_path(&gdir, &node_id, &versions[0]);
         std::fs::create_dir_all(v1.parent().unwrap()).unwrap();
         std::fs::write(&v1, b"fake").unwrap();
 
-        let uncached = find_uncached_versions(cache_dir, "cfg", &node_id, &versions);
+        let uncached = find_uncached_members(&gdir, &node_id, &versions);
         assert_eq!(uncached.len(), 1);
         assert_eq!(uncached[0].version, 2);
     }
@@ -825,8 +727,8 @@ mod tests {
     #[tokio::test]
     async fn test_write_and_list_partials_merge() {
         let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path();
         let node_id = test_node_id();
+        let gdir = glob_dir(tmp.path(), "cfg", &node_id);
         let schema = partials_schema();
 
         // Version 1: bucket 0 sum=10 count=2 ; bucket 1 sum=5 count=1
@@ -835,7 +737,7 @@ mod tests {
         let s1: Pin<
             Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
         > = Box::pin(futures::stream::iter(vec![Ok(b1)]));
-        _ = cache_write_version(cache_dir, "cfg", &node_id, &v1, schema.clone(), s1)
+        _ = write_glob_member(&gdir, &node_id, &v1, schema.clone(), s1)
             .await
             .unwrap();
 
@@ -845,21 +747,19 @@ mod tests {
         let s2: Pin<
             Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
         > = Box::pin(futures::stream::iter(vec![Ok(b2)]));
-        _ = cache_write_version(cache_dir, "cfg", &node_id, &v2, schema.clone(), s2)
+        _ = write_glob_member(&gdir, &node_id, &v2, schema.clone(), s2)
             .await
             .unwrap();
 
         // Incrementality: both versions now cached.
         assert_eq!(
-            find_uncached_versions(cache_dir, "cfg", &node_id, &[v1.clone(), v2.clone()]).len(),
+            find_uncached_members(&gdir, &node_id, &[v1.clone(), v2.clone()]).len(),
             0
         );
 
         // Merge the partials and verify the boundary bucket reconstructs exactly.
         let ctx = SessionContext::new();
-        let table = listing_table_from_cache(cache_dir, "cfg", &node_id, &ctx)
-            .await
-            .unwrap();
+        let table = listing_table_from_dir(&gdir, &ctx).await.unwrap();
         _ = ctx.register_table("partials", table).unwrap();
         let df = ctx
             .sql(
@@ -908,10 +808,15 @@ mod tests {
         let s1: Pin<
             Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
         > = Box::pin(futures::stream::iter(vec![Ok(b1)]));
-        _ = cache_write_version(cache_dir, "cfg", &node_id, &v1, schema.clone(), s1)
-            .await
-            .unwrap();
-
+        _ = write_glob_member(
+            &glob_dir(cache_dir, "cfg", &node_id),
+            &node_id,
+            &v1,
+            schema.clone(),
+            s1,
+        )
+        .await
+        .unwrap();
         assert!(cache_node_dir(cache_dir, "cfg", &node_id).exists());
         drop_node_namespace(cache_dir, "cfg", &node_id).unwrap();
         assert!(!cache_node_dir(cache_dir, "cfg", &node_id).exists());

--- a/crates/provider/src/version_cache.rs
+++ b/crates/provider/src/version_cache.rs
@@ -244,12 +244,28 @@ impl SidecarDir {
     /// source version. Doing it here rather than leaving it to a separate
     /// sweep is the point: a cache that only adds silently accumulates the
     /// superseded sidecars that produce double-counted reads.
+    ///
+    /// Reconciliation runs on the read path, and reads do not take the pond's
+    /// write lock, so two readers can reconcile the same shared directory at
+    /// once. A stale sidecar already removed by the other one satisfies this
+    /// one's post-condition, so `NotFound` is success, not failure -- the same
+    /// tolerance the write path gets from its tmp-file-and-rename.
     pub fn reconcile(&self, live: &LiveVersions) -> Result<Reconciliation> {
         let mut removed = Vec::new();
         for path in self.stale(live)? {
-            std::fs::remove_file(&path).map_err(crate::error::Error::Io)?;
-            log::debug!("[SWEEP] sidecar cache: removed stale {}", path.display());
-            removed.push(path);
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    log::debug!("[SWEEP] sidecar cache: removed stale {}", path.display());
+                    removed.push(path);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    log::debug!(
+                        "[SWEEP] sidecar cache: stale {} already removed concurrently",
+                        path.display()
+                    );
+                }
+                Err(e) => return Err(crate::error::Error::Io(e)),
+            }
         }
         Ok(Reconciliation {
             missing: self.missing(live),
@@ -577,6 +593,33 @@ mod tests {
         assert!(rec.removed.is_empty());
         assert!(tmp_file.exists(), "in-flight writes are not garbage");
         assert!(frontier.exists(), "sidecar sweep must not eat bookkeeping");
+    }
+
+    #[test]
+    fn reconcile_tolerates_a_concurrently_removed_stale_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = SidecarDir::new(tmp.path().to_path_buf(), SidecarNaming::NodeOwned);
+        let n = node(1);
+        let live = LiveVersions::from_persistence(n, vec![version(1, Some("aaa"))]);
+        touch(&dir.sidecar_path(&n, &live.as_slice()[0]));
+
+        // A superseded sidecar that another reader deletes after we listed it
+        // but before we unlink it. Reads take no write lock, so this race is
+        // reachable by two concurrent reads of the same collapsed node.
+        let doomed = dir.sidecar_path(&n, &version(9, Some("dead")));
+        touch(&doomed);
+        let stale = dir.stale(&live).unwrap();
+        assert_eq!(stale, vec![doomed.clone()]);
+        std::fs::remove_file(&doomed).unwrap();
+
+        let rec = dir
+            .reconcile(&live)
+            .expect("losing the delete race is not an error");
+        assert!(
+            rec.removed.is_empty(),
+            "we did not remove it; the other did"
+        );
+        assert!(!doomed.exists());
     }
 
     #[test]

--- a/crates/provider/src/version_cache.rs
+++ b/crates/provider/src/version_cache.rs
@@ -1,0 +1,645 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-version Parquet sidecar caches.
+//!
+//! Both [`crate::format_cache`] and [`crate::rollup_cache`] maintain the same
+//! thing: a directory holding one Parquet sidecar per *version* of a node,
+//! keyed by the version's content hash, written once and reused until the node
+//! changes. That shape was copy-pasted rather than named, and the cost was a
+//! silent corruption -- when the double-counting fix landed in one copy it
+//! could not reach the other (testsuite 731 vs 733).
+//!
+//! This module names it once. The design goal is that the bug class is not
+//! merely fixed but *unwritable*, via three barriers:
+//!
+//! 1. [`LiveVersions`] -- a version list is not a bare `Vec`; it is a
+//!    node-scoped set that its constructor documents as live. "Did the caller
+//!    pass the right list?" becomes a type question rather than a review one.
+//!
+//! 2. [`SidecarDir::reconcile`] -- reconciliation both ADDS missing sidecars
+//!    and REMOVES stale ones, so the directory is a pure projection of the live
+//!    set. Caches that only ever add are how a superseded version's sidecar
+//!    survives to be read a second time.
+//!
+//! 3. [`CachedSet`] -- the only route to a `TableProvider`. It names its files
+//!    explicitly and can only be obtained from a [`LiveVersions`]. There is
+//!    deliberately no `fn(&Path) -> TableProvider` in this module, because
+//!    every instance of the bug has been exactly that function.
+//!
+//! Barriers 2 and 3 are independent on purpose: with reconciliation alone a
+//! stray directory listing would still be correct, and with explicit paths
+//! alone the disk would still leak.
+//!
+//! ## Why collapse breaks the naive version
+//!
+//! Before version collapse these two sets were always equal:
+//!
+//! > {every sidecar ever written} == {sidecars of currently live versions}
+//!
+//! Collapse merges a run of versions into one new version that *stands in for*
+//! them without deleting them, so the equality no longer holds. A cache that
+//! lists its directory then returns both the merged sidecar and the superseded
+//! ones it replaces -- double-counting every row in the collapsed window, and
+//! again on each later collapse.
+
+use arrow::datatypes::{Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use datafusion::catalog::TableProvider;
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::{
+    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+};
+use futures::{Stream, StreamExt};
+use parquet::arrow::AsyncArrowWriter;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use tinyfs::FileVersionInfo;
+
+type Result<T> = std::result::Result<T, crate::error::Error>;
+
+/// A batch stream of the shape both caches write.
+pub type BatchStream =
+    Pin<Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>>;
+
+/// The set of versions of one node that are currently **live** -- i.e. not
+/// superseded by a collapse run.
+///
+/// Exists so that "these are the live versions" is carried by the type rather
+/// than assumed. Every cache entry point takes this instead of a bare slice,
+/// which is what stops a historical or unfiltered list from reaching a cache.
+///
+/// The live set is decided in tlogfs (`live_series_entries`) and surfaces here
+/// through `list_file_versions`; this type does not re-derive it, it only
+/// prevents an arbitrary `Vec` from being mistaken for it.
+#[derive(Debug, Clone)]
+pub struct LiveVersions {
+    node_id: tinyfs::NodeID,
+    versions: Vec<FileVersionInfo>,
+}
+
+impl LiveVersions {
+    /// Build from the result of a `list_file_versions` call.
+    ///
+    /// Named for its obligation: `versions` must be the node's live set, as
+    /// returned by the persistence layer, not a filtered or remembered subset.
+    /// Pruning for a query's bounds happens later, in [`SidecarDir::cached_set`],
+    /// so that reconciliation still sees the whole live set and does not delete
+    /// sidecars merely because this query did not need them.
+    #[must_use]
+    pub fn from_persistence(node_id: tinyfs::NodeID, versions: Vec<FileVersionInfo>) -> Self {
+        Self { node_id, versions }
+    }
+
+    #[must_use]
+    pub fn node_id(&self) -> &tinyfs::NodeID {
+        &self.node_id
+    }
+
+    #[must_use]
+    pub fn as_slice(&self) -> &[FileVersionInfo] {
+        &self.versions
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.versions.is_empty()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.versions.len()
+    }
+}
+
+/// How sidecar files are named within a directory.
+///
+/// The distinction is load-bearing for deletion: in a [`Self::NodeScoped`]
+/// directory, files belonging to *other* nodes are legitimately present, so
+/// reconciliation must never treat them as stale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidecarNaming {
+    /// `v{version}_{key}.parquet`. The directory belongs to a single node, so
+    /// every Parquet in it is that node's.
+    NodeOwned,
+    /// `{node_id}_v{version}_{key}.parquet`. The directory is shared by every
+    /// node a pattern matched -- one rotated log file per node, each with its
+    /// own versions.
+    NodeScoped,
+}
+
+/// Cache key for a version: its blake3 content hash, or -- for dynamic inputs
+/// that carry no blake3 -- the node's short id, which is itself content
+/// derived (e.g. a git blob OID).
+#[must_use]
+fn version_key(node_id: &tinyfs::NodeID, version: &FileVersionInfo) -> String {
+    match version.blake3.as_deref() {
+        Some(hash) => hash.to_string(),
+        None => node_id.to_short_string(),
+    }
+}
+
+/// A directory of per-version Parquet sidecars.
+#[derive(Debug, Clone)]
+pub struct SidecarDir {
+    dir: PathBuf,
+    naming: SidecarNaming,
+}
+
+/// What [`SidecarDir::reconcile`] found and did.
+#[derive(Debug, Default)]
+pub struct Reconciliation {
+    /// Live versions with no sidecar yet; the caller must write these.
+    pub missing: Vec<FileVersionInfo>,
+    /// Sidecars deleted because their version is no longer live.
+    pub removed: Vec<PathBuf>,
+}
+
+impl SidecarDir {
+    #[must_use]
+    pub fn new(dir: PathBuf, naming: SidecarNaming) -> Self {
+        Self { dir, naming }
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Path of one version's sidecar.
+    #[must_use]
+    pub fn sidecar_path(&self, node_id: &tinyfs::NodeID, version: &FileVersionInfo) -> PathBuf {
+        let key = version_key(node_id, version);
+        let name = match self.naming {
+            SidecarNaming::NodeOwned => format!("v{}_{}.parquet", version.version, key),
+            SidecarNaming::NodeScoped => {
+                format!("{}_v{}_{}.parquet", node_id, version.version, key)
+            }
+        };
+        self.dir.join(name)
+    }
+
+    /// Whether `path` is a sidecar this node owns.
+    ///
+    /// For [`SidecarNaming::NodeScoped`] this is the guard that keeps
+    /// reconciliation from deleting a sibling node's sidecars out of a shared
+    /// directory.
+    fn owned_by(&self, node_id: &tinyfs::NodeID, path: &Path) -> bool {
+        if path.extension().and_then(|e| e.to_str()) != Some("parquet") {
+            return false; // ignore .tmp and anything else
+        }
+        match self.naming {
+            SidecarNaming::NodeOwned => true,
+            SidecarNaming::NodeScoped => path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(&format!("{}_v", node_id))),
+        }
+    }
+
+    /// Live versions that have no sidecar on disk yet.
+    #[must_use]
+    pub fn missing(&self, live: &LiveVersions) -> Vec<FileVersionInfo> {
+        live.as_slice()
+            .iter()
+            .filter(|v| !self.sidecar_path(live.node_id(), v).exists())
+            .cloned()
+            .collect()
+    }
+
+    /// Sidecars of this node that no longer correspond to a live version.
+    ///
+    /// After a version collapse these are the superseded versions' sidecars:
+    /// still on disk, no longer part of the series, and counted a second time
+    /// by anything that lists the directory.
+    pub fn stale(&self, live: &LiveVersions) -> Result<Vec<PathBuf>> {
+        if !self.dir.exists() {
+            return Ok(Vec::new());
+        }
+        let keep: std::collections::HashSet<PathBuf> = live
+            .as_slice()
+            .iter()
+            .map(|v| self.sidecar_path(live.node_id(), v))
+            .collect();
+
+        let mut stale = Vec::new();
+        for entry in std::fs::read_dir(&self.dir).map_err(crate::error::Error::Io)? {
+            let path = entry.map_err(crate::error::Error::Io)?.path();
+            if self.owned_by(live.node_id(), &path) && !keep.contains(&path) {
+                stale.push(path);
+            }
+        }
+        stale.sort();
+        Ok(stale)
+    }
+
+    /// Make the directory a projection of `live`: delete this node's stale
+    /// sidecars and report which live versions still need writing.
+    ///
+    /// Deleting is safe because a sidecar is derived data, regenerable from the
+    /// source version. Doing it here rather than leaving it to a separate
+    /// sweep is the point: a cache that only adds silently accumulates the
+    /// superseded sidecars that produce double-counted reads.
+    pub fn reconcile(&self, live: &LiveVersions) -> Result<Reconciliation> {
+        let mut removed = Vec::new();
+        for path in self.stale(live)? {
+            std::fs::remove_file(&path).map_err(crate::error::Error::Io)?;
+            log::debug!("[SWEEP] sidecar cache: removed stale {}", path.display());
+            removed.push(path);
+        }
+        Ok(Reconciliation {
+            missing: self.missing(live),
+            removed,
+        })
+    }
+
+    /// The live versions' sidecars that exist on disk, as an explicit file set.
+    ///
+    /// `retain` prunes for a query's bounds; it does not affect what
+    /// [`Self::reconcile`] considers live.
+    #[must_use]
+    pub fn cached_set(
+        &self,
+        live: &LiveVersions,
+        retain: impl Fn(&FileVersionInfo) -> bool,
+    ) -> CachedSet {
+        let files = live
+            .as_slice()
+            .iter()
+            .filter(|v| retain(v))
+            .map(|v| self.sidecar_path(live.node_id(), v))
+            .filter(|p| p.exists())
+            .collect();
+        CachedSet {
+            files,
+            fallback_dir: self.dir.clone(),
+        }
+    }
+
+    /// Write one version's sidecar, streaming batches to disk.
+    ///
+    /// Atomic (`.tmp` then rename), so a crash never leaves a truncated file
+    /// that a later run would mistake for a complete cached version.
+    pub async fn write_sidecar(
+        &self,
+        node_id: &tinyfs::NodeID,
+        version: &FileVersionInfo,
+        schema: SchemaRef,
+        stream: BatchStream,
+    ) -> Result<PathBuf> {
+        tokio::fs::create_dir_all(&self.dir).await?;
+        let final_path = self.sidecar_path(node_id, version);
+        write_parquet_stream(&final_path, schema, stream).await?;
+        log::debug!("[SAVE] sidecar cache: wrote {}", final_path.display());
+        Ok(final_path)
+    }
+}
+
+/// An explicit set of cached Parquet files for a node's live versions.
+///
+/// The only way to reach a `TableProvider` in this module. It carries file
+/// paths, never a directory to list, so a superseded version's sidecar cannot
+/// re-enter a read.
+#[derive(Debug, Clone)]
+pub struct CachedSet {
+    files: Vec<PathBuf>,
+    /// Used only to recover a schema when no live sidecar is present yet.
+    fallback_dir: PathBuf,
+}
+
+impl CachedSet {
+    #[must_use]
+    pub fn files(&self) -> &[PathBuf] {
+        &self.files
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// Absorb another node's cached set from the same directory.
+    ///
+    /// A [`SidecarNaming::NodeScoped`] directory is read as one table spanning
+    /// every source node, so the read side unions the per-node sets rather than
+    /// listing the directory. Each set is still derived from its own node's
+    /// live versions, which is what keeps a superseded sidecar out.
+    pub fn extend(&mut self, other: CachedSet) {
+        self.files.extend(other.files);
+    }
+
+    /// An empty set that falls back to `dir` for schema recovery.
+    #[must_use]
+    pub fn empty_in(dir: PathBuf) -> Self {
+        Self {
+            files: Vec::new(),
+            fallback_dir: dir,
+        }
+    }
+
+    /// Build a `ListingTable` over exactly these files.
+    ///
+    /// Schemas are merged across them (UNION-ALL-BY-NAME), so a column that
+    /// appears only in newer versions is present and back-filled with NULLs for
+    /// older ones. The merge is scoped to the retained files for the same
+    /// reason the scan is: a superseded version's schema must not shape the read.
+    pub async fn table_provider(&self) -> Result<Arc<dyn TableProvider>> {
+        let merged_schema = merge_parquet_schemas(&self.files, &self.fallback_dir).await?;
+
+        if self.files.is_empty() {
+            // Everything pruned, or nothing cached yet: an empty table over the
+            // cache schema, so the query yields 0 rows rather than erroring or
+            // falling back to scanning a directory.
+            let table = datafusion::datasource::MemTable::try_new(merged_schema, vec![vec![]])?;
+            return Ok(Arc::new(table));
+        }
+
+        let mut paths = Vec::with_capacity(self.files.len());
+        for p in &self.files {
+            paths.push(ListingTableUrl::parse(format!("file://{}", p.display()))?);
+        }
+        let listing_options =
+            ListingOptions::new(Arc::new(ParquetFormat::default())).with_file_extension(".parquet");
+        let config = ListingTableConfig::new_with_multi_paths(paths)
+            .with_listing_options(listing_options)
+            .with_schema(merged_schema);
+        Ok(Arc::new(ListingTable::try_new(config)?))
+    }
+}
+
+/// Stream `stream` into a Parquet file at `path`, atomically.
+pub async fn write_parquet_stream(
+    path: &Path,
+    schema: SchemaRef,
+    mut stream: BatchStream,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp_path = path.with_extension("parquet.tmp");
+    let file = tokio::fs::File::create(&tmp_path).await?;
+    let props = WriterProperties::builder()
+        .set_compression(Compression::ZSTD(parquet::basic::ZstdLevel::default()))
+        .build();
+    let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props))
+        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
+
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        writer
+            .write(&batch)
+            .await
+            .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
+    }
+    let _metadata = writer
+        .close()
+        .await
+        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
+
+    tokio::fs::rename(&tmp_path, path).await?;
+    Ok(())
+}
+
+/// Read and merge the Arrow schemas of an explicit list of Parquet files.
+///
+/// When `files` is empty there is no live sidecar to describe the data, so fall
+/// back to whatever `fallback_dir` holds -- the caller still needs a usable
+/// schema for an empty table.
+pub async fn merge_parquet_schemas(files: &[PathBuf], fallback_dir: &Path) -> Result<SchemaRef> {
+    let mut schemas = Vec::with_capacity(files.len());
+    for path in files {
+        schemas.push(read_parquet_schema(path).await?);
+    }
+    if schemas.is_empty() {
+        return merge_parquet_schemas_in_dir(fallback_dir).await;
+    }
+    Ok(Arc::new(Schema::try_merge(schemas).map_err(|e| {
+        crate::error::Error::Arrow(format!("Failed to merge parquet schemas: {e}"))
+    })?))
+}
+
+/// Merge the schemas of every `.parquet` directly under `dir`.
+///
+/// Only for schema recovery and for genuinely directory-shaped caches (the
+/// symlink glob dir, which is rebuilt from the live set on every query). Never
+/// use it to decide which files a read scans.
+pub async fn merge_parquet_schemas_in_dir(dir: &Path) -> Result<SchemaRef> {
+    let mut schemas = Vec::new();
+    if dir.exists() {
+        let mut entries = tokio::fs::read_dir(dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("parquet") {
+                schemas.push(read_parquet_schema(&path).await?);
+            }
+        }
+    }
+    if schemas.is_empty() {
+        return Err(crate::error::Error::Arrow(format!(
+            "No cached parquet files found in '{}'",
+            dir.display()
+        )));
+    }
+    Ok(Arc::new(Schema::try_merge(schemas).map_err(|e| {
+        crate::error::Error::Arrow(format!("Failed to merge parquet schemas: {e}"))
+    })?))
+}
+
+async fn read_parquet_schema(path: &Path) -> Result<Schema> {
+    let file = tokio::fs::File::open(path).await?;
+    let reader = parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder::new(file)
+        .await
+        .map_err(|e| {
+            crate::error::Error::Arrow(format!(
+                "Failed to read parquet metadata from '{}': {e}",
+                path.display()
+            ))
+        })?;
+    Ok(reader.schema().as_ref().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tinyfs::EntryType;
+
+    fn node(n: u64) -> tinyfs::NodeID {
+        tinyfs::NodeID::new(format!("00000000-0000-7000-8000-{n:012x}"))
+    }
+
+    fn version(v: u64, blake3: Option<&str>) -> FileVersionInfo {
+        FileVersionInfo {
+            version: v,
+            timestamp: 1_700_000_000_000_000,
+            size: 128,
+            blake3: blake3.map(str::to_string),
+            entry_type: EntryType::FilePhysicalSeries,
+            extended_metadata: None,
+        }
+    }
+
+    fn touch(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"x").unwrap();
+    }
+
+    #[test]
+    fn missing_reports_live_versions_without_sidecars() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = SidecarDir::new(tmp.path().to_path_buf(), SidecarNaming::NodeOwned);
+        let live = LiveVersions::from_persistence(
+            node(1),
+            vec![version(1, Some("aaa")), version(2, Some("bbb"))],
+        );
+
+        assert_eq!(dir.missing(&live).len(), 2);
+        touch(&dir.sidecar_path(live.node_id(), &live.as_slice()[0]));
+        let missing = dir.missing(&live);
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].version, 2);
+    }
+
+    /// The collapse case: versions 1..=3 are superseded by a merged version 4,
+    /// so `list_file_versions` now returns only v4. The three superseded
+    /// sidecars must be swept, or a directory listing counts their rows twice.
+    #[test]
+    fn reconcile_removes_sidecars_of_superseded_versions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = SidecarDir::new(tmp.path().to_path_buf(), SidecarNaming::NodeOwned);
+        let n = node(1);
+
+        let old: Vec<FileVersionInfo> = (1..=3)
+            .map(|v| version(v, Some(&format!("hash{v}"))))
+            .collect();
+        for v in &old {
+            touch(&dir.sidecar_path(&n, v));
+        }
+
+        // After collapse the live set is a single merged run.
+        let merged = version(4, Some("merged"));
+        let live = LiveVersions::from_persistence(n, vec![merged.clone()]);
+
+        let rec = dir.reconcile(&live).unwrap();
+        assert_eq!(rec.removed.len(), 3, "all superseded sidecars swept");
+        assert_eq!(rec.missing.len(), 1, "the merged run still needs writing");
+        for v in &old {
+            assert!(!dir.sidecar_path(&n, v).exists());
+        }
+    }
+
+    /// A shared glob dir holds one sidecar per (source node, version). Sweeping
+    /// node A must not touch node B: the rollup cache's dir is shared by every
+    /// file a pattern matched.
+    #[test]
+    fn reconcile_is_node_scoped_in_a_shared_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = SidecarDir::new(tmp.path().to_path_buf(), SidecarNaming::NodeScoped);
+        let (a, b) = (node(1), node(2));
+
+        let a_old = version(1, Some("a1"));
+        let b_old = version(1, Some("b1"));
+        touch(&dir.sidecar_path(&a, &a_old));
+        touch(&dir.sidecar_path(&b, &b_old));
+
+        // Node A collapsed; node B is untouched and still live at v1.
+        let live_a = LiveVersions::from_persistence(a, vec![version(2, Some("a-merged"))]);
+        let rec = dir.reconcile(&live_a).unwrap();
+
+        assert_eq!(rec.removed.len(), 1);
+        assert!(
+            !dir.sidecar_path(&a, &a_old).exists(),
+            "A's stale sidecar go"
+        );
+        assert!(
+            dir.sidecar_path(&b, &b_old).exists(),
+            "B's sidecar must survive a sweep scoped to A"
+        );
+    }
+
+    #[test]
+    fn reconcile_ignores_non_parquet_and_tmp_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = SidecarDir::new(tmp.path().to_path_buf(), SidecarNaming::NodeOwned);
+        let n = node(1);
+        let live = LiveVersions::from_persistence(n, vec![version(1, Some("aaa"))]);
+        touch(&dir.sidecar_path(&n, &live.as_slice()[0]));
+
+        let tmp_file = tmp.path().join("v9_partial.parquet.tmp");
+        let frontier = tmp.path().join("frontier.json");
+        touch(&tmp_file);
+        touch(&frontier);
+
+        let rec = dir.reconcile(&live).unwrap();
+        assert!(rec.removed.is_empty());
+        assert!(tmp_file.exists(), "in-flight writes are not garbage");
+        assert!(frontier.exists(), "sidecar sweep must not eat bookkeeping");
+    }
+
+    #[test]
+    fn cached_set_names_only_live_present_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = SidecarDir::new(tmp.path().to_path_buf(), SidecarNaming::NodeOwned);
+        let n = node(1);
+        let v1 = version(1, Some("aaa"));
+        let v2 = version(2, Some("bbb"));
+
+        // A superseded sidecar on disk that is NOT in the live set.
+        touch(&dir.sidecar_path(&n, &version(9, Some("dead"))));
+        touch(&dir.sidecar_path(&n, &v1));
+
+        let live = LiveVersions::from_persistence(n, vec![v1.clone(), v2.clone()]);
+        let set = dir.cached_set(&live, |_| true);
+
+        // v2 has no file yet, and the dead sidecar is not reachable at all.
+        assert_eq!(set.files().len(), 1);
+        assert!(set.files()[0].ends_with("v1_aaa.parquet"));
+    }
+
+    #[test]
+    fn cached_set_respects_the_retain_predicate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = SidecarDir::new(tmp.path().to_path_buf(), SidecarNaming::NodeOwned);
+        let n = node(1);
+        let v1 = version(1, Some("aaa"));
+        let v2 = version(2, Some("bbb"));
+        touch(&dir.sidecar_path(&n, &v1));
+        touch(&dir.sidecar_path(&n, &v2));
+
+        let live = LiveVersions::from_persistence(n, vec![v1, v2]);
+        let set = dir.cached_set(&live, |v| v.version > 1);
+        assert_eq!(set.files().len(), 1);
+        assert!(set.files()[0].ends_with("v2_bbb.parquet"));
+    }
+
+    #[test]
+    fn sidecar_naming_layouts() {
+        let n = node(7);
+        let v = version(3, Some("abc"));
+        let owned = SidecarDir::new(PathBuf::from("/c"), SidecarNaming::NodeOwned);
+        let scoped = SidecarDir::new(PathBuf::from("/c"), SidecarNaming::NodeScoped);
+
+        assert_eq!(
+            owned.sidecar_path(&n, &v).file_name().unwrap(),
+            "v3_abc.parquet"
+        );
+        assert_eq!(
+            scoped.sidecar_path(&n, &v).file_name().unwrap().to_str(),
+            Some(format!("{n}_v3_abc.parquet").as_str())
+        );
+    }
+
+    #[test]
+    fn dynamic_versions_key_on_node_id() {
+        let n = node(7);
+        let v = version(1, None);
+        let dir = SidecarDir::new(PathBuf::from("/c"), SidecarNaming::NodeOwned);
+        let name = dir.sidecar_path(&n, &v);
+        let name = name.file_name().unwrap().to_str().unwrap();
+        assert!(name.starts_with("v1_"));
+        assert!(name.contains(&n.to_short_string()));
+    }
+}

--- a/crates/steward/src/content_tree.rs
+++ b/crates/steward/src/content_tree.rs
@@ -44,7 +44,7 @@ use sync_store::content::{
     recipe_hash, series_hash,
 };
 use tinyfs::{EntryType, ROOT_UUID};
-use tlogfs::schema::{OplogEntry, decode_directory_entries};
+use tlogfs::schema::{CollapseRange, OplogEntry, decode_directory_entries, live_series_versions};
 
 use crate::control_table::CommitSpine;
 use crate::{Ship, StewardError};
@@ -537,7 +537,7 @@ pub(crate) async fn incremental_spine_inputs(
     let mut dir_rows: HashMap<String, (i64, Vec<u8>)> = HashMap::new();
     let mut leaf_latest: HashMap<String, OplogEntry> = HashMap::new();
     let mut series_new: HashMap<String, BTreeMap<i64, ObjectHash>> = HashMap::new();
-    let mut series_collapsed: HashMap<String, i64> = HashMap::new();
+    let mut series_ranges: HashMap<String, Vec<(i64, CollapseRange)>> = HashMap::new();
     let mut changed: BTreeSet<String> = BTreeSet::new();
     for row in uncommitted {
         // Foreign-pond rows (cross-pond mount subtrees) are never folded into
@@ -556,10 +556,10 @@ pub(crate) async fn incremental_spine_inputs(
                     .entry(node.clone())
                     .or_default()
                     .insert(row.version, hash);
-                if let Some(k) = row.collapsed_through {
-                    let slot = series_collapsed.entry(node).or_insert(k);
-                    *slot = (*slot).max(k);
-                }
+                series_ranges
+                    .entry(node)
+                    .or_default()
+                    .push((row.version, CollapseRange::of(&row)));
             }
             EntryType::DirectoryPhysical => {
                 let content = row.content.clone().unwrap_or_default();
@@ -607,23 +607,23 @@ pub(crate) async fn incremental_spine_inputs(
     }
 
     // New content hash of every touched series: its committed version blobs
-    // followed by this transaction's appended versions, with every version at
-    // or below the highest `collapsed_through` sentinel (from either side)
-    // pruned, exactly as [`fold_rows`] does, then hashed as one series object.
+    // followed by this transaction's appended versions, pruned by range
+    // containment and ordered oldest content first, exactly as [`fold_rows`]
+    // does, then hashed as one series object.
     for (node, appended) in &series_new {
-        let (mut versions, committed_collapsed) =
+        let (mut versions, mut ranges) =
             read_series_committed(committed_table.clone(), local_pond_id, node).await?;
         for (version, hash) in appended {
             let _ = versions.insert(*version, *hash);
         }
-        let collapsed = committed_collapsed
+        // This transaction's rows shadow the committed rows of the same version.
+        if let Some(new_ranges) = series_ranges.get(node) {
+            ranges.retain(|(v, _)| !new_ranges.iter().any(|(nv, _)| nv == v));
+            ranges.extend(new_ranges.iter().copied());
+        }
+        let ordered: Vec<ObjectHash> = live_series_versions(&ranges)
             .into_iter()
-            .chain(series_collapsed.get(node).copied())
-            .max();
-        let ordered: Vec<ObjectHash> = versions
-            .into_iter()
-            .filter(|(version, _)| collapsed.is_none_or(|k| *version > k))
-            .map(|(_, hash)| hash)
+            .filter_map(|version| versions.get(&version).copied())
             .collect();
         let _ = child_hash.insert(node.clone(), series_hash(&ordered));
     }
@@ -772,9 +772,9 @@ fn node_depth(
 }
 
 /// Read a series node's committed version blob hashes from `table`, keyed by
-/// version, together with the highest `collapsed_through` sentinel recorded on
-/// any of its committed rows.  Unlike [`fold_rows`], the pruning is left to the
-/// caller so this transaction's appended sentinel can be folded in first.
+/// version, together with the [`CollapseRange`] of every committed row.  Unlike
+/// [`fold_rows`], the pruning is left to the caller so this transaction's
+/// appended rows can be folded in first.
 ///
 /// Used by the incremental fold to rebuild a touched series' hash from its
 /// committed history plus this transaction's appended versions.
@@ -786,13 +786,13 @@ async fn read_series_committed(
     table: deltalake::DeltaTable,
     pond_id: &str,
     node_id: &str,
-) -> Result<(BTreeMap<i64, ObjectHash>, Option<i64>), StewardError> {
+) -> Result<(BTreeMap<i64, ObjectHash>, Vec<(i64, CollapseRange)>), StewardError> {
     let ctx = SessionContext::new();
     let _previous = ctx
         .register_table("series_live", Arc::new(table))
         .map_err(|e| StewardError::DeltaLake(e.to_string()))?;
     let sql = format!(
-        "SELECT version, blake3, content, collapsed_through FROM series_live \
+        "SELECT version, blake3, content, collapsed_from, collapsed_through FROM series_live \
          WHERE pond_id = '{pond_id}' AND node_id = '{node_id}' ORDER BY version",
     );
     let batches = ctx
@@ -808,7 +808,15 @@ async fn read_series_committed(
             .map_err(|e| StewardError::DeltaLake(e.to_string()))?;
         rows.extend(parsed);
     }
-    let collapsed = rows.iter().filter_map(|r| r.collapsed_through).max();
+    let ranges: Vec<(i64, CollapseRange)> = rows
+        .iter()
+        .map(|r| {
+            (
+                r.version,
+                CollapseRange::new(r.version, r.collapsed_from, r.collapsed_through),
+            )
+        })
+        .collect();
     let mut versions: BTreeMap<i64, ObjectHash> = BTreeMap::new();
     for row in rows {
         let _ = versions.insert(
@@ -816,16 +824,17 @@ async fn read_series_committed(
             row_blob_hash(&row.blake3, row.content.as_deref()),
         );
     }
-    Ok((versions, collapsed))
+    Ok((versions, ranges))
 }
 
 /// One committed series version row: its version and the fields
-/// [`row_blob_hash`] needs, plus the compaction sentinel.
+/// [`row_blob_hash`] needs, plus the collapse range columns.
 #[derive(serde::Deserialize)]
 struct SeriesVersionRow {
     version: i64,
     blake3: Option<String>,
     content: Option<Vec<u8>>,
+    collapsed_from: Option<i64>,
     collapsed_through: Option<i64>,
 }
 
@@ -1108,7 +1117,7 @@ async fn scan_live_rows(
 const NARROW_META_SQL: &str = "SELECT part_id, node_id, file_type, timestamp, version, \
      arrow_cast(NULL, 'Binary') AS content, blake3, size, min_event_time, max_event_time, \
      min_override, max_override, extended_attributes, factory, format, txn_seq, pond_id, \
-     arrow_cast(NULL, 'Binary') AS bao_outboard, collapsed_through \
+     arrow_cast(NULL, 'Binary') AS bao_outboard, collapsed_through, collapsed_from \
      FROM content_live ORDER BY pond_id, part_id, node_id, version";
 
 /// Content of exactly the structural rows the fold decodes -- those without a
@@ -1200,10 +1209,10 @@ fn fold_rows(
     // Latest-version facts per node, and per-version blobs for series.
     let mut latest: HashMap<NodeKey, NodeFacts> = HashMap::new();
     let mut series_versions: HashMap<NodeKey, BTreeMap<i64, VersionBlob>> = HashMap::new();
-    // Highest `collapsed_through` sentinel seen per series node.  A series
-    // compaction leaves the superseded per-version rows in the table beside a
-    // merged row carrying this sentinel; the versions are pruned after the scan.
-    let mut collapsed_through: HashMap<NodeKey, i64> = HashMap::new();
+    // Collapse range of every series row.  A compaction leaves the superseded
+    // per-version rows in the table beside a merged row covering them; the
+    // superseded versions are pruned after the scan.
+    let mut series_ranges: HashMap<NodeKey, Vec<(i64, CollapseRange)>> = HashMap::new();
 
     for row in rows {
         let key = (row.pond_id.clone(), row.node_id.to_string());
@@ -1220,10 +1229,10 @@ fn fold_rows(
                     content: row.content.clone(),
                 },
             );
-            if let Some(k) = row.collapsed_through {
-                let entry = collapsed_through.entry(key.clone()).or_insert(k);
-                *entry = (*entry).max(k);
-            }
+            series_ranges
+                .entry(key.clone())
+                .or_default()
+                .push((row.version, CollapseRange::of(&row)));
         }
 
         let _ = latest.insert(
@@ -1236,15 +1245,18 @@ fn fold_rows(
         );
     }
 
-    // Drop versions superseded by a compaction.  The live series read path skips
-    // every version at or below the highest `collapsed_through` sentinel (see
+    // Drop versions superseded by a compaction.  The live series read path keeps
+    // exactly the rows no *other* row's collapse range contains (see
+    // tlogfs::schema::live_series_entries, used by
     // OpLogPersistence::async_file_reader_series); the content fold must match it
-    // exactly, or a compacted series would fold in phantom superseded blobs and a
-    // pulled mirror would reconstruct duplicated data whose fold still equals the
-    // source's (both sides would fold the same dead rows).
-    for (key, k) in &collapsed_through {
+    // exactly.  Folding in phantom superseded blobs makes a pulled mirror
+    // reconstruct duplicated data whose fold still equals the source's; dropping
+    // a live row is worse, because the mirror then never learns it needs that
+    // blob yet both sides still agree the trees match.
+    for (key, ranges) in &series_ranges {
         if let Some(versions) = series_versions.get_mut(key) {
-            versions.retain(|version, _| *version > *k);
+            let live = live_series_versions(ranges);
+            versions.retain(|version, _| live.contains(version));
         }
     }
 
@@ -1507,6 +1519,23 @@ mod tests {
             .register_table("content_live", Arc::new(mem))
             .expect("register");
         ctx
+    }
+
+    /// The narrow scan projects an explicit column list, and serde_arrow fills a
+    /// missing `Option` field with `None` instead of failing. Adding a field to
+    /// `OplogEntry` without adding it here therefore fails *silently*, which is
+    /// how `collapsed_from` was first missed: every merged run then folded as
+    /// `[0, hi]` and superseded live rows it never covered.
+    #[test]
+    fn narrow_scan_projects_every_oplog_entry_field() {
+        use tlogfs::schema::ForArrow;
+        for field in OplogEntry::for_arrow() {
+            let name = field.name();
+            assert!(
+                NARROW_META_SQL.contains(name.as_str()),
+                "NARROW_META_SQL is missing OplogEntry field `{name}`; a field                  absent from the projection deserializes as None and corrupts                  the fold silently"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/steward/src/content_tree.rs
+++ b/crates/steward/src/content_tree.rs
@@ -1578,7 +1578,7 @@ mod tests {
         // Run A absorbed versions 1..=10 and was allocated version 26.
         // A later window, versions 21..=31, merged as version 36 -- so the
         // highest sentinel (31) sits *above* run A's version number (26).
-        let mut series_row = |version: i64, from: Option<i64>, through: Option<i64>| {
+        let series_row = |version: i64, from: Option<i64>, through: Option<i64>| {
             let mut row = OplogEntry::new_small_file(
                 series_id,
                 version,

--- a/crates/steward/src/content_tree.rs
+++ b/crates/steward/src/content_tree.rs
@@ -1253,12 +1253,27 @@ fn fold_rows(
     // reconstruct duplicated data whose fold still equals the source's; dropping
     // a live row is worse, because the mirror then never learns it needs that
     // blob yet both sides still agree the trees match.
-    for (key, ranges) in &series_ranges {
-        if let Some(versions) = series_versions.get_mut(key) {
-            let live = live_series_versions(ranges);
-            versions.retain(|version, _| live.contains(version));
-        }
+    //
+    // The result is a *sequence in byte order*, not a version-keyed map: a
+    // merged run carries a fresh highest version while standing for content in
+    // the middle of the stream, so iterating by version would order the runs
+    // after the loose tail. That ordering is not cosmetic -- a destination
+    // reconstructs a pulled series by writing these blobs in order, and
+    // plan_series_versions compares them as a prefix to find the suffix it must
+    // append.
+    let mut series_live: HashMap<NodeKey, Vec<VersionBlob>> = HashMap::new();
+    for (key, versions) in &mut series_versions {
+        let ordered = match series_ranges.get(key) {
+            Some(ranges) => live_series_versions(ranges),
+            None => versions.keys().copied().collect(),
+        };
+        let blobs: Vec<VersionBlob> = ordered
+            .into_iter()
+            .filter_map(|version| versions.remove(&version))
+            .collect();
+        let _ = series_live.insert(key.clone(), blobs);
     }
+    let series_versions = series_live;
 
     let root_key = (local_pond_id.to_string(), ROOT_UUID.to_string());
     if !latest.contains_key(&root_key) {
@@ -1282,7 +1297,7 @@ fn fold_rows(
 
     let series_version_hashes = series_versions
         .into_iter()
-        .map(|(key, versions)| (key, versions.values().map(|v| v.hash).collect()))
+        .map(|(key, versions)| (key, versions.iter().map(|v| v.hash).collect()))
         .collect();
 
     Ok(ContentTreeIndex {
@@ -1313,7 +1328,7 @@ fn row_blob_hash(blake3: &Option<String>, content: Option<&[u8]>) -> ObjectHash 
 fn hash_directory(
     key: &NodeKey,
     latest: &HashMap<NodeKey, NodeFacts>,
-    series_versions: &HashMap<NodeKey, BTreeMap<i64, VersionBlob>>,
+    series_versions: &HashMap<NodeKey, Vec<VersionBlob>>,
     memo: &mut HashMap<NodeKey, ObjectHash>,
     in_progress: &mut Vec<NodeKey>,
     dirs: &mut HashMap<NodeKey, Vec<ChildRef>>,
@@ -1414,7 +1429,7 @@ fn hash_child(
     key: &NodeKey,
     entry_type: EntryType,
     latest: &HashMap<NodeKey, NodeFacts>,
-    series_versions: &HashMap<NodeKey, BTreeMap<i64, VersionBlob>>,
+    series_versions: &HashMap<NodeKey, Vec<VersionBlob>>,
     memo: &mut HashMap<NodeKey, ObjectHash>,
     in_progress: &mut Vec<NodeKey>,
     dirs: &mut HashMap<NodeKey, Vec<ChildRef>>,
@@ -1428,13 +1443,13 @@ fn hash_child(
             let versions = series_versions.get(key).ok_or_else(|| {
                 StewardError::DeltaLake(format!("missing series node {}/{}", key.0, key.1))
             })?;
-            let ordered: Vec<ObjectHash> = versions.values().map(|v| v.hash).collect();
+            let ordered: Vec<ObjectHash> = versions.iter().map(|v| v.hash).collect();
             let series = series_hash(&ordered);
             if let Some(sink) = sink {
                 // The series manifest object, plus each version blob: small
                 // versions inline, large (externalized) versions by hash (D7).
                 sink.put_inline(series, encode_series(&ordered));
-                for v in versions.values() {
+                for v in versions.iter() {
                     record_blob(sink, v.hash, v.content.as_deref());
                 }
             }
@@ -1536,6 +1551,94 @@ mod tests {
                 "NARROW_META_SQL is missing OplogEntry field `{name}`; a field                  absent from the projection deserializes as None and corrupts                  the fold silently"
             );
         }
+    }
+
+    /// Corruption #4: the content fold must prune series versions by *range
+    /// containment*, never by the highest `collapsed_through` sentinel.
+    ///
+    /// Once collapse is tiered, a run created early carries a low version and a
+    /// low range, while a later merge of a *newer* window can have a
+    /// `collapsed_through` above that run's version number. The old rule --
+    /// "drop every version <= max(collapsed_through)" -- then discards a live
+    /// run holding the only copy of the versions it absorbed.
+    ///
+    /// The failure is silent in the worst way: both ponds in a pull apply the
+    /// same rule, so their tree hashes still agree and the guard reports
+    /// convergence, while the destination never learns it needs that blob.
+    #[test]
+    fn fold_prunes_series_by_range_not_by_max_watermark() {
+        use tinyfs::{DirectoryEntry, EntryType, FileID};
+        use tlogfs::schema::encode_directory_entries;
+
+        let pond = tinyfs::local_pond_uuid();
+        let dir_id = FileID::root_for(pond);
+        let series_id =
+            FileID::new_in_partition(dir_id.part_id(), EntryType::FilePhysicalSeries, pond);
+
+        // Run A absorbed versions 1..=10 and was allocated version 26.
+        // A later window, versions 21..=31, merged as version 36 -- so the
+        // highest sentinel (31) sits *above* run A's version number (26).
+        let mut series_row = |version: i64, from: Option<i64>, through: Option<i64>| {
+            let mut row = OplogEntry::new_small_file(
+                series_id,
+                version,
+                version,
+                format!("blob-for-version-{version}").into_bytes(),
+                1,
+            );
+            row.collapsed_from = from;
+            row.collapsed_through = through;
+            row
+        };
+        let run_a = series_row(26, Some(1), Some(10));
+        let loose_11 = series_row(11, None, None);
+        let run_b = series_row(36, Some(21), Some(31));
+        let loose_40 = series_row(40, None, None);
+        // A row run A genuinely covers: it must be pruned.
+        let superseded_5 = series_row(5, None, None);
+
+        let dir_content = encode_directory_entries(&[DirectoryEntry::new(
+            "series".to_string(),
+            series_id.node_id(),
+            EntryType::FilePhysicalSeries,
+            1,
+        )])
+        .expect("encode directory");
+        let dir_row = OplogEntry::new_inline(dir_id, 1, 1, dir_content, 1);
+
+        let rows = vec![
+            dir_row,
+            run_a.clone(),
+            loose_11.clone(),
+            run_b.clone(),
+            loose_40.clone(),
+            superseded_5.clone(),
+        ];
+        let index = fold_rows(rows, &pond.to_string(), None).expect("fold");
+
+        let key = (pond.to_string(), series_id.node_id().to_string());
+        let folded = index
+            .series_versions
+            .get(&key)
+            .expect("the series is folded into the tree");
+
+        let expect = |row: &OplogEntry| row_blob_hash(&row.blake3, row.content.as_deref());
+        assert_eq!(
+            folded,
+            &vec![
+                expect(&run_a),
+                expect(&loose_11),
+                expect(&run_b),
+                expect(&loose_40)
+            ],
+            "run A (version 26) is live -- no other row's range contains \
+             [1,10] -- and must be folded, in range order, ahead of the loose \
+             versions that follow it in the byte stream"
+        );
+        assert!(
+            !folded.contains(&expect(&superseded_5)),
+            "version 5 lies inside run A's range and must be pruned"
+        );
     }
 
     #[tokio::test]

--- a/crates/steward/src/lib.rs
+++ b/crates/steward/src/lib.rs
@@ -28,6 +28,7 @@ mod host;
 mod inner_control;
 pub mod maintenance;
 mod rebuild;
+pub mod reclaim;
 mod remote_config;
 mod ship;
 mod write_lock;

--- a/crates/steward/src/reclaim.rs
+++ b/crates/steward/src/reclaim.rs
@@ -21,7 +21,13 @@
 //!
 //! Deleting superseded rows is Merkle-neutral: steward's content fold already
 //! prunes them, so a pond's `root_tree_hash` is unchanged by reclamation and
-//! mirrors -- which never received these rows -- stay converged.
+//! mirrors -- which never received these rows -- stay converged.  That claim is
+//! *checked*, not assumed: the content root is snapshotted before and after the
+//! deletes and asserted identical, and the check runs BEFORE the blob sweep.
+//! The ordering is the point -- deleted rows are still recoverable from Delta
+//! history or a mirror, but a swept blob is gone.  Verifying while recovery is
+//! still possible turns a silent, unrecoverable data loss into a loud, fixable
+//! one.
 //!
 //! Reclamation is deliberately *not* a separate command or flag.  It is what
 //! makes collapse actually free space, so it runs as part of the same
@@ -125,6 +131,7 @@ const PREDICATE_BUDGET: usize = 60_000;
 pub async fn reclaim_superseded(
     table: DeltaTable,
     pond_path: &Path,
+    local_pond_id: &str,
     app_metadata: HashMap<String, serde_json::Value>,
 ) -> Result<(DeltaTable, ReclaimStats), StewardError> {
     let mut stats = ReclaimStats::default();
@@ -132,7 +139,43 @@ pub async fn reclaim_superseded(
     let dead = find_superseded(&table).await?;
     let mut table = table;
     if !dead.is_empty() {
+        // Snapshot the content root BEFORE deleting.  Reclamation must be
+        // content-preserving; this is what turns that from a comment into a
+        // checked invariant.
+        let pre = crate::content_tree::compute_content_tree_for_table(table.clone(), local_pond_id)
+            .await
+            .map_err(|e| {
+                StewardError::ControlTable(format!("reclaim: pre-delete content snapshot: {e}"))
+            })?
+            .root_tree_hash;
+
         table = delete_rows(table, &dead, app_metadata, &mut stats).await?;
+
+        let post =
+            crate::content_tree::compute_content_tree_for_table(table.clone(), local_pond_id)
+                .await
+                .map_err(|e| {
+                    StewardError::ControlTable(format!(
+                        "reclaim: post-delete content snapshot: {e}"
+                    ))
+                })?
+                .root_tree_hash;
+
+        // Return BEFORE sweeping.  A wrong delete has removed rows that Delta
+        // history still holds and that a mirror can restore; sweeping their
+        // blobs is what would make the loss permanent.
+        if pre != post {
+            return Err(StewardError::ControlTable(format!(
+                "reclaim altered content root: pre={} post={} -- {} superseded row(s) were \
+                 deleted that a reader could still see, so supersession was computed wrong. \
+                 The `_large_files` sweep was SKIPPED, so no content is lost yet: recover the \
+                 rows from the data table's Delta history or re-pull from a mirror before \
+                 running maintain again.",
+                pre.to_hex(),
+                post.to_hex(),
+                stats.rows_deleted,
+            )));
+        }
     }
 
     // Only now that the rows are gone can their blobs be unreferenced.
@@ -279,4 +322,125 @@ async fn flush_delete(
 async fn referenced_hashes(table: &DeltaTable) -> Result<HashSet<String>, StewardError> {
     let rows: Vec<ReferencedHash> = query_rows(table, REFERENCED_SQL).await?;
     Ok(rows.into_iter().filter_map(|r| r.blake3).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Ship, get_data_path};
+    use tempfile::tempdir;
+    use tlogfs::{PondTxnMetadata, PondUserMetadata};
+    use tokio::io::AsyncWriteExt;
+
+    /// Deleting superseded rows must not move the pond's `root_tree_hash`.
+    ///
+    /// This is the assumption reclamation rests on: mirrors never received the
+    /// superseded rows, so a pond that deletes them must still fold to the same
+    /// content root, or replication silently diverges.  It is also what makes
+    /// the deletes safe -- if supersession were computed wrong, reclamation
+    /// would remove rows a reader can still see and then sweep their blobs.
+    ///
+    /// The check must bracket the DELETES ALONE.  It cannot be observed through
+    /// `Ship::collapse_versions`, because collapse commits its merged rows as an
+    /// ordinary write and legitimately does move the content root; so this test
+    /// collapses and reclaims as separate steps, exactly as `Ship::reclaim`
+    /// brackets them internally.
+    #[tokio::test]
+    async fn deleting_superseded_rows_preserves_the_content_root() {
+        let tmp = tempdir().expect("tempdir");
+        let pond = tmp.path().join("pond");
+        let mut ship = Ship::create_pond(pond.clone(), "reclaim-merkle")
+            .await
+            .expect("create pond");
+
+        let meta = PondUserMetadata::new(vec!["test".into(), "reclaim-merkle".into()]);
+        for i in 0..12u64 {
+            let bytes = filler(i);
+            ship.write_transaction(&meta, async move |fs| {
+                let root = fs.root().await?;
+                let mut w = root
+                    .async_writer_path_with_type(
+                        "/events.series",
+                        tinyfs::EntryType::FilePhysicalSeries,
+                    )
+                    .await?;
+                w.write_all(&bytes)
+                    .await
+                    .map_err(|e| crate::StewardError::Aborted(format!("write: {e}")))?;
+                w.shutdown()
+                    .await
+                    .map_err(|e| crate::StewardError::Aborted(format!("close: {e}")))?;
+                Ok(())
+            })
+            .await
+            .expect("append version");
+        }
+
+        // Collapse ONLY -- no reclaim.  The pond now carries superseded rows,
+        // which is precisely the state reclamation acts on.
+        let tx = ship.begin_write(&meta).await.expect("begin write");
+        {
+            let state = tx.state().expect("state");
+            let candidates = state
+                .list_collapsible_series(1)
+                .await
+                .expect("list collapsible");
+            assert!(!candidates.is_empty(), "series should be collapsible");
+            for id in candidates {
+                let stats = state.collapse_file_series(id, 1).await.expect("collapse");
+                assert!(stats.collapsed, "collapse should have merged a window");
+            }
+        }
+        let _ = tx.commit().await.expect("commit collapse");
+
+        let pond_id = ship.control_table().pond_id_uuid().to_string();
+        let table = ship.data_persistence().table().clone();
+
+        let before = crate::content_tree::compute_content_tree_for_table(table.clone(), &pond_id)
+            .await
+            .expect("content root before reclaim")
+            .root_tree_hash;
+
+        let mut txn_meta = PondTxnMetadata::new(ship.last_write_seq(), meta.clone());
+        txn_meta.pond_id = pond_id.clone();
+        let (new_table, stats) = super::reclaim_superseded(
+            table,
+            &get_data_path(&pond),
+            &pond_id,
+            txn_meta.to_delta_maintenance_metadata(),
+        )
+        .await
+        .expect("reclaim must not trip its own content invariant");
+
+        assert!(
+            stats.rows_deleted > 0,
+            "the collapse must have left superseded rows for this to prove anything"
+        );
+
+        let after = crate::content_tree::compute_content_tree_for_table(new_table, &pond_id)
+            .await
+            .expect("content root after reclaim")
+            .root_tree_hash;
+
+        assert_eq!(
+            before.to_hex(),
+            after.to_hex(),
+            "deleting {} superseded row(s) moved the content root; a mirror that never \
+             received them would now diverge",
+            stats.rows_deleted,
+        );
+    }
+
+    /// Distinct, incompressible bytes per version, so each lands as its own
+    /// `_large_files` blob instead of deduplicating or inlining.
+    pub(super) fn filler(seed: u64) -> Vec<u8> {
+        let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+        (0..96 * 1024)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                (state >> 24) as u8
+            })
+            .collect()
+    }
 }

--- a/crates/steward/src/reclaim.rs
+++ b/crates/steward/src/reclaim.rs
@@ -80,7 +80,7 @@ impl std::fmt::Display for ReclaimStats {
 
 /// The projection reclamation needs: enough to evaluate supersession, and the
 /// identity columns needed to name a row in a delete predicate.
-#[derive(serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct SeriesRow {
     pond_id: String,
     part_id: String,
@@ -90,15 +90,29 @@ struct SeriesRow {
     collapsed_through: Option<i64>,
 }
 
-/// Every row of a physical series, projected to the columns above.
+/// Every row of a physical series *in the local pond*, projected to the columns
+/// above.
 ///
 /// Both physical series kinds are collapsible and so both can hold superseded
 /// rows; no other entry type has a supersession relation at all.
+///
+/// The `pond_id` filter is a safety scope, not an optimization. The content-root
+/// guard in [`reclaim_superseded`] is computed for the local pond only, and the
+/// fold deliberately skips foreign-pond subtrees, so a foreign row deleted here
+/// would be invisible to the guard -- `pre == post` even if the delete were
+/// wrong, after which the sweep would make it permanent. Restricting the scan
+/// keeps what we may delete equal to what the guard can see.
 const SERIES_ROWS_SQL: &str = "SELECT pond_id, part_id, node_id, version, collapsed_from, \
      collapsed_through FROM reclaim_scan \
-     WHERE file_type IN ('file:physical:series', 'table:physical:series')";
+     WHERE file_type IN ('file:physical:series', 'table:physical:series') \
+     AND pond_id = '{pond_id}'";
 
 /// Hashes still referenced by *some* row, across every pond_id.
+///
+/// Deliberately unscoped, and the asymmetry with [`SERIES_ROWS_SQL`] is the
+/// point: we may only delete rows the guard can see, but a blob must be
+/// retained if *anything* references it, including a foreign pond mirrored
+/// into this table.
 const REFERENCED_SQL: &str = "SELECT DISTINCT blake3 FROM reclaim_scan WHERE blake3 IS NOT NULL";
 
 #[derive(serde::Deserialize)]
@@ -136,7 +150,7 @@ pub async fn reclaim_superseded(
 ) -> Result<(DeltaTable, ReclaimStats), StewardError> {
     let mut stats = ReclaimStats::default();
 
-    let dead = find_superseded(&table).await?;
+    let dead = find_superseded(&table, local_pond_id).await?;
     let mut table = table;
     if !dead.is_empty() {
         // Snapshot the content root BEFORE deleting.  Reclamation must be
@@ -224,8 +238,22 @@ async fn query_rows<T: serde::de::DeserializeOwned>(
 /// version while standing for content in the middle of the stream, so both
 /// "everything below K" and "any version inside a run's range" would delete
 /// live runs.
-async fn find_superseded(table: &DeltaTable) -> Result<HashMap<SeriesKey, Vec<i64>>, StewardError> {
-    let rows: Vec<SeriesRow> = query_rows(table, SERIES_ROWS_SQL).await?;
+async fn find_superseded(
+    table: &DeltaTable,
+    local_pond_id: &str,
+) -> Result<HashMap<SeriesKey, Vec<i64>>, StewardError> {
+    // pond_id is a UUID from the control table, never user text; reject anything
+    // that could not be one rather than interpolating it blind.
+    if !local_pond_id
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() || c == '-')
+    {
+        return Err(StewardError::ControlTable(format!(
+            "reclaim: refusing to scan with a non-UUID pond id {local_pond_id:?}"
+        )));
+    }
+    let sql = SERIES_ROWS_SQL.replace("{pond_id}", local_pond_id);
+    let rows: Vec<SeriesRow> = query_rows(table, &sql).await?;
 
     let mut by_node: HashMap<SeriesKey, Vec<(i64, CollapseRange)>> = HashMap::new();
     for row in rows {
@@ -344,6 +372,15 @@ mod tests {
     /// ordinary write and legitimately does move the content root; so this test
     /// collapses and reclaims as separate steps, exactly as `Ship::reclaim`
     /// brackets them internally.
+    ///
+    /// It collapses in SEVERAL ROUNDS on purpose.  A single round produces one
+    /// merged run holding the highest version, so "drop everything at or below
+    /// the highest `collapsed_through`" and "drop everything inside some run's
+    /// range" select the same rows, and the test would pass under either rule.
+    /// Only once an earlier merged run sits BELOW a later run's
+    /// `collapsed_through` do the two rules disagree -- and the watermark rule
+    /// then deletes a live run.  The test asserts that shape was actually
+    /// reached before it concludes anything.
     #[tokio::test]
     async fn deleting_superseded_rows_preserves_the_content_root() {
         let tmp = tempdir().expect("tempdir");
@@ -352,48 +389,65 @@ mod tests {
             .await
             .expect("create pond");
 
-        let meta = PondUserMetadata::new(vec!["test".into(), "reclaim-merkle".into()]);
-        for i in 0..12u64 {
-            let bytes = filler(i);
-            ship.write_transaction(&meta, async move |fs| {
-                let root = fs.root().await?;
-                let mut w = root
-                    .async_writer_path_with_type(
-                        "/events.series",
-                        tinyfs::EntryType::FilePhysicalSeries,
-                    )
-                    .await?;
-                w.write_all(&bytes)
-                    .await
-                    .map_err(|e| crate::StewardError::Aborted(format!("write: {e}")))?;
-                w.shutdown()
-                    .await
-                    .map_err(|e| crate::StewardError::Aborted(format!("close: {e}")))?;
-                Ok(())
-            })
-            .await
-            .expect("append version");
-        }
+        const MAX_LIVE: usize = 4;
 
-        // Collapse ONLY -- no reclaim.  The pond now carries superseded rows,
-        // which is precisely the state reclamation acts on.
-        let tx = ship.begin_write(&meta).await.expect("begin write");
-        {
-            let state = tx.state().expect("state");
-            let candidates = state
-                .list_collapsible_series(1)
+        let meta = PondUserMetadata::new(vec!["test".into(), "reclaim-merkle".into()]);
+        let mut seed = 0u64;
+        for _round in 0..3 {
+            for _ in 0..12u64 {
+                let bytes = filler(seed);
+                seed += 1;
+                ship.write_transaction(&meta, async move |fs| {
+                    let root = fs.root().await?;
+                    let mut w = root
+                        .async_writer_path_with_type(
+                            "/events.series",
+                            tinyfs::EntryType::FilePhysicalSeries,
+                        )
+                        .await?;
+                    w.write_all(&bytes)
+                        .await
+                        .map_err(|e| crate::StewardError::Aborted(format!("write: {e}")))?;
+                    w.shutdown()
+                        .await
+                        .map_err(|e| crate::StewardError::Aborted(format!("close: {e}")))?;
+                    Ok(())
+                })
                 .await
-                .expect("list collapsible");
-            assert!(!candidates.is_empty(), "series should be collapsible");
-            for id in candidates {
-                let stats = state.collapse_file_series(id, 1).await.expect("collapse");
-                assert!(stats.collapsed, "collapse should have merged a window");
+                .expect("append version");
             }
+
+            // Collapse ONLY -- no reclaim.  The pond accumulates superseded
+            // rows across rounds, which is precisely the state reclaim acts on.
+            let tx = ship.begin_write(&meta).await.expect("begin write");
+            {
+                let state = tx.state().expect("state");
+                // max_live must be > 1.  With max_live == 1 every round is
+                // forced to merge the previous round's accumulated run too, so
+                // the series is flattened back to one tier and the tiered shape
+                // this test needs never forms.
+                let candidates = state
+                    .list_collapsible_series(MAX_LIVE)
+                    .await
+                    .expect("list collapsible");
+                assert!(!candidates.is_empty(), "series should be collapsible");
+                for id in candidates {
+                    let stats = state
+                        .collapse_file_series(id, MAX_LIVE)
+                        .await
+                        .expect("collapse");
+                    assert!(stats.collapsed, "collapse should have merged a window");
+                }
+            }
+            let _ = tx.commit().await.expect("commit collapse");
         }
-        let _ = tx.commit().await.expect("commit collapse");
 
         let pond_id = ship.control_table().pond_id_uuid().to_string();
         let table = ship.data_persistence().table().clone();
+
+        // Prove the structure actually distinguishes the two rules, so a future
+        // change that flattens it turns this test red instead of toothless.
+        assert_tiered_beyond_a_watermark(&table, &pond_id).await;
 
         let before = crate::content_tree::compute_content_tree_for_table(table.clone(), &pond_id)
             .await
@@ -427,6 +481,59 @@ mod tests {
             "deleting {} superseded row(s) moved the content root; a mirror that never \
              received them would now diverge",
             stats.rows_deleted,
+        );
+    }
+
+    /// Assert some LIVE row sits at or below the highest `collapsed_through`.
+    ///
+    /// That is exactly the case where a watermark ("everything below K is
+    /// dead") disagrees with range containment, because a merged run takes a
+    /// fresh highest version while standing for content mid-stream.  Without
+    /// this shape, the surrounding test cannot tell the two rules apart.
+    async fn assert_tiered_beyond_a_watermark(table: &deltalake::DeltaTable, pond_id: &str) {
+        let sql = super::SERIES_ROWS_SQL.replace("{pond_id}", pond_id);
+        let rows: Vec<super::SeriesRow> = super::query_rows(table, &sql).await.expect("scan rows");
+        assert!(!rows.is_empty(), "expected series rows");
+
+        // Group exactly as find_superseded does; versions are only comparable
+        // within one node.
+        let mut by_node: std::collections::HashMap<
+            (String, String, String),
+            Vec<(i64, tlogfs::schema::CollapseRange)>,
+        > = std::collections::HashMap::new();
+        for r in &rows {
+            by_node
+                .entry((r.pond_id.clone(), r.part_id.clone(), r.node_id.clone()))
+                .or_default()
+                .push((
+                    r.version,
+                    tlogfs::schema::CollapseRange::new(
+                        r.version,
+                        r.collapsed_from,
+                        r.collapsed_through,
+                    ),
+                ));
+        }
+
+        let tiered = by_node.values().any(|entries| {
+            let Some(watermark) = entries
+                .iter()
+                .filter(|(_, r)| r.merged)
+                .map(|(_, r)| r.hi)
+                .max()
+            else {
+                return false;
+            };
+            tlogfs::schema::live_series_versions(entries)
+                .into_iter()
+                .any(|v| v <= watermark)
+        });
+
+        assert!(
+            tiered,
+            "collapse produced only a single tier (every live version sits above its node's \
+             highest collapsed_through), so this test cannot distinguish range containment \
+             from a watermark; rows={rows:?}"
         );
     }
 

--- a/crates/steward/src/reclaim.rs
+++ b/crates/steward/src/reclaim.rs
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reclamation: the second half of version collapse.
+//!
+//! Collapse merges a window of series versions into one run row but leaves the
+//! superseded rows in the table.  Those rows are already invisible to every
+//! reader (they go through [`tlogfs::schema::live_series_entries`]), yet each
+//! one still *references* its `_large_files` blob, so nothing is reclaimed
+//! until the rows themselves are deleted.  Reclamation therefore runs in two
+//! ordered steps:
+//!
+//! 1. Delete superseded series rows from the data Delta table.
+//! 2. Mark-sweep `_large_files`, deleting every blob whose blake3 no longer
+//!    appears in any remaining row.
+//!
+//! The order matters and cannot be inverted: `pond fsck`'s content pass reads
+//! *every* row and requires each large-file blob to exist, so sweeping a blob
+//! while its row survives turns a healthy pond into a failing one.
+//!
+//! Deleting superseded rows is Merkle-neutral: steward's content fold already
+//! prunes them, so a pond's `root_tree_hash` is unchanged by reclamation and
+//! mirrors -- which never received these rows -- stay converged.
+//!
+//! Reclamation is deliberately *not* a separate command or flag.  It is what
+//! makes collapse actually free space, so it runs as part of the same
+//! `pond maintain` pass.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use datafusion::prelude::SessionContext;
+use deltalake::DeltaTable;
+use deltalake::kernel::transaction::CommitProperties;
+use log::debug;
+
+use std::sync::Arc;
+use tlogfs::schema::{CollapseRange, live_series_versions};
+
+use crate::StewardError;
+
+/// Series rows are grouped by this key before supersession is evaluated.
+type SeriesKey = (String, String, String);
+
+/// What a reclamation pass freed.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ReclaimStats {
+    /// Superseded series rows deleted from the data table.
+    pub rows_deleted: usize,
+    /// `_large_files` blobs deleted because no row referenced them.
+    pub blobs_removed: usize,
+    /// Bytes reclaimed from those blobs.
+    pub bytes_freed: u64,
+}
+
+impl ReclaimStats {
+    /// True when the pass changed nothing, so callers can stay quiet.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rows_deleted == 0 && self.blobs_removed == 0
+    }
+}
+
+impl std::fmt::Display for ReclaimStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "reclaim: {} superseded row(s) deleted, {} blob(s) freed ({} bytes)",
+            self.rows_deleted, self.blobs_removed, self.bytes_freed
+        )
+    }
+}
+
+/// The projection reclamation needs: enough to evaluate supersession, and the
+/// identity columns needed to name a row in a delete predicate.
+#[derive(serde::Deserialize)]
+struct SeriesRow {
+    pond_id: String,
+    part_id: String,
+    node_id: String,
+    version: i64,
+    collapsed_from: Option<i64>,
+    collapsed_through: Option<i64>,
+}
+
+/// Every row of a physical series, projected to the columns above.
+///
+/// Both physical series kinds are collapsible and so both can hold superseded
+/// rows; no other entry type has a supersession relation at all.
+const SERIES_ROWS_SQL: &str = "SELECT pond_id, part_id, node_id, version, collapsed_from, \
+     collapsed_through FROM reclaim_scan \
+     WHERE file_type IN ('file:physical:series', 'table:physical:series')";
+
+/// Hashes still referenced by *some* row, across every pond_id.
+const REFERENCED_SQL: &str = "SELECT DISTINCT blake3 FROM reclaim_scan WHERE blake3 IS NOT NULL";
+
+#[derive(serde::Deserialize)]
+struct ReferencedHash {
+    blake3: Option<String>,
+}
+
+/// Cap on a single delete predicate's length.  Superseded versions are named
+/// explicitly (a range predicate would be wrong -- a run's own version can fall
+/// inside a *later* run's range), so a first pass over a pond with years of
+/// accumulated debt can produce a very long list.  Deletes are chunked instead
+/// of building one enormous expression.
+const PREDICATE_BUDGET: usize = 60_000;
+
+/// Delete superseded series rows, then sweep unreferenced `_large_files`.
+///
+/// `pond_path` is the pond root (the parent of `_large_files`).  Returns the
+/// new [`DeltaTable`] handle, since each delete produces a fresh table state.
+///
+/// # Safety
+///
+/// The caller **must** hold the pond write lock for the whole call.  The sweep
+/// deletes any blob no committed row references, which is indistinguishable
+/// from a blob a concurrent transaction has written but not yet committed.
+///
+/// # Errors
+///
+/// Returns an error if the data table cannot be scanned, a delete fails, or
+/// `_large_files` cannot be traversed.
+pub async fn reclaim_superseded(
+    table: DeltaTable,
+    pond_path: &Path,
+    app_metadata: HashMap<String, serde_json::Value>,
+) -> Result<(DeltaTable, ReclaimStats), StewardError> {
+    let mut stats = ReclaimStats::default();
+
+    let dead = find_superseded(&table).await?;
+    let mut table = table;
+    if !dead.is_empty() {
+        table = delete_rows(table, &dead, app_metadata, &mut stats).await?;
+    }
+
+    // Only now that the rows are gone can their blobs be unreferenced.
+    let referenced = referenced_hashes(&table).await?;
+    let swept = tlogfs::large_files::sweep_unreferenced(pond_path, &referenced).await?;
+    stats.blobs_removed = swept.removed;
+    stats.bytes_freed = swept.bytes_freed;
+
+    if !stats.is_empty() {
+        debug!("[MAINTAIN] {stats}");
+    }
+    Ok((table, stats))
+}
+
+/// Register `table` as `reclaim_scan` and run `sql`, deserializing the rows.
+async fn query_rows<T: serde::de::DeserializeOwned>(
+    table: &DeltaTable,
+    sql: &str,
+) -> Result<Vec<T>, StewardError> {
+    let ctx = SessionContext::new();
+    let _previous = ctx
+        .register_table("reclaim_scan", Arc::new(table.clone()))
+        .map_err(|e| StewardError::DeltaLake(e.to_string()))?;
+    let batches = ctx
+        .sql(sql)
+        .await
+        .map_err(|e| StewardError::DeltaLake(e.to_string()))?
+        .collect()
+        .await
+        .map_err(|e| StewardError::DeltaLake(e.to_string()))?;
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let decoded: Vec<T> = serde_arrow::from_record_batch(batch)
+            .map_err(|e| StewardError::DeltaLake(format!("reclaim: decode scan: {e}")))?;
+        rows.extend(decoded);
+    }
+    Ok(rows)
+}
+
+/// Group every series row by node and return the versions no reader can see.
+///
+/// Supersession is evaluated by [`live_series_versions`] -- the single
+/// definition shared with the read path -- and the dead set is its complement.
+/// It is never inferred from a watermark: a merged run carries a fresh highest
+/// version while standing for content in the middle of the stream, so both
+/// "everything below K" and "any version inside a run's range" would delete
+/// live runs.
+async fn find_superseded(table: &DeltaTable) -> Result<HashMap<SeriesKey, Vec<i64>>, StewardError> {
+    let rows: Vec<SeriesRow> = query_rows(table, SERIES_ROWS_SQL).await?;
+
+    let mut by_node: HashMap<SeriesKey, Vec<(i64, CollapseRange)>> = HashMap::new();
+    for row in rows {
+        by_node
+            .entry((row.pond_id, row.part_id, row.node_id))
+            .or_default()
+            .push((
+                row.version,
+                CollapseRange::new(row.version, row.collapsed_from, row.collapsed_through),
+            ));
+    }
+
+    let mut dead = HashMap::new();
+    for (key, entries) in by_node {
+        let live: HashSet<i64> = live_series_versions(&entries).into_iter().collect();
+        if live.len() == entries.len() {
+            continue; // nothing collapsed on this node
+        }
+        let victims: Vec<i64> = entries
+            .iter()
+            .map(|(version, _)| *version)
+            .filter(|version| !live.contains(version))
+            .collect();
+        if !victims.is_empty() {
+            let _previous = dead.insert(key, victims);
+        }
+    }
+    Ok(dead)
+}
+
+/// Delete the named rows in as few Delta commits as the predicate budget allows.
+async fn delete_rows(
+    table: DeltaTable,
+    dead: &HashMap<SeriesKey, Vec<i64>>,
+    app_metadata: HashMap<String, serde_json::Value>,
+    stats: &mut ReclaimStats,
+) -> Result<DeltaTable, StewardError> {
+    let mut table = table;
+    let mut clauses: Vec<String> = Vec::new();
+    let mut budget = 0usize;
+
+    for ((pond_id, part_id, node_id), versions) in dead {
+        for chunk in versions.chunks(256) {
+            let list = chunk
+                .iter()
+                .map(i64::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            let clause = format!(
+                "(pond_id = '{pond_id}' AND part_id = '{part_id}' AND node_id = '{node_id}' \
+                 AND version IN ({list}))"
+            );
+            budget += clause.len();
+            clauses.push(clause);
+            if budget >= PREDICATE_BUDGET {
+                table = flush_delete(table, &mut clauses, &app_metadata, stats).await?;
+                budget = 0;
+            }
+        }
+    }
+    flush_delete(table, &mut clauses, &app_metadata, stats).await
+}
+
+/// Commit one delete for the accumulated clauses, clearing them.
+async fn flush_delete(
+    table: DeltaTable,
+    clauses: &mut Vec<String>,
+    app_metadata: &HashMap<String, serde_json::Value>,
+    stats: &mut ReclaimStats,
+) -> Result<DeltaTable, StewardError> {
+    if clauses.is_empty() {
+        return Ok(table);
+    }
+    let predicate = clauses.join(" OR ");
+    clauses.clear();
+
+    let (new_table, metrics) = table
+        .delete()
+        .with_predicate(predicate)
+        .with_commit_properties(CommitProperties::default().with_metadata(app_metadata.clone()))
+        .await
+        .map_err(|e| StewardError::DeltaLake(format!("reclaim: delete superseded rows: {e}")))?;
+    stats.rows_deleted += metrics.num_deleted_rows;
+    Ok(new_table)
+}
+
+/// Every blake3 still named by a row, across all ponds.
+///
+/// Blobs are content-addressed, so one file can back rows in many nodes and
+/// many ponds (cross-pond imports mirror rows verbatim).  The referenced set
+/// must therefore be global; a per-node view would sweep blobs still in use.
+/// Inline rows carry a blake3 too, and including them is harmless -- it only
+/// ever *retains* a blob.
+async fn referenced_hashes(table: &DeltaTable) -> Result<HashSet<String>, StewardError> {
+    let rows: Vec<ReferencedHash> = query_rows(table, REFERENCED_SQL).await?;
+    Ok(rows.into_iter().filter_map(|r| r.blake3).collect())
+}

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -884,7 +884,7 @@ impl Ship {
             // TablePhysicalSeries must be re-encoded as a single parquet file.
             let collapsed = match id.entry_type() {
                 tinyfs::EntryType::TablePhysicalSeries => state.collapse_table_series(id).await,
-                _ => state.collapse_file_series(id).await,
+                _ => state.collapse_file_series(id, threshold).await,
             };
             match collapsed {
                 Ok(stats) if stats.collapsed => {

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -927,8 +927,19 @@ impl Ship {
     /// Content-preserving and therefore invisible to replication: steward's
     /// content fold already prunes superseded rows, so `root_tree_hash` is
     /// unchanged and mirrors -- which never received them -- stay converged.
-    /// The delete commit reuses the collapse transaction's sequence rather than
-    /// consuming a new one, since it introduces no new logical content.
+    /// `reclaim_superseded` asserts that rather than assuming it, and skips the
+    /// irreversible blob sweep if it does not hold.
+    ///
+    /// Consuming no sequence of its own is what makes reclamation a tail of the
+    /// collapse rather than a transaction: it introduces no new logical
+    /// content, so there is nothing for a mirror to receive.  Its delete
+    /// commits are therefore stamped as MAINTENANCE (`pond_maintenance`), not
+    /// as `pond_txn`.  Stamping them with the collapse's `txn_seq` would make
+    /// `reconstruct_txn_history` -- which yields one transaction per `pond_txn`
+    /// commit -- emit N+1 entries for that one sequence, so `pond rebuild`
+    /// would replay N+1 duplicate lifecycle records into the control table.
+    /// Seq recovery on open is unaffected: it takes the per-pond MAX over
+    /// `pond_txn` commits, and the collapse's own commit still carries it.
     async fn reclaim(
         &mut self,
         meta: &PondUserMetadata,
@@ -946,7 +957,8 @@ impl Ship {
         let (new_table, stats) = crate::reclaim::reclaim_superseded(
             self.data_persistence.table().clone(),
             &get_data_path(&self.pond_path),
-            txn_meta.to_delta_metadata(),
+            &pond_id.to_string(),
+            txn_meta.to_delta_maintenance_metadata(),
         )
         .await?;
         self.data_persistence.set_table(new_table);

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -883,7 +883,9 @@ impl Ship {
             // means: a FilePhysicalSeries is byte-concatenated, while a
             // TablePhysicalSeries must be re-encoded as a single parquet file.
             let collapsed = match id.entry_type() {
-                tinyfs::EntryType::TablePhysicalSeries => state.collapse_table_series(id).await,
+                tinyfs::EntryType::TablePhysicalSeries => {
+                    state.collapse_table_series(id, threshold).await
+                }
                 _ => state.collapse_file_series(id, threshold).await,
             };
             match collapsed {

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -52,6 +52,8 @@ pub struct CollapseReport {
     pub files_collapsed: usize,
     /// Total live versions superseded across all collapsed nodes.
     pub versions_collapsed: usize,
+    /// What the reclamation pass that follows the collapse actually freed.
+    pub reclaimed: crate::reclaim::ReclaimStats,
 }
 
 impl std::fmt::Display for CollapseReport {
@@ -60,7 +62,11 @@ impl std::fmt::Display for CollapseReport {
             f,
             "collapse: {} file(s) collapsed, {} version(s) superseded ({} candidate(s))",
             self.files_collapsed, self.versions_collapsed, self.candidates
-        )
+        )?;
+        if !self.reclaimed.is_empty() {
+            write!(f, "\n  {}", self.reclaimed)?;
+        }
+        Ok(())
     }
 }
 
@@ -869,6 +875,10 @@ impl Ship {
             ..CollapseReport::default()
         };
         if candidates.is_empty() {
+            // Still reclaim: a pond can carry debt from before reclamation
+            // existed, from a crash between collapse and reclaim, or from a
+            // blob staged by a transaction that never committed.
+            report.reclaimed = self.reclaim(&meta).await?;
             return Ok(report);
         }
 
@@ -899,7 +909,48 @@ impl Ship {
         }
         _ = tx.commit().await?;
 
+        // Phase 3: reclaim, now that the merged runs are durable.  This is the
+        // second half of collapse, not a separate feature: until the superseded
+        // rows are deleted they still reference their `_large_files` blobs, so
+        // collapse alone bounds the GROWTH RATE of a pond without ever
+        // returning a byte.  Doing it after the commit is what makes it
+        // crash-safe -- an interruption leaves the superseded rows in place,
+        // which is exactly the pre-reclaim state, whereas deleting first could
+        // lose content if the merged run never landed.
+        report.reclaimed = self.reclaim(&meta).await?;
+
         Ok(report)
+    }
+
+    /// Delete rows no reader can see and sweep the blobs they held down.
+    ///
+    /// Content-preserving and therefore invisible to replication: steward's
+    /// content fold already prunes superseded rows, so `root_tree_hash` is
+    /// unchanged and mirrors -- which never received them -- stay converged.
+    /// The delete commit reuses the collapse transaction's sequence rather than
+    /// consuming a new one, since it introduces no new logical content.
+    async fn reclaim(
+        &mut self,
+        meta: &PondUserMetadata,
+    ) -> Result<crate::reclaim::ReclaimStats, StewardError> {
+        let pond_id = self.control_table.pond_id_uuid();
+        let control_dir = get_control_path(&self.pond_path);
+        let mut txn_meta = PondTxnMetadata::new(self.last_write_seq, meta.clone());
+        txn_meta.pond_id = pond_id.to_string();
+
+        // The sweep deletes every blob no committed row names, which it cannot
+        // distinguish from a blob a concurrent writer has staged but not yet
+        // committed.  Exclusion is the guarantee that makes it safe.
+        let _write_lock = crate::write_lock::WriteLockGuard::try_acquire(&control_dir, &txn_meta)?;
+
+        let (new_table, stats) = crate::reclaim::reclaim_superseded(
+            self.data_persistence.table().clone(),
+            &get_data_path(&self.pond_path),
+            txn_meta.to_delta_metadata(),
+        )
+        .await?;
+        self.data_persistence.set_table(new_table);
+        Ok(stats)
     }
 
     /// Compact this pond's own data partitions as a RECORDED, pushable

--- a/crates/steward/tests/rebuild_control_test.rs
+++ b/crates/steward/tests/rebuild_control_test.rs
@@ -257,3 +257,79 @@ async fn rebuild_control_preserves_content_roots() -> Result<()> {
 
     Ok(())
 }
+
+/// Reclamation's delete commits must not be replayed as transactions.
+///
+/// `reclaim` runs as the tail of a collapse and deliberately consumes no
+/// sequence of its own.  Its deletes are chunked, so stamping them with the
+/// collapse's `txn_seq` under the `pond_txn` key would make
+/// `reconstruct_txn_history` -- which yields one transaction per `pond_txn`
+/// commit -- emit several entries for that single sequence, and rebuild would
+/// replay a duplicate lifecycle record for each.  Maintenance commits are
+/// stamped under `pond_maintenance` instead, so they stay attributable on disk
+/// while being invisible to transaction reconstruction.
+#[tokio::test]
+async fn rebuild_after_collapse_reclaim_replays_one_txn_per_seq() -> Result<()> {
+    let temp = tempdir()?;
+    let pond_path = temp.path().join("pond");
+
+    let (orig_last_seq, reclaimed_rows) = {
+        let mut ship = Ship::create_pond(&pond_path, "reclaim-rebuild").await?;
+
+        // Enough versions of a collapsible series that a collapse has real
+        // work, and reclaim has real rows to delete.
+        for i in 0..12u64 {
+            let meta = PondUserMetadata::new(vec!["test".into(), format!("append{i}")]);
+            let bytes = vec![b'a'.wrapping_add((i % 26) as u8); 4096];
+            ship.write_transaction(&meta, async move |fs| {
+                let root = fs.root().await?;
+                let mut w = root
+                    .async_writer_path_with_type("/events.series", EntryType::FilePhysicalSeries)
+                    .await?;
+                w.write_all(&bytes)
+                    .await
+                    .map_err(|e| steward::StewardError::Aborted(format!("write: {}", e)))?;
+                w.shutdown()
+                    .await
+                    .map_err(|e| steward::StewardError::Aborted(format!("close: {}", e)))?;
+                Ok(())
+            })
+            .await?;
+        }
+
+        let report = ship.collapse_versions(1).await?;
+        assert!(report.files_collapsed > 0, "series should have collapsed");
+        assert!(
+            report.reclaimed.rows_deleted > 0,
+            "collapse must have superseded rows to reclaim"
+        );
+        (ship.last_write_seq(), report.reclaimed.rows_deleted)
+    };
+
+    std::fs::remove_dir_all(get_control_path(&pond_path))?;
+    let report = rebuild_control_table(&pond_path, false).await?;
+
+    assert_eq!(
+        report.last_txn_seq, orig_last_seq,
+        "reclaim consumes no sequence, so the recovered frontier is the collapse's"
+    );
+    assert_eq!(
+        report.txns_reconstructed as i64, orig_last_seq,
+        "exactly one reconstructed txn per committed seq: reclaim deleted {reclaimed_rows} \
+         row(s) across its own Delta commits, and none of them may appear as a transaction"
+    );
+
+    // The rebuilt control table must agree, and the pond must still open.
+    let mut ship = Ship::open_pond(&pond_path).await?;
+    assert_eq!(ship.last_write_seq(), orig_last_seq);
+    assert_eq!(
+        ship.control_table().get_last_write_sequence().await?,
+        orig_last_seq
+    );
+
+    // And a further write continues from the recovered frontier.
+    write_file(&mut ship, "/after.txt", b"ok", vec!["copy", "after"]).await?;
+    assert_eq!(ship.last_write_seq(), orig_last_seq + 1);
+
+    Ok(())
+}

--- a/crates/steward/tests/reclaim_test.rs
+++ b/crates/steward/tests/reclaim_test.rs
@@ -248,3 +248,53 @@ async fn reclamation_is_idempotent() {
     );
     assert_eq!(blobs_on_disk(&pond), settled, "blob set must be stable");
 }
+
+/// Collapse + reclaim must leave the pond fully readable and internally
+/// consistent: every appended byte still present, and no row naming a blob the
+/// sweep removed.
+///
+/// The Merkle-neutrality of reclamation itself is pinned separately, as a unit
+/// test in `steward::reclaim`, because it must bracket the deletes alone --
+/// collapse commits merged rows as an ordinary write and legitimately moves the
+/// content root, so it cannot be measured through `collapse_versions`.
+#[tokio::test]
+async fn collapse_and_reclaim_leave_a_consistent_pond() {
+    let tmp = tempdir().expect("tempdir");
+    let pond = tmp.path().join("pond");
+    let mut ship = Ship::create_pond(pond.clone(), "reclaim-consistent")
+        .await
+        .expect("create pond");
+
+    for i in 0..12 {
+        append_series_version(&mut ship, "/events.series", &chunk(i + 7, 96 * 1024)).await;
+    }
+    write_file(&mut ship, "/bystander.txt", b"untouched").await;
+
+    let report = ship.collapse_versions(1).await.expect("collapse");
+    assert!(report.files_collapsed > 0, "series should have collapsed");
+    assert!(
+        report.reclaimed.rows_deleted > 0,
+        "reclamation must have deleted superseded rows for this to prove anything"
+    );
+
+    let bytes = read_bytes(&mut ship, "/events.series").await;
+    assert_eq!(
+        bytes.len(),
+        12 * 96 * 1024,
+        "every appended byte must survive collapse + reclaim"
+    );
+    assert_eq!(
+        read_bytes(&mut ship, "/bystander.txt").await,
+        b"untouched",
+        "reclamation must not touch an unrelated file"
+    );
+
+    let fsck = steward::fsck(&ship, FsckOptions::default())
+        .await
+        .expect("fsck after reclaim");
+    assert!(
+        fsck.errors.is_empty(),
+        "fsck must find no dangling blob after the sweep: {:?}",
+        fsck.errors
+    );
+}

--- a/crates/steward/tests/reclaim_test.rs
+++ b/crates/steward/tests/reclaim_test.rs
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for reclamation -- the second half of version collapse.
+//!
+//! Collapse alone bounds a pond's growth RATE but never returns a byte: the
+//! superseded rows survive, and each one still references its `_large_files`
+//! blob.  These tests pin the two properties that make deleting them safe:
+//! only rows no reader can see are removed, and a blob is swept only when NO
+//! remaining row names its hash.
+//!
+//! The failure mode being guarded against is silent: sweeping a live blob
+//! leaves a pond that looks healthy until something tries to read it.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use steward::{FsckOptions, Ship};
+use tempfile::tempdir;
+use tlogfs::PondUserMetadata;
+use tokio::io::AsyncWriteExt;
+
+fn meta(label: &str) -> PondUserMetadata {
+    PondUserMetadata::new(vec!["test".into(), label.into()])
+}
+
+/// Incompressible bytes, so every version really does exceed
+/// `LARGE_FILE_THRESHOLD` and lands as its own blob rather than inline.
+fn chunk(seed: u64, len: usize) -> Vec<u8> {
+    // The seed must never collide across versions: identical content would
+    // dedup to ONE blob and quietly weaken every assertion below.
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 24) as u8
+        })
+        .collect()
+}
+
+/// Every `blake3=<hash>.parquet` currently on disk, flat or sharded.
+fn blobs_on_disk(pond: &Path) -> HashSet<String> {
+    let root = pond.join("data").join("_large_files");
+    let mut found = HashSet::new();
+    let mut dirs = vec![root];
+    while let Some(dir) = dirs.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                dirs.push(path);
+                continue;
+            }
+            if let Some(hash) = entry
+                .file_name()
+                .to_str()
+                .and_then(|n| n.strip_prefix("blake3="))
+                .and_then(|n| n.strip_suffix(".parquet"))
+            {
+                let _ = found.insert(hash.to_string());
+            }
+        }
+    }
+    found
+}
+
+async fn write_file(ship: &mut Ship, path: &str, bytes: &[u8]) {
+    let path = path.to_string();
+    let bytes = bytes.to_vec();
+    ship.write_transaction(&meta("write"), async move |fs| {
+        let root = fs.root().await?;
+        let _ = tinyfs::async_helpers::convenience::create_file_path(&root, &path, &bytes).await?;
+        Ok(())
+    })
+    .await
+    .expect("write transaction");
+}
+
+/// Append one version to a `FilePhysicalSeries` -- the kind collapse merges by
+/// byte concatenation.
+async fn append_series_version(ship: &mut Ship, path: &str, bytes: &[u8]) {
+    let path = path.to_string();
+    let bytes = bytes.to_vec();
+    ship.write_transaction(&meta("series"), async move |fs| {
+        let root = fs.root().await?;
+        let mut writer = root
+            .async_writer_path_with_type(&path, tinyfs::EntryType::FilePhysicalSeries)
+            .await?;
+        writer.write_all(&bytes).await?;
+        writer.shutdown().await?;
+        Ok(())
+    })
+    .await
+    .expect("series transaction");
+}
+
+async fn read_bytes(ship: &mut Ship, path: &str) -> Vec<u8> {
+    let tx = ship.begin_read(&meta("read")).await.expect("begin read");
+    let root = tx.root().await.expect("root");
+    root.read_file_path_to_vec(path).await.expect("read")
+}
+
+/// A collapse that merges versions must also delete the rows it superseded and
+/// free the blobs those rows were the last referrers of -- otherwise collapse
+/// changes only the growth rate and the pond never shrinks.
+#[tokio::test]
+async fn collapse_reclaims_superseded_rows_and_blobs() {
+    let tmp = tempdir().expect("tempdir");
+    let pond = tmp.path().join("pond");
+    let mut ship = Ship::create_pond(pond.clone(), "reclaim-src")
+        .await
+        .expect("create pond");
+
+    // Twelve versions, each its own large blob, so a fanout-10 window has
+    // something to merge and a loose tail survives it.
+    let chunks: Vec<Vec<u8>> = (0..12).map(|i| chunk(i + 7, 96 * 1024)).collect();
+    for bytes in &chunks {
+        append_series_version(&mut ship, "/events.series", bytes).await;
+    }
+    let cumulative: Vec<u8> = chunks.concat();
+    assert_eq!(read_bytes(&mut ship, "/events.series").await, cumulative);
+
+    let before = blobs_on_disk(&pond);
+    assert!(
+        before.len() >= chunks.len(),
+        "each version should have externalized its own blob, saw {}",
+        before.len()
+    );
+
+    let report = ship.collapse_versions(1).await.expect("collapse");
+    assert!(report.files_collapsed > 0, "series should have collapsed");
+    assert!(
+        report.reclaimed.rows_deleted > 0,
+        "collapse must delete the rows it superseded"
+    );
+    assert!(
+        report.reclaimed.blobs_removed > 0,
+        "deleting the last referrers must free their blobs"
+    );
+    assert!(report.reclaimed.bytes_freed > 0, "freed bytes must be real");
+
+    let after = blobs_on_disk(&pond);
+    assert!(
+        after.len() < before.len(),
+        "blob count must fall: {} -> {}",
+        before.len(),
+        after.len()
+    );
+
+    // The whole point: the content is unchanged.
+    assert_eq!(
+        read_bytes(&mut ship, "/events.series").await,
+        cumulative,
+        "reclamation must not change what the series reads back"
+    );
+
+    // And the pond still verifies -- fsck's content pass reads EVERY surviving
+    // row and requires its blob to exist, so a premature sweep fails here.
+    let report = steward::fsck(&ship, FsckOptions::default())
+        .await
+        .expect("fsck");
+    assert!(report.ok(), "fsck must pass after reclamation");
+}
+
+/// Blobs are content-addressed, so one file can back many rows.  Reclamation
+/// must therefore mark-sweep by hash: a blob whose series version is superseded
+/// is still live if any OTHER row shares its content.
+#[tokio::test]
+async fn shared_blob_survives_when_one_referrer_is_deleted() {
+    let tmp = tempdir().expect("tempdir");
+    let pond = tmp.path().join("pond");
+    let mut ship = Ship::create_pond(pond.clone(), "reclaim-shared")
+        .await
+        .expect("create pond");
+
+    let chunks: Vec<Vec<u8>> = (0..12).map(|i| chunk(i + 31, 96 * 1024)).collect();
+    for bytes in &chunks {
+        append_series_version(&mut ship, "/events.series", bytes).await;
+    }
+    // A plain file with byte-identical content to the series' first version.
+    // Both rows name the same blake3, so both name the same blob.
+    write_file(&mut ship, "/keep.bin", &chunks[0]).await;
+
+    let shared: HashSet<String> = blobs_on_disk(&pond);
+    let report = ship.collapse_versions(1).await.expect("collapse");
+    assert!(
+        report.reclaimed.rows_deleted > 0,
+        "rows should have been cut"
+    );
+
+    let survivors = blobs_on_disk(&pond);
+    assert!(
+        survivors.len() < shared.len(),
+        "unshared superseded blobs should still be freed"
+    );
+
+    // The shared blob must have survived the sweep even though the version that
+    // co-owned it is gone.
+    let kept = read_bytes(&mut ship, "/keep.bin").await;
+    assert_eq!(
+        kept, chunks[0],
+        "a blob shared with a live row must not be swept"
+    );
+
+    let report = steward::fsck(&ship, FsckOptions::default())
+        .await
+        .expect("fsck");
+    assert!(report.ok(), "fsck must pass with a shared blob retained");
+}
+
+/// A second pass has nothing left to reclaim.  This is the direct guard against
+/// the catastrophic case -- a sweep that keeps finding "garbage" is a sweep
+/// that is eating live data.
+#[tokio::test]
+async fn reclamation_is_idempotent() {
+    let tmp = tempdir().expect("tempdir");
+    let pond = tmp.path().join("pond");
+    let mut ship = Ship::create_pond(pond.clone(), "reclaim-idem")
+        .await
+        .expect("create pond");
+
+    for i in 0..12 {
+        append_series_version(&mut ship, "/events.series", &chunk(i + 101, 96 * 1024)).await;
+    }
+    // Collapse to a fixed point first: with `max_live = 1` a single pass merges
+    // one window, so the pond is only settled once a pass finds nothing.
+    loop {
+        let pass = ship.collapse_versions(1).await.expect("collapse pass");
+        if pass.files_collapsed == 0 {
+            break;
+        }
+    }
+    let settled = blobs_on_disk(&pond);
+
+    let second = ship.collapse_versions(1).await.expect("second collapse");
+    assert_eq!(
+        second.reclaimed.rows_deleted, 0,
+        "no live row may be mistaken for garbage on a second pass"
+    );
+    assert_eq!(
+        second.reclaimed.blobs_removed, 0,
+        "no live blob may be mistaken for garbage on a second pass"
+    );
+    assert_eq!(blobs_on_disk(&pond), settled, "blob set must be stable");
+}

--- a/crates/tlogfs/src/file.rs
+++ b/crates/tlogfs/src/file.rs
@@ -259,10 +259,15 @@ impl OpLogFile {
 /// Read the pending tail bytes from previous versions of a FilePhysicalSeries.
 ///
 /// The pending bytes are the last `pending_len` bytes of the cumulative content
-/// (all versions concatenated). They are needed to correctly resume the bao-tree
-/// incremental hash state.
+/// (all live versions concatenated). They are needed to correctly resume the
+/// bao-tree incremental hash state.
 ///
-/// Reads versions backward from the most recent, collecting enough tail bytes.
+/// Walks the *live* rows backward in series byte order. Counting down through
+/// version numbers would be wrong once size-tiered collapse is in play: a merged
+/// run is appended with a fresh, highest version number while standing for
+/// content in the middle of the stream, and the versions it superseded still
+/// exist as rows, so a numeric walk would both mis-order the tail and
+/// double-count superseded bytes.
 async fn read_pending_bytes(
     state: &State,
     file_id: FileID,
@@ -270,38 +275,32 @@ async fn read_pending_bytes(
     pending_len: usize,
 ) -> tinyfs::Result<Vec<u8>> {
     debug!(
-        "Reading {} pending bytes for file {} (versions 1..{})",
-        pending_len,
-        file_id,
-        allocated_version - 1
+        "Reading {} pending bytes for file {} (versions below {})",
+        pending_len, file_id, allocated_version
     );
+
+    let records = state
+        .query_records(file_id)
+        .await
+        .map_other_context("read_pending_bytes: query records")?;
+    let live_versions: Vec<u64> = crate::schema::live_series_entries(&records)
+        .into_iter()
+        .filter(|r| r.size.unwrap_or(0) > 0 && r.version < allocated_version)
+        .map(|r| r.version as u64)
+        .collect();
 
     let mut collected: Vec<u8> = Vec::with_capacity(pending_len);
 
-    // Walk versions backward from the most recent
-    let mut version = (allocated_version - 1) as u64;
-    while collected.len() < pending_len && version >= 1 {
-        let version_content = state.read_file_version(file_id, version).await?;
-        let needed = pending_len - collected.len();
-
-        if version_content.len() >= needed {
-            // This version has enough bytes — take from the tail
-            let start = version_content.len() - needed;
-            // Prepend to collected (we're walking backward)
-            let mut new_collected = version_content[start..].to_vec();
-            new_collected.extend_from_slice(&collected);
-            collected = new_collected;
-        } else {
-            // Take the entire version and keep looking
-            let mut new_collected = version_content;
-            new_collected.extend_from_slice(&collected);
-            collected = new_collected;
-        }
-
-        if version == 0 {
+    for version in live_versions.iter().rev() {
+        if collected.len() >= pending_len {
             break;
         }
-        version -= 1;
+        let version_content = state.read_file_version(file_id, *version).await?;
+        let needed = pending_len - collected.len();
+        let start = version_content.len().saturating_sub(needed);
+        let mut new_collected = version_content[start..].to_vec();
+        new_collected.extend_from_slice(&collected);
+        collected = new_collected;
     }
 
     if collected.len() != pending_len {

--- a/crates/tlogfs/src/file.rs
+++ b/crates/tlogfs/src/file.rs
@@ -268,7 +268,7 @@ impl OpLogFile {
 /// content in the middle of the stream, and the versions it superseded still
 /// exist as rows, so a numeric walk would both mis-order the tail and
 /// double-count superseded bytes.
-async fn read_pending_bytes(
+pub(crate) async fn read_pending_bytes(
     state: &State,
     file_id: FileID,
     allocated_version: i64,

--- a/crates/tlogfs/src/large_files.rs
+++ b/crates/tlogfs/src/large_files.rs
@@ -865,3 +865,72 @@ impl tokio::io::AsyncSeek for ParquetFileReader {
         Poll::Ready(Ok(self.position))
     }
 }
+
+/// Outcome of a [`sweep_unreferenced`] pass.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SweepStats {
+    /// Blobs deleted because no row referenced their hash.
+    pub removed: usize,
+    /// Bytes reclaimed from the deleted blobs.
+    pub bytes_freed: u64,
+}
+
+/// Delete every `_large_files` blob whose blake3 is absent from `referenced`.
+///
+/// Blobs are content-addressed, so one file can back many rows across many
+/// nodes and ponds; reclamation must therefore be a mark-sweep over the whole
+/// table's referenced hashes, never a per-row delete.
+///
+/// # Safety
+///
+/// The caller **must** hold the pond write lock. An uncommitted transaction can
+/// have already written a blob that no committed row references yet, and this
+/// sweep cannot distinguish that from garbage.
+///
+/// Only files named `blake3=<hash>.parquet` are considered, so in-flight temp
+/// files are never touched.
+///
+/// # Errors
+///
+/// Returns an error if `_large_files` cannot be traversed or a blob cannot be
+/// removed.
+pub async fn sweep_unreferenced<P: AsRef<Path>>(
+    pond_path: P,
+    referenced: &std::collections::HashSet<String>,
+) -> std::io::Result<SweepStats> {
+    let root = pond_path.as_ref().join("_large_files");
+    if !root.exists() {
+        return Ok(SweepStats::default());
+    }
+
+    // `_large_files` is either flat or one level of `blake3_16=` shards.
+    let mut dirs = vec![root];
+    let mut stats = SweepStats::default();
+    while let Some(dir) = dirs.pop() {
+        let mut entries = tokio::fs::read_dir(&dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            if file_type.is_dir() {
+                dirs.push(entry.path());
+                continue;
+            }
+            let name = entry.file_name();
+            let Some(hash) = name
+                .to_str()
+                .and_then(|n| n.strip_prefix("blake3="))
+                .and_then(|n| n.strip_suffix(".parquet"))
+            else {
+                continue;
+            };
+            if referenced.contains(hash) {
+                continue;
+            }
+            let size = entry.metadata().await.map(|m| m.len()).unwrap_or(0);
+            tokio::fs::remove_file(entry.path()).await?;
+            stats.removed += 1;
+            stats.bytes_freed += size;
+            debug!("swept unreferenced large-file blob blake3={hash} ({size} bytes)");
+        }
+    }
+    Ok(stats)
+}

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -1499,7 +1499,11 @@ impl State {
     /// Returns an error if `id` is not a `TablePhysicalSeries`, if the series
     /// carries no timestamp column, if reading or re-encoding fails, or if the
     /// post-collapse row count or temporal bounds do not match the input.
-    pub async fn collapse_table_series(&self, id: FileID) -> Result<CollapseStats, TLogFSError> {
+    pub async fn collapse_table_series(
+        &self,
+        id: FileID,
+        max_live: usize,
+    ) -> Result<CollapseStats, TLogFSError> {
         use tokio::io::AsyncWriteExt;
 
         if id.entry_type() != EntryType::TablePhysicalSeries {
@@ -1511,18 +1515,20 @@ impl State {
             });
         }
 
-        // Assess current versions and gather metadata the merged row inherits.
-        // The lock is released before any table-provider work below, which
-        // re-enters the persistence layer to resolve versions.
-        //
-        // Unlike `collapse_file_series`, this still merges the *entire* live set
-        // on every call: `reencode_table_series` reads the whole series back
-        // through the table provider, which has no way to restrict itself to a
-        // version window. Tiering the table path therefore needs a
-        // version-bounded provider and is left as follow-up work; the range
-        // bookkeeping below is written generically so only the window selection
-        // has to change.
-        let (versions_before, lo, hi, min_event, max_event, timestamp_column, store_path, options) = {
+        // Assess current versions and pick the window to merge. The lock is
+        // released before any table-provider work below, which re-enters the
+        // persistence layer to resolve versions.
+        let (
+            versions_before,
+            window_versions,
+            lo,
+            hi,
+            min_event,
+            max_event,
+            timestamp_column,
+            store_path,
+            options,
+        ) = {
             let mut inner = self.inner.lock().await;
             let records = inner.query_records(id).await?;
             let live: Vec<&OplogEntry> = crate::schema::live_series_entries(&records)
@@ -1530,17 +1536,18 @@ impl State {
                 .filter(|r| r.size.unwrap_or(0) > 0)
                 .collect();
 
-            if live.len() < 2 {
+            let Some(range) = choose_collapse_window(&live, max_live) else {
                 return Ok(CollapseStats {
                     collapsed: false,
                     versions_before: live.len(),
                     merged_version: 0,
                     bytes: 0,
                 });
-            }
+            };
+            let window = &live[range];
 
-            let latest = *live.last().expect("live is non-empty");
-            let timestamp_column = latest
+            let newest = *window.last().expect("window is non-empty");
+            let timestamp_column = newest
                 .get_extended_attributes()
                 .map(|a| a.timestamp_column().to_string())
                 .filter(|s| !s.is_empty())
@@ -1550,22 +1557,24 @@ impl State {
                          TablePhysicalSeries cannot be rewritten without one"
                     ),
                 })?;
-            let min_event = live.iter().filter_map(|r| r.min_event_time).min();
-            let max_event = live.iter().filter_map(|r| r.max_event_time).max();
+            let min_event = window.iter().filter_map(|r| r.min_event_time).min();
+            let max_event = window.iter().filter_map(|r| r.max_event_time).max();
 
-            let lo = live
+            let lo = window
                 .iter()
                 .map(|r| crate::schema::CollapseRange::of(r).lo)
                 .min()
-                .expect("live is non-empty");
-            let hi = live
+                .expect("window is non-empty");
+            let hi = window
                 .iter()
                 .map(|r| crate::schema::CollapseRange::of(r).hi)
                 .max()
-                .expect("live is non-empty");
+                .expect("window is non-empty");
+            let window_versions: Vec<i64> = window.iter().map(|r| r.version).collect();
 
             (
                 live.len(),
+                window_versions,
                 lo,
                 hi,
                 min_event,
@@ -1576,10 +1585,12 @@ impl State {
             )
         };
 
-        // Re-encode every live version into a single parquet buffer. The table
-        // provider unions the per-version parquet files, so this is the
-        // authoritative post-collapse content.
-        let (merged, rows_before) = self.reencode_table_series(id, &timestamp_column).await?;
+        // Re-encode just this window into a single parquet buffer. The table
+        // provider unions the listed per-version parquet files and merges their
+        // schemas, so this is the authoritative content for the merged run.
+        let (merged, rows_before) = self
+            .reencode_table_versions(id, &window_versions, &timestamp_column)
+            .await?;
 
         // Store the merged parquet as a fresh first-version body so the bao-tree
         // cumulative state covers exactly this content.
@@ -1660,9 +1671,12 @@ impl State {
         };
 
         // Invariant: re-encoding must preserve logical content. Byte-identity
-        // does not hold across a parquet rewrite, so compare row count and the
-        // event-time bounds recovered from the merged file itself.
-        let (after, rows_after) = self.reencode_table_series(id, &timestamp_column).await?;
+        // does not hold across a parquet rewrite, so compare the row count of
+        // the stored merged run against the window it replaced. Scanning only
+        // the merged version keeps verification proportional to the window.
+        let (after, rows_after) = self
+            .reencode_table_versions(id, &[merged_version], &timestamp_column)
+            .await?;
         if rows_after != rows_before {
             return Err(TLogFSError::Transaction {
                 message: format!(
@@ -1681,23 +1695,37 @@ impl State {
         })
     }
 
-    /// Read every live version of a table series back through its table
-    /// provider and re-encode the union as a single parquet buffer.
+    /// Read the given versions of a table series back through a table provider
+    /// and re-encode their union as a single parquet buffer.
+    ///
+    /// The versions are passed as explicit per-version URLs rather than the
+    /// series' "all versions" pattern, so a collapse can re-encode just the
+    /// window it intends to merge. DataFusion still infers and merges the schema
+    /// across the listed files, which is why this goes through the provider
+    /// instead of decoding each version's parquet directly.
     ///
     /// Returns the parquet bytes and the total row count.
-    async fn reencode_table_series(
+    async fn reencode_table_versions(
         &self,
         id: FileID,
+        versions: &[i64],
         timestamp_column: &str,
     ) -> Result<(Vec<u8>, usize), TLogFSError> {
         use futures::StreamExt;
         use parquet::arrow::ArrowWriter;
 
         let context = self.as_provider_context();
+        let additional_urls: Vec<String> = versions
+            .iter()
+            .map(|v| provider::TinyFsPathBuilder::url_specific_version(&id, *v as u64))
+            .collect();
         let table_provider = provider::create_table_provider(
             id,
             &context,
-            provider::TableProviderOptions::default(),
+            provider::TableProviderOptions {
+                version_selection: provider::VersionSelection::AllVersions,
+                additional_urls,
+            },
         )
         .await
         .map_err(|e| TLogFSError::Internal(format!("collapse: build table provider: {e}")))?;

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -22,6 +22,7 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use provider::{FactoryContext, FactoryRegistry};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -178,6 +179,81 @@ struct CollapseCandidate {
     pond_id: String,
     part_id: String,
     node_id: String,
+}
+
+/// Number of same-size-class runs merged into one run of the next class.
+///
+/// This is the fanout of a size-tiered (LSM-style) compaction: each byte is
+/// rewritten once per class it is promoted through, so total write volume is
+/// `O(N log_F N)` rather than the `O(N^2)` of repeatedly rewriting the whole
+/// series.
+///
+/// The value trades write volume against read cost. A larger fanout writes
+/// slightly less but leaves up to `F - 1` live runs per class, and reads pay
+/// per live segment. At `F = 10` a series holds at most a few dozen live
+/// segments across all classes -- fewer than the ~100 loose versions the old
+/// scheme allowed between collapses -- while keeping write amplification to a
+/// small constant.
+pub const COLLAPSE_FANOUT: usize = 10;
+
+/// Size class of a run, i.e. its magnitude in units of [`COLLAPSE_FANOUT`].
+///
+/// Runs merge only with runs of the same class, which is what keeps a large
+/// accumulated run from being rewritten every time a few small versions arrive.
+fn size_class(bytes: u64) -> u32 {
+    let mut class = 0u32;
+    let mut bound = COLLAPSE_FANOUT as u64;
+    while bytes >= bound {
+        class += 1;
+        match bound.checked_mul(COLLAPSE_FANOUT as u64) {
+            Some(next) => bound = next,
+            None => break,
+        }
+    }
+    class
+}
+
+/// Choose the contiguous window of live rows to merge, or `None` for a no-op.
+///
+/// Size-tiered policy: merge the oldest group of [`COLLAPSE_FANOUT`] *adjacent*
+/// rows sharing a size class. Merging only same-class neighbours is the whole
+/// point -- it is what stops a 96 MB accumulated run from being rewritten to
+/// absorb 10 KB of new data.
+///
+/// `max_live` is a backstop for read cost. If no same-class group exists but the
+/// series has drifted past `max_live` segments, the oldest `COLLAPSE_FANOUT`
+/// rows are merged regardless of class so segment count stays bounded.
+///
+/// Returns a half-open index range into `live` (which must be ordered oldest
+/// content first).
+fn choose_collapse_window(live: &[&OplogEntry], max_live: usize) -> Option<Range<usize>> {
+    if live.len() < 2 {
+        return None;
+    }
+
+    // Oldest same-class group of at least COLLAPSE_FANOUT adjacent rows.
+    let classes: Vec<u32> = live
+        .iter()
+        .map(|r| size_class(r.size.unwrap_or(0).max(0) as u64))
+        .collect();
+    let mut start = 0usize;
+    while start < classes.len() {
+        let mut end = start + 1;
+        while end < classes.len() && classes[end] == classes[start] {
+            end += 1;
+        }
+        if end - start >= COLLAPSE_FANOUT {
+            return Some(start..start + COLLAPSE_FANOUT);
+        }
+        start = end;
+    }
+
+    // Backstop: bound live segment count even when classes are ragged.
+    if live.len() > max_live {
+        return Some(0..COLLAPSE_FANOUT.min(live.len()));
+    }
+
+    None
 }
 
 /// One reconstructed write transaction recovered from the data Delta
@@ -622,7 +698,7 @@ impl OpLogPersistence {
                     "delta.dataSkippingStatsColumns".to_string(),
                     // pond_id and part_id are partition columns (in the file path);
                     // partition columns do not need data-skipping stats.
-                    Some("node_id,name,parent_id,entry_type,file_type,timestamp,version,blake3,size,min_event_time,max_event_time,min_override,max_override,extended_attributes,factory,txn_seq,collapsed_through".to_string())
+                    Some("node_id,name,parent_id,entry_type,file_type,timestamp,version,blake3,size,min_event_time,max_event_time,min_override,max_override,extended_attributes,factory,txn_seq,collapsed_through,collapsed_from".to_string())
                 )]
                 .into_iter()
                 .collect();
@@ -1144,24 +1220,41 @@ impl State {
         &self.large_file_options
     }
 
-    /// Collapse all live versions of a `FilePhysicalSeries` node into a single
-    /// merged version so that subsequent reads are O(1) instead of O(versions).
+    /// Collapse one contiguous window of live versions of a
+    /// `FilePhysicalSeries` node into a single merged run, bounding the number
+    /// of segments a reader must open.
     ///
-    /// The merged version stores the full concatenated content plus a
-    /// `collapsed_through = M - 1` sentinel; the series read path then skips
-    /// every superseded version. The bytes read back from the file are
-    /// byte-identical before and after, which this method verifies, failing
-    /// the transaction on any mismatch.
+    /// Uses size-tiered (LSM-style) compaction: only [`COLLAPSE_FANOUT`]
+    /// adjacent runs of the same size class are merged, and the merged row
+    /// records the closed version range `[collapsed_from, collapsed_through]` it
+    /// supersedes. Merging a bounded window rather than the whole series is what
+    /// makes total write volume `O(N log N)` instead of `O(N^2)`: previously
+    /// every collapse rewrote the entire accumulated history to absorb one
+    /// window's worth of new bytes.
+    ///
+    /// The newest versions are deliberately left un-merged. That keeps
+    /// per-version `max_event_time` and version numbers intact at the tail,
+    /// where bounded readers ([`tinyfs::SeriesReadBounds`]) prune, and it means
+    /// the latest row's cumulative bao outboard -- which the append path resumes
+    /// from -- is never disturbed.
+    ///
+    /// Bytes read back from the file are identical before and after, which this
+    /// method verifies over the merged window, failing the transaction on any
+    /// mismatch.
     ///
     /// Must be called inside an open write transaction; the merged row is
     /// committed with the surrounding transaction. Returns a no-op result when
-    /// fewer than two live versions exist.
+    /// no window qualifies.
     ///
     /// # Errors
     /// Returns an error if `id` is not a `FilePhysicalSeries`, if reading or
     /// writing the merged content fails, or if the post-collapse content does
     /// not match the pre-collapse content.
-    pub async fn collapse_file_series(&self, id: FileID) -> Result<CollapseStats, TLogFSError> {
+    pub async fn collapse_file_series(
+        &self,
+        id: FileID,
+        max_live: usize,
+    ) -> Result<CollapseStats, TLogFSError> {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         if id.entry_type() != EntryType::FilePhysicalSeries {
@@ -1173,62 +1266,79 @@ impl State {
             });
         }
 
-        // Assess current versions and gather metadata the merged row inherits.
-        let (versions_before, temporal, store_path, options) = {
+        // Assess current versions and pick the window to merge.
+        let (versions_before, window, temporal, inherited_bao, store_path, options) = {
             let mut inner = self.inner.lock().await;
             let records = inner.query_records(id).await?;
-            let collapsed_through = records.iter().filter_map(|r| r.collapsed_through).max();
-            let mut live: Vec<&OplogEntry> = records
-                .iter()
+            let live: Vec<&OplogEntry> = crate::schema::live_series_entries(&records)
+                .into_iter()
                 .filter(|r| r.size.unwrap_or(0) > 0)
-                .filter(|r| collapsed_through.is_none_or(|k| r.version > k))
                 .collect();
-            live.sort_by_key(|r| r.version);
 
-            if live.len() < 2 {
+            let Some(range) = choose_collapse_window(&live, max_live) else {
                 return Ok(CollapseStats {
                     collapsed: false,
                     versions_before: live.len(),
                     merged_version: 0,
                     bytes: 0,
                 });
-            }
+            };
+            let window: Vec<OplogEntry> = live[range].iter().map(|r| (*r).clone()).collect();
 
-            let latest = *live.last().expect("live is non-empty");
-            let timestamp_column = latest
+            let newest = window.last().expect("window is non-empty");
+            let timestamp_column = newest
                 .get_extended_attributes()
                 .map(|a| a.timestamp_column().to_string())
                 .filter(|s| !s.is_empty());
-            let min_event = live.iter().filter_map(|r| r.min_event_time).min();
-            let max_event = live.iter().filter_map(|r| r.max_event_time).max();
+            let min_event = window.iter().filter_map(|r| r.min_event_time).min();
+            let max_event = window.iter().filter_map(|r| r.max_event_time).max();
             let temporal = match (min_event, max_event, timestamp_column) {
                 (Some(min), Some(max), Some(col)) => Some((min, max, col)),
                 _ => None,
             };
 
+            // The merged run inherits the cumulative bao state of the newest
+            // version it absorbs. Collapse regroups an unchanged byte stream, so
+            // the series prefix through that version is byte-identical before and
+            // after; recomputing it would be both wasteful and, for a run that
+            // does not start at version 1, wrong.
+            let inherited_bao = newest.bao_outboard.clone();
+
             (
                 live.len(),
+                window,
                 temporal,
+                inherited_bao,
                 inner.path.clone(),
                 inner.large_file_options.clone(),
             )
         };
 
-        // Read the merged content via the existing series reader. It already
-        // concatenates only the live versions oldest-first, so this is the
-        // authoritative post-collapse content.
+        let lo = crate::schema::CollapseRange::of(&window[0]).lo;
+        let hi = crate::schema::CollapseRange::of(window.last().expect("non-empty")).hi;
+
+        // Read just this window's bytes. Reading the whole series here is what
+        // made collapse O(N^2); the window is the only content the merged run
+        // stands in for.
         let merged = {
-            let mut reader = self.inner.lock().await.async_file_reader(id).await?;
+            let inner = self.inner.lock().await;
             let mut buf = Vec::new();
-            _ = reader.read_to_end(&mut buf).await.map_err(|e| {
-                TLogFSError::Internal(format!("collapse: read merged content: {e}"))
-            })?;
+            for record in &window {
+                if record.is_large_file() {
+                    let mut reader = inner.open_large_file_reader(record).await?;
+                    let before = buf.len();
+                    _ = reader.read_to_end(&mut buf).await.map_err(|e| {
+                        TLogFSError::Internal(format!("collapse: read window content: {e}"))
+                    })?;
+                    debug_assert!(buf.len() >= before);
+                } else {
+                    buf.extend_from_slice(record.verified_content_required()?);
+                }
+            }
             buf
         };
 
-        // Re-write the merged bytes as a fresh first-version body so the
-        // bao-tree cumulative state covers exactly this content; a later append
-        // then resumes correctly from the merged baseline.
+        // Re-write the window's bytes as a single standalone body.
         let mut writer = crate::large_files::HybridWriter::with_options(&store_path, options);
         writer
             .write_all(&merged)
@@ -1244,11 +1354,27 @@ impl State {
             .map_err(|e| TLogFSError::Internal(format!("collapse: finalize merged: {e}")))?;
 
         let content_len = result.size;
-        let series_outboard = utilities::bao_outboard::SeriesOutboard::from_first_version_state(
-            &result.bao_state,
-            content_len as u64,
-        );
-        let bao_outboard = series_outboard.to_bytes();
+
+        // The merged run inherits the cumulative bao state of the newest version
+        // it absorbs, with `version_size` restated as the run's own length.
+        // Collapse only regroups bytes, so the series prefix through `hi` is
+        // unchanged; recomputing it as a fresh first version would be correct
+        // only for a run starting at the very beginning of the series, and is
+        // wrong for every later run.
+        let bao_outboard = match inherited_bao
+            .as_deref()
+            .and_then(|b| utilities::bao_outboard::SeriesOutboard::from_bytes(b).ok())
+        {
+            Some(mut inherited) => {
+                inherited.version_size = content_len as u64;
+                inherited.to_bytes()
+            }
+            None => utilities::bao_outboard::SeriesOutboard::from_first_version_state(
+                &result.bao_state,
+                content_len as u64,
+            )
+            .to_bytes(),
+        };
 
         let content_ref = if result.content.is_empty()
             && content_len >= crate::large_files::LARGE_FILE_THRESHOLD
@@ -1294,20 +1420,36 @@ impl State {
                 }
             };
             entry.set_bao_outboard(bao_outboard);
-            entry.collapsed_through = Some(version - 1);
+            entry.collapsed_from = Some(lo);
+            entry.collapsed_through = Some(hi);
             inner.records.push(entry);
             version
         };
 
-        // Invariant: bytes read back must be identical to the merged content.
+        // Invariant: the merged run must read back byte-identically. Verifying
+        // the run rather than the whole series keeps collapse's I/O proportional
+        // to the window it actually rewrote.
         let after = {
-            let mut reader = self.inner.lock().await.async_file_reader(id).await?;
-            let mut buf = Vec::new();
-            _ = reader
-                .read_to_end(&mut buf)
-                .await
-                .map_err(|e| TLogFSError::Internal(format!("collapse: verify read: {e}")))?;
-            buf
+            let inner = self.inner.lock().await;
+            let record = inner
+                .records
+                .iter()
+                .rev()
+                .find(|r| r.node_id == id.node_id() && r.version == merged_version)
+                .ok_or_else(|| {
+                    TLogFSError::Internal("collapse: merged row missing after enqueue".to_string())
+                })?;
+            if record.is_large_file() {
+                let mut reader = inner.open_large_file_reader(record).await?;
+                let mut buf = Vec::new();
+                _ = reader
+                    .read_to_end(&mut buf)
+                    .await
+                    .map_err(|e| TLogFSError::Internal(format!("collapse: verify read: {e}")))?;
+                buf
+            } else {
+                record.verified_content_required()?.to_vec()
+            }
         };
         if after != merged {
             return Err(TLogFSError::Transaction {
@@ -1372,16 +1514,21 @@ impl State {
         // Assess current versions and gather metadata the merged row inherits.
         // The lock is released before any table-provider work below, which
         // re-enters the persistence layer to resolve versions.
-        let (versions_before, min_event, max_event, timestamp_column, store_path, options) = {
+        //
+        // Unlike `collapse_file_series`, this still merges the *entire* live set
+        // on every call: `reencode_table_series` reads the whole series back
+        // through the table provider, which has no way to restrict itself to a
+        // version window. Tiering the table path therefore needs a
+        // version-bounded provider and is left as follow-up work; the range
+        // bookkeeping below is written generically so only the window selection
+        // has to change.
+        let (versions_before, lo, hi, min_event, max_event, timestamp_column, store_path, options) = {
             let mut inner = self.inner.lock().await;
             let records = inner.query_records(id).await?;
-            let collapsed_through = records.iter().filter_map(|r| r.collapsed_through).max();
-            let mut live: Vec<&OplogEntry> = records
-                .iter()
+            let live: Vec<&OplogEntry> = crate::schema::live_series_entries(&records)
+                .into_iter()
                 .filter(|r| r.size.unwrap_or(0) > 0)
-                .filter(|r| collapsed_through.is_none_or(|k| r.version > k))
                 .collect();
-            live.sort_by_key(|r| r.version);
 
             if live.len() < 2 {
                 return Ok(CollapseStats {
@@ -1406,8 +1553,21 @@ impl State {
             let min_event = live.iter().filter_map(|r| r.min_event_time).min();
             let max_event = live.iter().filter_map(|r| r.max_event_time).max();
 
+            let lo = live
+                .iter()
+                .map(|r| crate::schema::CollapseRange::of(r).lo)
+                .min()
+                .expect("live is non-empty");
+            let hi = live
+                .iter()
+                .map(|r| crate::schema::CollapseRange::of(r).hi)
+                .max()
+                .expect("live is non-empty");
+
             (
                 live.len(),
+                lo,
+                hi,
                 min_event,
                 max_event,
                 timestamp_column,
@@ -1493,7 +1653,8 @@ impl State {
                 }
             };
             entry.set_bao_outboard(bao_outboard);
-            entry.collapsed_through = Some(version - 1);
+            entry.collapsed_from = Some(lo);
+            entry.collapsed_through = Some(hi);
             inner.records.push(entry);
             version
         };
@@ -1595,10 +1756,11 @@ impl State {
     /// deltas whose versions are disjoint, so both can be merged safely, and
     /// both pay a per-version read cost that grows without bound.
     ///
-    /// A live version has `size > 0` and a `version` greater than the node's
-    /// highest `collapsed_through` sentinel, so a node already collapsed to a
-    /// single merged version is never returned. The query spans all partitions
-    /// in the pond.
+    /// A live row has `size > 0` and is not covered by any *other* row's
+    /// collapse range `[collapsed_from, collapsed_through]`. Loose rows occupy
+    /// the degenerate range `[version, version]`, so one anti-join expresses
+    /// supersession for both loose rows and superseded merge runs. The query
+    /// spans all partitions in the pond.
     ///
     /// # Errors
     /// Returns an error if the discovery query fails or a returned identifier
@@ -1616,17 +1778,28 @@ impl State {
         // collapsed, so it is excluded from candidacy here.
         let log_node = tinyfs::LOG_NODE_UUID;
         let sql = format!(
-            "SELECT t.pond_id AS pond_id, t.part_id AS part_id, t.node_id AS node_id \
-             FROM delta_table t \
-             JOIN ( \
-                 SELECT part_id, node_id, MAX(COALESCE(collapsed_through, -1)) AS k \
+            "SELECT pond_id, part_id, node_id FROM ( \
+                 SELECT t.pond_id AS pond_id, t.part_id AS part_id, t.node_id AS node_id, \
+                        t.version AS version, \
+                        CASE WHEN t.collapsed_through IS NULL THEN t.version \
+                             ELSE COALESCE(t.collapsed_from, 0) END AS lo, \
+                        CASE WHEN t.collapsed_through IS NULL THEN t.version \
+                             ELSE t.collapsed_through END AS hi \
+                 FROM delta_table t \
+                 WHERE t.file_type IN {series_types} AND t.size > 0 \
+                   AND t.node_id != '{log_node}' \
+             ) x \
+             LEFT JOIN ( \
+                 SELECT part_id AS rpart, node_id AS rnode, version AS rversion, \
+                        COALESCE(collapsed_from, 0) AS rlo, collapsed_through AS rhi \
                  FROM delta_table \
-                 WHERE file_type IN {series_types} AND node_id != '{log_node}' \
-                 GROUP BY part_id, node_id \
-             ) m ON t.part_id = m.part_id AND t.node_id = m.node_id \
-             WHERE t.file_type IN {series_types} AND t.size > 0 AND t.version > m.k \
-               AND t.node_id != '{log_node}' \
-             GROUP BY t.pond_id, t.part_id, t.node_id \
+                 WHERE file_type IN {series_types} AND collapsed_through IS NOT NULL \
+                   AND node_id != '{log_node}' \
+             ) r \
+             ON x.part_id = r.rpart AND x.node_id = r.rnode AND r.rversion != x.version \
+                AND r.rlo <= x.lo AND x.hi <= r.rhi \
+             WHERE r.rversion IS NULL \
+             GROUP BY pond_id, part_id, node_id \
              HAVING COUNT(*) > {threshold}"
         );
 
@@ -2925,25 +3098,29 @@ impl InnerState {
     ) -> Result<Pin<Box<dyn tinyfs::AsyncReadSeek>>, TLogFSError> {
         use tinyfs::chained_reader::ChainedReader;
 
-        // Versions at or below the highest `collapsed_through` sentinel have been
-        // superseded by a merged collapse row and must be skipped; otherwise their
-        // bytes would be double-counted alongside the merged version that replaced
-        // them. `None` (the common, un-collapsed case) keeps every version.
-        let collapsed_through = records.iter().filter_map(|r| r.collapsed_through).max();
-
-        // Filter for non-empty, non-superseded versions and reverse to get
-        // oldest-first order (query_records returns newest-first).
-        let mut valid_records: Vec<&OplogEntry> = records
-            .iter()
+        // Rows inside a merged collapse row's [collapsed_from, collapsed_through]
+        // range have been superseded and must be skipped; otherwise their bytes
+        // would be double-counted alongside the merged row that replaced them.
+        // `live_series_entries` returns rows in series byte order (by range
+        // start), which for merged rows is *not* their version number.
+        let mut valid_records: Vec<&OplogEntry> = crate::schema::live_series_entries(records)
+            .into_iter()
             .filter(|r| r.size.unwrap_or(0) > 0) // Skip 0-byte versions
-            .filter(|r| collapsed_through.is_none_or(|k| r.version > k))
             // Bounded pruning: skip versions below the event-time lower bound
             // and/or at-or-below the version watermark. Versions without a
             // recorded `max_event_time` are retained by the event-time
-            // predicate (a missing bound must never drop data).
-            .filter(|r| series_version_retained(r.max_event_time, r.version, &bounds))
+            // predicate (a missing bound must never drop data). A merged row is
+            // pruned on the newest version it covers, so a run is retained
+            // whenever any version inside it would have been.
+            .filter(|r| {
+                series_version_retained(
+                    r.max_event_time,
+                    crate::schema::CollapseRange::of(r).hi,
+                    &bounds,
+                )
+            })
             .collect();
-        valid_records.reverse(); // Now oldest-first
+        valid_records.sort_by_key(|r| crate::schema::CollapseRange::of(r).sort_key());
 
         if valid_records.is_empty() {
             // Return empty reader for empty series
@@ -4213,7 +4390,22 @@ impl InnerState {
             );
         }
 
-        if let Some(record) = records.first() {
+        // For a FilePhysicalSeries the newest *content* is not necessarily the
+        // highest *version*: size-tiered collapse appends a merged run with a
+        // fresh (highest) version number while that run stands for versions in
+        // the middle of the byte stream. The append path resumes its cumulative
+        // bao state from this record, so it must be the row covering the end of
+        // the stream -- the last live row in range order -- not `records.first()`.
+        let newest = if id.entry_type() == EntryType::FilePhysicalSeries {
+            crate::schema::live_series_entries(&records)
+                .into_iter()
+                .rfind(|r| r.size.unwrap_or(0) > 0)
+                .or_else(|| records.first())
+        } else {
+            records.first()
+        };
+
+        if let Some(record) = newest {
             // Use the record directly - it's already an OplogEntry with metadata() method
             let file_type_str = format!("{:?}", record.file_type);
             debug!(
@@ -4251,15 +4443,19 @@ impl InnerState {
         // Sort records by version number (which should match timestamp order anyway)
         records.sort_by_key(|record| record.version);
 
-        // Hide versions superseded by a collapse merge row: a FilePhysicalSeries
-        // merged version stores collapsed_through = M-1, so versions <= M-1 are no
-        // longer independently readable. collapsed_through is always None for other
-        // entry types, leaving their listings unchanged.
-        let collapsed_through = records.iter().filter_map(|r| r.collapsed_through).max();
+        // Hide versions superseded by a collapse merge row: a merged
+        // FilePhysicalSeries row covers the closed version range
+        // [collapsed_from, collapsed_through], so rows inside that range are no
+        // longer independently readable. Rows of other entry types carry no
+        // range and are left unchanged.
+        let live: std::collections::HashSet<i64> = crate::schema::live_series_entries(&records)
+            .into_iter()
+            .map(|r| r.version)
+            .collect();
 
         let version_infos = records
             .into_iter()
-            .filter(|record| collapsed_through.is_none_or(|k| record.version > k))
+            .filter(|record| live.contains(&record.version))
             .map(|record| {
                 // Use the actual database version number, not a re-enumerated logical version
                 let version = record.version as u64;

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -213,6 +213,28 @@ fn size_class(bytes: u64) -> u32 {
     class
 }
 
+/// Temporal overrides the merged run must carry forward.
+///
+/// `set-temporal-bounds` records manual bounds on a dedicated ZERO-BYTE version.
+/// Collapse deliberately excludes zero-byte rows from the merge window (they
+/// contribute no content), but the merged run's `[lo, hi]` range still SPANS
+/// their version numbers, so `is_superseded` retires them. Without inheriting
+/// their bounds here, a collapse silently deletes the override and every reader
+/// falls back to unbounded filtering -- re-admitting exactly the rows the
+/// operator excluded.
+///
+/// The newest override inside the window wins, matching "latest setting wins".
+/// A newer override outside the window still wins overall, because the merged
+/// run sorts at its range position, below that later row.
+fn inherited_overrides(records: &[OplogEntry], lo: i64, hi: i64) -> (Option<i64>, Option<i64>) {
+    records
+        .iter()
+        .filter(|r| r.version >= lo && r.version <= hi)
+        .filter(|r| r.min_override.is_some() || r.max_override.is_some())
+        .max_by_key(|r| r.version)
+        .map_or((None, None), |r| (r.min_override, r.max_override))
+}
+
 /// Choose the contiguous window of live rows to merge, or `None` for a no-op.
 ///
 /// Size-tiered policy: merge the oldest group of [`COLLAPSE_FANOUT`] *adjacent*
@@ -1288,7 +1310,16 @@ impl State {
         }
 
         // Assess current versions and pick the window to merge.
-        let (versions_before, window, temporal, inherited_bao, newest_version, store_path, options) = {
+        let (
+            versions_before,
+            window,
+            temporal,
+            inherited_bao,
+            newest_version,
+            overrides,
+            store_path,
+            options,
+        ) = {
             let mut inner = self.inner.lock().await;
             let records = inner.query_records(id).await?;
             let live: Vec<&OplogEntry> = crate::schema::live_series_entries(&records)
@@ -1326,12 +1357,23 @@ impl State {
             let inherited_bao = newest.bao_outboard.clone();
             let newest_version = newest.version;
 
+            // Zero-byte override rows are filtered out of `window` above, but
+            // the merged range still spans them, so carry their bounds forward.
+            let overrides = {
+                let lo = crate::schema::CollapseRange::of(&window[0]).lo;
+                let hi =
+                    crate::schema::CollapseRange::of(window.last().expect("window is non-empty"))
+                        .hi;
+                inherited_overrides(&records, lo, hi)
+            };
+
             (
                 live.len(),
                 window,
                 temporal,
                 inherited_bao,
                 newest_version,
+                overrides,
                 inner.path.clone(),
                 inner.large_file_options.clone(),
             )
@@ -1463,6 +1505,7 @@ impl State {
             entry.set_bao_outboard(bao_outboard);
             entry.collapsed_from = Some(lo);
             entry.collapsed_through = Some(hi);
+            (entry.min_override, entry.max_override) = overrides;
             inner.records.push(entry);
             version
         };
@@ -1567,6 +1610,7 @@ impl State {
             min_event,
             max_event,
             timestamp_column,
+            overrides,
             store_path,
             options,
         ) = {
@@ -1613,6 +1657,10 @@ impl State {
                 .expect("window is non-empty");
             let window_versions: Vec<i64> = window.iter().map(|r| r.version).collect();
 
+            // Zero-byte override rows are filtered out of `window` above, but
+            // the merged range still spans them, so carry their bounds forward.
+            let overrides = inherited_overrides(&records, lo, hi);
+
             (
                 live.len(),
                 window_versions,
@@ -1621,6 +1669,7 @@ impl State {
                 min_event,
                 max_event,
                 timestamp_column,
+                overrides,
                 inner.path.clone(),
                 inner.large_file_options.clone(),
             )
@@ -1707,6 +1756,7 @@ impl State {
             entry.set_bao_outboard(bao_outboard);
             entry.collapsed_from = Some(lo);
             entry.collapsed_through = Some(hi);
+            (entry.min_override, entry.max_override) = overrides;
             inner.records.push(entry);
             version
         };
@@ -2437,23 +2487,28 @@ impl State {
             return Ok(None);
         }
 
-        // FAIL-FAST: Find latest version or fail explicitly
-        let latest_version = file_series_records
+        // Resolve over LIVE rows in range order, not by raw version.
+        //
+        // A collapse output takes a fresh highest version while standing for
+        // content in the middle of the stream, so `max_by_key(version)` selects
+        // the merged run rather than the real tail. Merged runs never carry
+        // overrides (the merge constructors do not copy them), so that lookup
+        // returns None and the caller falls back to (i64::MIN, i64::MAX) --
+        // silently disabling the filtering `set-temporal-bounds` established.
+        // Take the newest live row that actually carries an override.
+        let live = crate::schema::live_series_entries(&file_series_records);
+        let Some(latest_override) = live
             .iter()
-            .max_by_key(|r| r.version)
-            .ok_or_else(|| {
-                debug!(
-                    "[ERR] FAIL-FAST: No records found to determine latest version for node_id {id}"
-                );
-                TLogFSError::Transaction {
-                    message: format!(
-                        "Cannot find latest version for temporal overrides: node_id {id}"
-                    ),
-                }
-            })?;
+            .rev()
+            .find(|r| r.temporal_overrides().is_some())
+            .copied()
+        else {
+            debug!("[WARN] TEMPORAL: No live record carries temporal overrides for node_id {id}");
+            return Ok(None);
+        };
 
-        let version = latest_version.version;
-        let temporal_overrides = latest_version.temporal_overrides();
+        let version = latest_override.version;
+        let temporal_overrides = latest_override.temporal_overrides();
         let has_overrides = temporal_overrides.is_some();
         debug!(
             "[SEARCH] TEMPORAL: Latest version {version} has temporal overrides: {has_overrides}"

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -221,8 +221,19 @@ fn size_class(bytes: u64) -> u32 {
 /// absorb 10 KB of new data.
 ///
 /// `max_live` is a backstop for read cost. If no same-class group exists but the
-/// series has drifted past `max_live` segments, the oldest `COLLAPSE_FANOUT`
-/// rows are merged regardless of class so segment count stays bounded.
+/// series has drifted past `max_live` segments, `COLLAPSE_FANOUT` adjacent rows
+/// are merged regardless of class so segment count stays bounded.
+///
+/// The backstop merges the CHEAPEST such window, not the oldest. Taking the
+/// oldest looks natural but is the one choice that defeats tiering: after any
+/// previous collapse the oldest row IS the large accumulated run, so a backstop
+/// anchored at index 0 rewrites megabytes to absorb kilobytes -- precisely the
+/// `O(N^2)` behaviour size classes exist to prevent. It also fires more often
+/// than it appears to, because callers pass the same number as both the
+/// candidacy threshold (`HAVING COUNT(*) > threshold`) and `max_live`, so every
+/// candidate satisfies `live.len() > max_live` by construction. Choosing by
+/// total bytes bounds the segment count just as well while keeping write volume
+/// at the minimum any window could achieve.
 ///
 /// Returns a half-open index range into `live` (which must be ordered oldest
 /// content first).
@@ -248,9 +259,19 @@ fn choose_collapse_window(live: &[&OplogEntry], max_live: usize) -> Option<Range
         start = end;
     }
 
-    // Backstop: bound live segment count even when classes are ragged.
+    // Backstop: bound live segment count even when classes are ragged. Every
+    // window of this width reduces the segment count identically, so pick the
+    // one that rewrites the fewest bytes; ties resolve to the oldest.
     if live.len() > max_live {
-        return Some(0..COLLAPSE_FANOUT.min(live.len()));
+        let width = COLLAPSE_FANOUT.min(live.len());
+        let cost = |start: usize| -> u128 {
+            live[start..start + width]
+                .iter()
+                .map(|r| r.size.unwrap_or(0).max(0) as u128)
+                .sum()
+        };
+        let best = (0..=live.len() - width).min_by_key(|&start| cost(start))?;
+        return Some(best..best + width);
     }
 
     None
@@ -1267,7 +1288,7 @@ impl State {
         }
 
         // Assess current versions and pick the window to merge.
-        let (versions_before, window, temporal, inherited_bao, store_path, options) = {
+        let (versions_before, window, temporal, inherited_bao, newest_version, store_path, options) = {
             let mut inner = self.inner.lock().await;
             let records = inner.query_records(id).await?;
             let live: Vec<&OplogEntry> = crate::schema::live_series_entries(&records)
@@ -1303,12 +1324,14 @@ impl State {
             // after; recomputing it would be both wasteful and, for a run that
             // does not start at version 1, wrong.
             let inherited_bao = newest.bao_outboard.clone();
+            let newest_version = newest.version;
 
             (
                 live.len(),
                 window,
                 temporal,
                 inherited_bao,
+                newest_version,
                 inner.path.clone(),
                 inner.large_file_options.clone(),
             )
@@ -1361,11 +1384,29 @@ impl State {
         // unchanged; recomputing it as a fresh first version would be correct
         // only for a run starting at the very beginning of the series, and is
         // wrong for every later run.
-        let bao_outboard = match inherited_bao
-            .as_deref()
-            .and_then(|b| utilities::bao_outboard::SeriesOutboard::from_bytes(b).ok())
-        {
-            Some(mut inherited) => {
+        // "No outboard" and "unparseable outboard" are NOT the same case, and
+        // must not share a fallback: the fallback below is the FIRST-version
+        // baseline, which -- as the comment above states -- is correct only for
+        // a run starting at the beginning of the series.  Silently applying it
+        // to a run that merely failed to parse its predecessor's state would
+        // stamp a wrong baseline onto the merged run, which no later
+        // verification could attribute back to here.  A corrupt outboard is a
+        // hard error that aborts the collapse instead.
+        let bao_outboard = match inherited_bao.as_deref() {
+            Some(bytes) => {
+                let mut inherited = utilities::bao_outboard::SeriesOutboard::from_bytes(bytes)
+                    .map_err(|e| {
+                        TLogFSError::Internal(format!(
+                            "collapse: node {} version {} has an unreadable bao outboard \
+                             ({} bytes): {e}. The merged run must inherit that cumulative \
+                             state -- recomputing it as a first version would stamp a wrong \
+                             baseline -- so the collapse is aborted, leaving the series \
+                             uncollapsed and intact.",
+                            id,
+                            newest_version,
+                            bytes.len(),
+                        ))
+                    })?;
                 inherited.version_size = content_len as u64;
                 inherited.to_bytes()
             }
@@ -5118,5 +5159,112 @@ mod series_bounds_tests {
         // gate alone decides.
         assert!(series_version_retained(None, 6, &b));
         assert!(!series_version_retained(None, 5, &b));
+    }
+}
+
+#[cfg(test)]
+mod collapse_window_tests {
+    use super::{COLLAPSE_FANOUT, choose_collapse_window, size_class};
+    use crate::schema::OplogEntry;
+
+    /// A live row of the given byte size; only `size` affects window choice.
+    fn row(size: i64) -> OplogEntry {
+        let mut e = OplogEntry::new_small_file(
+            tinyfs::FileID::new_in_partition(
+                tinyfs::FileID::root_for(tinyfs::local_pond_uuid()).part_id(),
+                tinyfs::EntryType::FilePhysicalSeries,
+                tinyfs::local_pond_uuid(),
+            ),
+            0,
+            1,
+            Vec::new(),
+            0,
+        );
+        e.size = Some(size);
+        e
+    }
+
+    fn window(sizes: &[i64], max_live: usize) -> Option<std::ops::Range<usize>> {
+        let rows: Vec<OplogEntry> = sizes.iter().map(|s| row(*s)).collect();
+        let live: Vec<&OplogEntry> = rows.iter().collect();
+        choose_collapse_window(&live, max_live)
+    }
+
+    #[test]
+    fn fewer_than_two_live_rows_is_a_noop() {
+        assert_eq!(window(&[], 1), None);
+        assert_eq!(window(&[100], 1), None);
+    }
+
+    #[test]
+    fn size_classes_are_powers_of_the_fanout() {
+        assert_eq!(size_class(0), 0);
+        assert_eq!(size_class(COLLAPSE_FANOUT as u64 - 1), 0);
+        assert_eq!(size_class(COLLAPSE_FANOUT as u64), 1);
+        assert_eq!(size_class((COLLAPSE_FANOUT * COLLAPSE_FANOUT) as u64), 2);
+    }
+
+    /// The tiering rule: the oldest run of FANOUT same-class neighbours wins,
+    /// even when an older, larger run sits in front of it.
+    #[test]
+    fn prefers_the_oldest_same_class_group() {
+        // One big run, then ten small same-class rows.
+        let mut sizes = vec![1_000_000];
+        sizes.extend(std::iter::repeat_n(5, COLLAPSE_FANOUT));
+        assert_eq!(window(&sizes, usize::MAX), Some(1..1 + COLLAPSE_FANOUT));
+    }
+
+    /// Without a same-class group and within `max_live`, nothing is merged:
+    /// rewriting bytes to no purpose is worse than a few extra segments.
+    #[test]
+    fn ragged_classes_within_the_bound_are_left_alone() {
+        let sizes: Vec<i64> = (0..6).map(|i| 10i64.pow(i)).collect();
+        assert_eq!(window(&sizes, 100), None);
+    }
+
+    /// The backstop must NOT anchor at index 0.
+    ///
+    /// After any previous collapse the oldest row is the large accumulated run,
+    /// so merging from index 0 rewrites it to absorb a few small rows -- the
+    /// `O(N^2)` behaviour size classes exist to prevent. Callers pass the same
+    /// number as both the candidacy threshold and `max_live`, so this path is
+    /// reached far more often than "drifted past the bound" suggests.
+    #[test]
+    fn backstop_merges_the_cheapest_window_not_the_oldest() {
+        // A huge accumulated run, then rows whose classes are deliberately
+        // ragged so no same-class group of FANOUT exists.
+        let mut sizes = vec![100_000_000];
+        for i in 0..(COLLAPSE_FANOUT * 2) {
+            sizes.push(10i64.pow((i % 5) as u32 + 1));
+        }
+        let chosen = window(&sizes, 2).expect("backstop must fire past the bound");
+        assert_ne!(
+            chosen.start, 0,
+            "must not rewrite the large accumulated run"
+        );
+        assert_eq!(chosen.len(), COLLAPSE_FANOUT);
+
+        // And it really is the minimum-cost window.
+        let cheapest = (0..=sizes.len() - COLLAPSE_FANOUT)
+            .min_by_key(|&s| sizes[s..s + COLLAPSE_FANOUT].iter().sum::<i64>())
+            .unwrap();
+        assert_eq!(chosen.start, cheapest);
+    }
+
+    /// Ties resolve to the oldest window, so a uniform series still compacts
+    /// front to back rather than wandering.
+    #[test]
+    fn equal_cost_windows_resolve_to_the_oldest() {
+        let sizes: Vec<i64> = std::iter::repeat_n(7, COLLAPSE_FANOUT + 3).collect();
+        // All one class, so the same-class rule fires first -- also at 0.
+        assert_eq!(window(&sizes, 2), Some(0..COLLAPSE_FANOUT));
+    }
+
+    /// Fewer live rows than the fanout still collapses under the backstop,
+    /// merging everything available.
+    #[test]
+    fn backstop_handles_a_series_shorter_than_the_fanout() {
+        let sizes = vec![1, 1_000, 1_000_000];
+        assert_eq!(window(&sizes, 1), Some(0..3));
     }
 }

--- a/crates/tlogfs/src/schema.rs
+++ b/crates/tlogfs/src/schema.rs
@@ -363,22 +363,32 @@ pub struct CollapseRange {
 }
 
 impl CollapseRange {
-    /// Range covered by `entry`. A row with `collapsed_through = Some(hi)` and
-    /// no `collapsed_from` is a pre-tiering full-history merge, i.e. `[0, hi]`.
+    /// Range covered by a row given its version and collapse columns. A row with
+    /// `collapsed_through = Some(hi)` and no `collapsed_from` is a pre-tiering
+    /// full-history merge, i.e. `[0, hi]`.
+    ///
+    /// Takes the columns rather than a whole [`OplogEntry`] so consumers that
+    /// project a narrow row (steward's content scan) share one definition.
     #[must_use]
-    pub fn of(entry: &OplogEntry) -> Self {
-        match entry.collapsed_through {
+    pub fn new(version: i64, collapsed_from: Option<i64>, collapsed_through: Option<i64>) -> Self {
+        match collapsed_through {
             Some(hi) => Self {
-                lo: entry.collapsed_from.unwrap_or(0),
+                lo: collapsed_from.unwrap_or(0),
                 hi,
                 merged: true,
             },
             None => Self {
-                lo: entry.version,
-                hi: entry.version,
+                lo: version,
+                hi: version,
                 merged: false,
             },
         }
+    }
+
+    /// Range covered by `entry`.
+    #[must_use]
+    pub fn of(entry: &OplogEntry) -> Self {
+        Self::new(entry.version, entry.collapsed_from, entry.collapsed_through)
     }
 
     /// Ordering key placing rows in series byte order (oldest content first).
@@ -394,6 +404,45 @@ impl CollapseRange {
     }
 }
 
+/// Whether the row at index `i` of `rows` is superseded by some other row's
+/// merged range. `rows` pairs each row's `version` with its [`CollapseRange`].
+///
+/// This is *the* supersession rule. Every consumer that decides which series
+/// rows are live must go through it (directly or via [`live_series_entries`] /
+/// [`live_series_versions`]), because a reader using a different rule than the
+/// read path fails silently rather than loudly.
+#[must_use]
+fn is_superseded(i: usize, rows: &[(i64, CollapseRange)]) -> bool {
+    let (version, range) = rows[i];
+    rows.iter().enumerate().any(|(j, (other_version, run))| {
+        if j == i || !run.merged {
+            return false; // a run never supersedes itself; loose rows supersede nothing
+        }
+        // Identical ranges (should not occur) resolve to the newer row.
+        run.covers(&range) && (*run != range || *other_version > version)
+    })
+}
+
+/// Live subset of `(version, range)` pairs, ordered oldest content first.
+///
+/// The version-keyed counterpart of [`live_series_entries`], for callers that
+/// hold versions and ranges rather than whole rows -- notably steward's content
+/// fold, which must agree with the read path exactly or a mirror silently
+/// under-replicates.
+///
+/// Note the returned order is *range* order, not version order: a merged run
+/// carries a fresh highest version while standing for content in the middle of
+/// the stream.
+#[must_use]
+pub fn live_series_versions(rows: &[(i64, CollapseRange)]) -> Vec<i64> {
+    let mut live: Vec<(i64, CollapseRange)> = (0..rows.len())
+        .filter(|i| !is_superseded(*i, rows))
+        .map(|i| rows[i])
+        .collect();
+    live.sort_by_key(|(_, range)| range.sort_key());
+    live.into_iter().map(|(version, _)| version).collect()
+}
+
 /// Select the live rows of a series — those not superseded by any merged
 /// collapse row — ordered oldest content first.
 ///
@@ -406,26 +455,15 @@ impl CollapseRange {
 /// loose versions.
 #[must_use]
 pub fn live_series_entries(records: &[OplogEntry]) -> Vec<&OplogEntry> {
-    let runs: Vec<(usize, CollapseRange)> = records
+    let rows: Vec<(i64, CollapseRange)> = records
         .iter()
-        .enumerate()
-        .map(|(i, e)| (i, CollapseRange::of(e)))
-        .filter(|(_, r)| r.merged)
+        .map(|e| (e.version, CollapseRange::of(e)))
         .collect();
 
     let mut live: Vec<&OplogEntry> = records
         .iter()
         .enumerate()
-        .filter(|(i, entry)| {
-            let range = CollapseRange::of(entry);
-            !runs.iter().any(|(j, run)| {
-                if j == i {
-                    return false; // a run never supersedes itself
-                }
-                // Identical ranges (should not occur) resolve to the newer row.
-                run.covers(&range) && (*run != range || records[*j].version > entry.version)
-            })
-        })
+        .filter(|(i, _)| !is_superseded(*i, &rows))
         .map(|(_, entry)| entry)
         .collect();
 

--- a/crates/tlogfs/src/schema.rs
+++ b/crates/tlogfs/src/schema.rs
@@ -319,12 +319,118 @@ pub struct OplogEntry {
 
     /// Version-collapse sentinel for `FilePhysicalSeries`.
     ///
-    /// When a multi-version series file is collapsed into a single merged
-    /// version `M`, that merged row stores `collapsed_through = Some(M - 1)`,
-    /// meaning every version `<= M - 1` has been superseded by this row and
-    /// must be skipped by series readers. `None` for all non-merged rows and
-    /// all non-series entry types.
+    /// When a run of series versions is collapsed into a single merged row,
+    /// that row stores `collapsed_through = Some(hi)`, meaning every version in
+    /// `[collapsed_from, hi]` has been superseded by this row and must be
+    /// skipped by series readers. `None` for all non-merged rows and all
+    /// non-series entry types.
     pub collapsed_through: Option<i64>,
+
+    /// Lowest series version superseded by this merged row; paired with
+    /// [`Self::collapsed_through`] to form the closed range `[lo, hi]` that this
+    /// row replaces.
+    ///
+    /// `None` on a row that also has `collapsed_through = Some(hi)` means the
+    /// run starts at the beginning of the series (`lo = 0`) — this is how
+    /// pre-tiering rows, which always merged the entire history, are read.
+    /// `None` on a row with no `collapsed_through` simply means the row is not
+    /// a merged run.
+    ///
+    /// Version numbers are never reassigned. A merged row is allocated a fresh
+    /// (highest) version like any other append, so `version` is **not** part of
+    /// the range it covers, and rows must be ordered for reading by range start
+    /// rather than by `version` — see [`CollapseRange::sort_key`].
+    pub collapsed_from: Option<i64>,
+}
+
+/// The closed range of series versions a row occupies (loose row) or supersedes
+/// (merged collapse row).
+///
+/// Collapse is a *physical* regrouping of an append-only byte stream: merging
+/// versions changes how bytes are stored, never their identity or order. Version
+/// numbers are therefore never reassigned, and a merged row is allocated a fresh
+/// (highest) version like any other append. That makes `version` useless as a
+/// read ordering key for merged rows — a run covering versions 101..=200 may
+/// carry version 4000 — so readers must order by [`Self::sort_key`] instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CollapseRange {
+    /// First superseded version (inclusive); equals `version` for a loose row.
+    pub lo: i64,
+    /// Last superseded version (inclusive); equals `version` for a loose row.
+    pub hi: i64,
+    /// True when this row is a collapse output standing in for `[lo, hi]`.
+    pub merged: bool,
+}
+
+impl CollapseRange {
+    /// Range covered by `entry`. A row with `collapsed_through = Some(hi)` and
+    /// no `collapsed_from` is a pre-tiering full-history merge, i.e. `[0, hi]`.
+    #[must_use]
+    pub fn of(entry: &OplogEntry) -> Self {
+        match entry.collapsed_through {
+            Some(hi) => Self {
+                lo: entry.collapsed_from.unwrap_or(0),
+                hi,
+                merged: true,
+            },
+            None => Self {
+                lo: entry.version,
+                hi: entry.version,
+                merged: false,
+            },
+        }
+    }
+
+    /// Ordering key placing rows in series byte order (oldest content first).
+    #[must_use]
+    pub fn sort_key(&self) -> i64 {
+        self.lo
+    }
+
+    /// Whether `self` fully covers `other`.
+    #[must_use]
+    pub fn covers(&self, other: &Self) -> bool {
+        self.lo <= other.lo && other.hi <= self.hi
+    }
+}
+
+/// Select the live rows of a series — those not superseded by any merged
+/// collapse row — ordered oldest content first.
+///
+/// Replaces the former `max(collapsed_through)` scalar-watermark idiom, which
+/// could only express "everything up to K is dead" and so forced collapse to
+/// merge the entire series history on every cycle.
+///
+/// Cost is `O(rows x runs)`, not `O(rows^2)`: only merged rows can supersede
+/// anything, and they are few, while a single node can accumulate thousands of
+/// loose versions.
+#[must_use]
+pub fn live_series_entries(records: &[OplogEntry]) -> Vec<&OplogEntry> {
+    let runs: Vec<(usize, CollapseRange)> = records
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (i, CollapseRange::of(e)))
+        .filter(|(_, r)| r.merged)
+        .collect();
+
+    let mut live: Vec<&OplogEntry> = records
+        .iter()
+        .enumerate()
+        .filter(|(i, entry)| {
+            let range = CollapseRange::of(entry);
+            !runs.iter().any(|(j, run)| {
+                if j == i {
+                    return false; // a run never supersedes itself
+                }
+                // Identical ranges (should not occur) resolve to the newer row.
+                run.covers(&range) && (*run != range || records[*j].version > entry.version)
+            })
+        })
+        .map(|(_, entry)| entry)
+        .collect();
+
+    live.sort_by_key(|e| CollapseRange::of(e).sort_key());
+    live
 }
 
 impl ForArrow for OplogEntry {
@@ -354,6 +460,7 @@ impl ForArrow for OplogEntry {
             Arc::new(Field::new("pond_id", DataType::Utf8, false)), // Pond identity UUID (required, non-nullable)
             Arc::new(Field::new("bao_outboard", DataType::Binary, true)), // Bao-tree outboard for verified streaming
             Arc::new(Field::new("collapsed_through", DataType::Int64, true)), // Highest series version superseded by this merged row
+            Arc::new(Field::new("collapsed_from", DataType::Int64, true)), // Lowest series version superseded by this merged row (None => 0)
         ]
     }
 }
@@ -403,6 +510,7 @@ impl OplogEntry {
             pond_id: id.pond_id().to_string(),
             bao_outboard: None,
             collapsed_through: None,
+            collapsed_from: None,
         }
     }
 
@@ -445,6 +553,7 @@ impl OplogEntry {
             pond_id: id.pond_id().to_string(),
             bao_outboard: None,
             collapsed_through: None,
+            collapsed_from: None,
         }
     }
 
@@ -485,6 +594,7 @@ impl OplogEntry {
             pond_id: id.pond_id().to_string(),
             bao_outboard: None,
             collapsed_through: None,
+            collapsed_from: None,
         }
     }
 
@@ -543,6 +653,7 @@ impl OplogEntry {
             pond_id: id.pond_id().to_string(),
             bao_outboard: None,
             collapsed_through: None,
+            collapsed_from: None,
         }
     }
 
@@ -593,6 +704,7 @@ impl OplogEntry {
             pond_id: id.pond_id().to_string(),
             bao_outboard: None,
             collapsed_through: None,
+            collapsed_from: None,
         }
     }
 
@@ -719,6 +831,7 @@ impl OplogEntry {
             pond_id: id.pond_id().to_string(),
             bao_outboard: None,
             collapsed_through: None,
+            collapsed_from: None,
         }
     }
 
@@ -915,6 +1028,7 @@ impl OplogEntry {
             pond_id: id.pond_id().to_string(),
             bao_outboard: None,
             collapsed_through: None,
+            collapsed_from: None,
         }
     }
 }

--- a/crates/tlogfs/src/tests/mod.rs
+++ b/crates/tlogfs/src/tests/mod.rs
@@ -3763,3 +3763,155 @@ fn test_supersession_uses_ranges_not_max_watermark() {
         "version 5 lies inside run A's range and is superseded"
     );
 }
+
+/// Build a `FilePhysicalSeries` of `n` nine-byte versions and collapse it twice,
+/// leaving two merged runs coexisting with a loose tail. Returns the cumulative
+/// stream bytes.
+///
+/// This is the only shape that exposes the tiered-collapse reader bugs: with a
+/// single run, or with no loose tail, version order and byte order still agree.
+async fn build_two_run_series(persistence: &mut OpLogPersistence, file_path: &str) -> Vec<u8> {
+    let mut cumulative: Vec<u8> = Vec::new();
+    for i in 0..25u32 {
+        let chunk = format!("line-{i:03}\n").into_bytes();
+        cumulative.extend_from_slice(&chunk);
+        let create = if i == 0 { Some("data") } else { None };
+        append_series_version(persistence, file_path, &chunk, create).await;
+    }
+    for _ in 0..2 {
+        let tx = persistence.begin_test().await.expect("begin collapse tx");
+        let wd = tx.root().await.expect("root");
+        let id = wd.get_node_path(file_path).await.expect("node").id();
+        let stats = tx
+            .state()
+            .expect("state")
+            .collapse_file_series(id, 1000)
+            .await
+            .expect("collapse_file_series");
+        assert!(stats.collapsed, "expected a tiered collapse");
+        tx.commit_test().await.expect("commit collapse");
+    }
+    cumulative
+}
+
+/// Corruption #1: the series read path must concatenate live rows in *range*
+/// order, not version order.
+///
+/// A merged run is allocated a fresh (highest) version number while standing for
+/// content in the middle of the stream, so sorting by version emits the runs
+/// after the loose tail. The bytes are all present and the length is unchanged,
+/// so this corrupts content silently -- only comparing the exact byte sequence
+/// detects it.
+#[tokio::test]
+async fn test_corruption_read_path_orders_runs_by_range_not_version() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+    let file_path = "data/order.csv";
+
+    let cumulative = build_two_run_series(&mut persistence, file_path).await;
+    let read = read_series_content(&mut persistence, file_path).await;
+
+    assert_eq!(
+        read.len(),
+        cumulative.len(),
+        "no bytes may be lost or duplicated"
+    );
+    assert_eq!(
+        read, cumulative,
+        "runs must appear at their range position, not after the loose tail"
+    );
+    assert!(
+        read.starts_with(b"line-000\n"),
+        "the stream must begin with the oldest content, which now lives inside \
+         a run carrying one of the *highest* version numbers"
+    );
+}
+
+/// Corruption #2: `metadata()` must describe the row covering the *end* of the
+/// stream -- the last live row in range order -- not the highest version.
+///
+/// The append path resumes its cumulative bao state from this row. Post-tiering
+/// the highest version is a mid-stream run, so returning it makes every
+/// subsequent append continue from the wrong prefix, silently corrupting
+/// `cumulative_blake3` for all later readers.
+#[tokio::test]
+async fn test_corruption_metadata_describes_stream_tail_not_highest_version() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+    let file_path = "data/meta.csv";
+
+    let cumulative = build_two_run_series(&mut persistence, file_path).await;
+
+    let tx = persistence.begin_test().await.expect("begin read tx");
+    let wd = tx.root().await.expect("root");
+    let id = wd.get_node_path(file_path).await.expect("node").id();
+    let meta = {
+        use tinyfs::persistence::PersistenceLayer;
+        tx.state()
+            .expect("state")
+            .metadata(id)
+            .await
+            .expect("metadata")
+    };
+    tx.commit_test().await.expect("commit read");
+
+    let bao = meta
+        .bao_outboard
+        .expect("a series row carries a bao outboard");
+    let outboard =
+        utilities::bao_outboard::SeriesOutboard::from_bytes(&bao).expect("decode series outboard");
+    assert_eq!(
+        outboard.cumulative_size,
+        cumulative.len() as u64,
+        "metadata must describe the whole stream ({} bytes). A mid-stream run \
+         would report only the bytes through the end of its own range",
+        cumulative.len()
+    );
+}
+
+/// Corruption #3: `read_pending_bytes` must walk live rows backward in *range*
+/// order.
+///
+/// It reconstructs the trailing partial bao block, so it must return the true
+/// last `pending_len` bytes of the stream. Counting version numbers downward
+/// interleaves runs with loose versions and can re-read rows a run already
+/// superseded, yielding the right *number* of bytes from the wrong places --
+/// which then poisons the resumed hash state rather than failing.
+#[tokio::test]
+async fn test_corruption_read_pending_bytes_walks_range_order() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+    let file_path = "data/pending.csv";
+
+    let cumulative = build_two_run_series(&mut persistence, file_path).await;
+
+    let tx = persistence.begin_test().await.expect("begin read tx");
+    let wd = tx.root().await.expect("root");
+    let id = wd.get_node_path(file_path).await.expect("node").id();
+    let state = tx.state().expect("state");
+
+    // `allocated_version` is the version a subsequent append would take: high
+    // enough that every existing row is in scope.
+    let allocated = 10_000;
+    for pending_len in [9usize, 27, cumulative.len()] {
+        let tail = crate::file::read_pending_bytes(&state, id, allocated, pending_len)
+            .await
+            .expect("read_pending_bytes");
+        assert_eq!(
+            tail,
+            cumulative[cumulative.len() - pending_len..].to_vec(),
+            "the last {pending_len} bytes must come from the end of the stream \
+             in range order"
+        );
+    }
+    tx.commit_test().await.expect("commit read");
+}

--- a/crates/tlogfs/src/tests/mod.rs
+++ b/crates/tlogfs/src/tests/mod.rs
@@ -3682,3 +3682,84 @@ async fn series_bounded_read_memory_plateaus_as_history_grows() {
         "bounded read must be smaller than the full-history read at N=16: {b16} < {f16}"
     );
 }
+
+/// Supersession must be decided by *range containment*, never by the highest
+/// `collapsed_through` sentinel.
+///
+/// Once collapse is tiered, a merged run carries a fresh highest version while
+/// standing for content in the middle of the stream, so the two rules diverge:
+/// a run created early (low version, low range) can be outlived by a later
+/// merge whose range extends past that run's *version number*. The old
+/// `max(collapsed_through)` rule -- "every version <= K is dead" -- then drops a
+/// live run and its content disappears silently.
+#[test]
+fn test_supersession_uses_ranges_not_max_watermark() {
+    use crate::schema::{CollapseRange, live_series_versions};
+
+    let loose = |v: i64| {
+        (
+            v,
+            CollapseRange {
+                lo: v,
+                hi: v,
+                merged: false,
+            },
+        )
+    };
+    let run = |v: i64, lo: i64, hi: i64| {
+        (
+            v,
+            CollapseRange {
+                lo,
+                hi,
+                merged: true,
+            },
+        )
+    };
+
+    // Run A merged versions 1..=10 and was allocated version 26. Later, a
+    // window of loose versions 21..=31 merged as version 36. Note 36's range
+    // ends at 31, which is *above* run A's version number of 26.
+    let rows = vec![
+        run(26, 1, 10),
+        loose(11),
+        loose(12),
+        run(36, 21, 31),
+        loose(40),
+    ];
+
+    let live = live_series_versions(&rows);
+    assert_eq!(
+        live,
+        vec![26, 11, 12, 36, 40],
+        "every row is live: no range contains another. Order is range order \
+         (run A first, covering versions 1..=10), not version order"
+    );
+
+    // The rule this replaced: max(collapsed_through) = 31, retain version > 31.
+    let watermark = rows
+        .iter()
+        .filter(|(_, r)| r.merged)
+        .map(|(_, r)| r.hi)
+        .max()
+        .expect("a merged run is present");
+    let dropped_by_watermark: Vec<i64> = rows
+        .iter()
+        .map(|(v, _)| *v)
+        .filter(|v| *v <= watermark)
+        .collect();
+    assert_eq!(
+        dropped_by_watermark,
+        vec![26, 11, 12],
+        "the watermark rule would silently drop run A (version 26) along with \
+         live loose versions 11 and 12"
+    );
+
+    // A run does supersede what it actually covers.
+    let rows = vec![run(26, 1, 10), loose(5), loose(11)];
+    assert_eq!(
+        live_series_versions(&rows),
+        vec![26, 11],
+        "version 5 lies inside run A's range and is superseded"
+    );
+}

--- a/crates/tlogfs/src/tests/mod.rs
+++ b/crates/tlogfs/src/tests/mod.rs
@@ -2432,10 +2432,7 @@ async fn test_collapse_tiered_windows_preserve_order_and_content() {
 
     // `max_live` is high enough that the read-cost backstop never fires, so
     // every merge below is a genuine same-class tiered merge.
-    async fn collapse_window(
-        persistence: &mut OpLogPersistence,
-        file_path: &str,
-    ) -> (bool, i64) {
+    async fn collapse_window(persistence: &mut OpLogPersistence, file_path: &str) -> (bool, i64) {
         let tx = persistence.begin_test().await.expect("begin collapse tx");
         let wd = tx.root().await.expect("root");
         let id = wd.get_node_path(file_path).await.expect("node").id();
@@ -2617,7 +2614,7 @@ async fn test_collapse_table_series_reencodes_versions() {
         let stats = tx
             .state()
             .expect("state")
-            .collapse_table_series(id)
+            .collapse_table_series(id, 1)
             .await
             .expect("collapse_table_series");
         assert!(stats.collapsed, "expected a collapse");
@@ -2657,7 +2654,7 @@ async fn test_collapse_table_series_reencodes_versions() {
         let stats = tx
             .state()
             .expect("state")
-            .collapse_table_series(id)
+            .collapse_table_series(id, 1)
             .await
             .expect("second collapse_table_series");
         assert!(
@@ -2673,6 +2670,111 @@ async fn test_collapse_table_series_reencodes_versions() {
     assert_eq!(
         table_series_rows(&mut persistence, file_path).await,
         rows_before + 2,
+        "a post-collapse append adds exactly its own rows"
+    );
+}
+
+/// Tiering the table path: with a realistic `max_live`, collapse must merge a
+/// bounded *window* of same-size-class versions instead of re-encoding the
+/// entire series on every trigger. That is what turns collapse from an O(N^2)
+/// write amplifier into an O(N log N) one.
+///
+/// This drives two collapses so a merged run and loose versions coexist, which
+/// is the configuration that hid the ordering bugs on the file path. For tables
+/// the risk is different: the window is re-encoded through a table provider fed
+/// explicit per-version URLs, so a run must be readable as an ordinary version
+/// and must not be double-counted alongside the versions it replaced.
+#[tokio::test]
+async fn test_collapse_table_series_tiered_windows() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+    let file_path = "table.series";
+
+    // 25 tiny disjoint appends, the shape of an hourly collector.
+    const VERSIONS: usize = 25;
+    for i in 0..VERSIONS {
+        let base = (i as i64 + 1) * 1000;
+        append_table_series_version(
+            &mut persistence,
+            file_path,
+            vec![base, base + 1],
+            vec![i as f64, i as f64 + 0.5],
+        )
+        .await;
+    }
+
+    let rows_before = table_series_rows(&mut persistence, file_path).await;
+    assert_eq!(rows_before, VERSIONS * 2, "every appended row is visible");
+    assert_eq!(
+        live_version_count(&mut persistence, file_path).await,
+        VERSIONS,
+        "no collapse has run yet"
+    );
+
+    let id = node_id_of(&mut persistence, file_path).await;
+
+    // First collapse: merges exactly one fanout-sized window, not the history.
+    async fn collapse(
+        persistence: &mut OpLogPersistence,
+        id: tinyfs::FileID,
+        max_live: usize,
+    ) -> crate::persistence::CollapseStats {
+        let tx = persistence.begin_test().await.expect("begin collapse tx");
+        let stats = tx
+            .state()
+            .expect("state")
+            .collapse_table_series(id, max_live)
+            .await
+            .expect("collapse_table_series");
+        tx.commit_test().await.expect("commit collapse");
+        stats
+    }
+
+    let stats = collapse(&mut persistence, id, VERSIONS).await;
+    assert!(
+        stats.collapsed,
+        "a full same-size-class window is available"
+    );
+    let after_first = live_version_count(&mut persistence, file_path).await;
+    assert_eq!(
+        after_first,
+        VERSIONS - 9,
+        "a window of {} versions collapses to one merged run",
+        crate::persistence::COLLAPSE_FANOUT
+    );
+    assert_eq!(
+        table_series_rows(&mut persistence, file_path).await,
+        rows_before,
+        "merging a window must neither lose rows nor double-count the \
+         versions it superseded"
+    );
+
+    // Second collapse: a merged run now coexists with loose versions, so the
+    // window picker must skip the run (different size class) and merge the next
+    // group of loose versions.
+    let stats = collapse(&mut persistence, id, VERSIONS).await;
+    assert!(stats.collapsed, "a second loose window is still available");
+    assert_eq!(
+        live_version_count(&mut persistence, file_path).await,
+        after_first - 9,
+        "the second window collapses independently of the first run"
+    );
+    assert_eq!(
+        table_series_rows(&mut persistence, file_path).await,
+        rows_before,
+        "two coexisting merged runs must not overlap or drop rows"
+    );
+
+    // Appending afterwards must extend the series, not resurrect superseded
+    // versions absorbed by either run.
+    append_table_series_version(&mut persistence, file_path, vec![99_000], vec![9.9]).await;
+    assert_eq!(
+        table_series_rows(&mut persistence, file_path).await,
+        rows_before + 1,
         "a post-collapse append adds exactly its own rows"
     );
 }
@@ -2696,7 +2798,7 @@ async fn test_collapse_table_series_rejects_file_series() {
     let err = tx
         .state()
         .expect("state")
-        .collapse_table_series(id)
+        .collapse_table_series(id, 1)
         .await
         .expect_err("a FilePhysicalSeries must be rejected");
     assert!(

--- a/crates/tlogfs/src/tests/mod.rs
+++ b/crates/tlogfs/src/tests/mod.rs
@@ -2110,7 +2110,7 @@ async fn test_file_physical_series_collapse_and_append() {
         let id = wd.get_node_path(file_path).await.expect("node").id();
         let state = tx.state().expect("state");
         let stats = state
-            .collapse_file_series(id)
+            .collapse_file_series(id, 1)
             .await
             .expect("collapse_file_series");
         assert!(stats.collapsed, "expected a collapse to occur");
@@ -2273,7 +2273,7 @@ async fn test_collapse_large_file_series() {
         let stats = tx
             .state()
             .expect("state")
-            .collapse_file_series(id)
+            .collapse_file_series(id, 1)
             .await
             .expect("collapse_file_series");
         assert!(stats.collapsed, "expected a collapse");
@@ -2375,12 +2375,126 @@ async fn collapse_now(persistence: &mut OpLogPersistence, file_path: &str) -> i6
     let stats = tx
         .state()
         .expect("state")
-        .collapse_file_series(id)
+        .collapse_file_series(id, 1)
         .await
         .expect("collapse_file_series");
     assert!(stats.collapsed, "expected a collapse at {file_path}");
     tx.commit_test().await.expect("commit collapse");
     stats.merged_version
+}
+
+/// Read the full series content at `file_path`.
+async fn read_series_content(persistence: &mut OpLogPersistence, file_path: &str) -> Vec<u8> {
+    use tokio::io::AsyncReadExt;
+    let tx = persistence.begin_test().await.expect("begin read tx");
+    let wd = tx.root().await.expect("root");
+    let mut reader = wd.async_reader_path(file_path).await.expect("reader");
+    let mut content = Vec::new();
+    _ = reader.read_to_end(&mut content).await.expect("read series");
+    tx.commit_test().await.expect("commit read");
+    content
+}
+
+/// Size-tiered collapse merges a bounded *window* of same-size-class versions
+/// instead of the whole series, so several merged runs coexist. This is what
+/// makes total write volume `O(N log N)` rather than `O(N^2)`: absorbing new
+/// versions must not rewrite the accumulated history.
+///
+/// The critical invariant is ordering. A merged run is allocated a fresh
+/// (highest) version number, so a run covering versions 1..=10 outranks the
+/// loose versions 21..=25 that follow it in the byte stream. Readers must
+/// therefore order by range start, not by version. Concatenating by version
+/// would silently emit the runs *after* the loose tail, which only a
+/// multi-run fixture like this one can detect.
+#[tokio::test]
+async fn test_collapse_tiered_windows_preserve_order_and_content() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    use crate::persistence::COLLAPSE_FANOUT;
+
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+    let file_path = "data/tiered.csv";
+
+    // 25 versions of 9 bytes each: small enough to share one size class, so the
+    // tiering policy sees a single mergeable group.
+    let mut cumulative: Vec<u8> = Vec::new();
+    for i in 0..25u32 {
+        let chunk = format!("line-{i:03}\n").into_bytes();
+        assert_eq!(chunk.len(), 9);
+        cumulative.extend_from_slice(&chunk);
+        let create = if i == 0 { Some("data") } else { None };
+        append_series_version(&mut persistence, file_path, &chunk, create).await;
+    }
+    assert_eq!(live_version_count(&mut persistence, file_path).await, 25);
+
+    // `max_live` is high enough that the read-cost backstop never fires, so
+    // every merge below is a genuine same-class tiered merge.
+    async fn collapse_window(
+        persistence: &mut OpLogPersistence,
+        file_path: &str,
+    ) -> (bool, i64) {
+        let tx = persistence.begin_test().await.expect("begin collapse tx");
+        let wd = tx.root().await.expect("root");
+        let id = wd.get_node_path(file_path).await.expect("node").id();
+        let stats = tx
+            .state()
+            .expect("state")
+            .collapse_file_series(id, 1000)
+            .await
+            .expect("collapse_file_series");
+        tx.commit_test().await.expect("commit collapse");
+        (stats.collapsed, stats.merged_version)
+    }
+
+    // First window: COLLAPSE_FANOUT versions merge into one run, leaving the
+    // rest loose. A whole-series collapse would have left exactly one version.
+    let (first_collapsed, first_version) = collapse_window(&mut persistence, file_path).await;
+    assert!(first_collapsed, "expected a tiered collapse");
+    assert_eq!(
+        live_version_count(&mut persistence, file_path).await,
+        25 - COLLAPSE_FANOUT + 1,
+        "only one window merges; the remaining versions stay loose"
+    );
+    assert_eq!(
+        read_series_content(&mut persistence, file_path).await,
+        cumulative,
+        "content unchanged after the first tiered merge"
+    );
+
+    // Second window: a second run now coexists with the first. Its version
+    // number is higher than the loose tail's, so this is the case that fails if
+    // readers order by version rather than by range start.
+    let (second_collapsed, second_version) = collapse_window(&mut persistence, file_path).await;
+    assert!(second_collapsed, "expected a second tiered collapse");
+    assert!(
+        second_version > first_version,
+        "runs are appended, never renumbered"
+    );
+    assert_eq!(
+        live_version_count(&mut persistence, file_path).await,
+        25 - 2 * COLLAPSE_FANOUT + 2,
+        "two runs plus the still-loose tail"
+    );
+    assert_eq!(
+        read_series_content(&mut persistence, file_path).await,
+        cumulative,
+        "two coexisting runs still concatenate in series byte order"
+    );
+
+    // Appending after collapse must continue from the tail, and cumulative bao
+    // must still describe the whole stream.
+    let tail = b"line-final\n";
+    cumulative.extend_from_slice(tail);
+    append_series_version(&mut persistence, file_path, tail, None).await;
+    assert_eq!(
+        read_series_content(&mut persistence, file_path).await,
+        cumulative,
+        "append after tiered collapse lands at the end"
+    );
+    verify_cumulative_blake3(&mut persistence, file_path, &cumulative).await;
 }
 
 /// Append one parquet version to a `TablePhysicalSeries`, creating it on the

--- a/crates/tlogfs/src/tests/mod.rs
+++ b/crates/tlogfs/src/tests/mod.rs
@@ -1131,6 +1131,102 @@ async fn test_temporal_bounds_on_file_series() -> Result<(), Box<dyn std::error:
         // Don't commit this read-only transaction
     }
 
+    // Transaction 6: keep appending after the bounds were set, so the series
+    // has enough versions to be collapsible and the override row is no longer
+    // the highest version.  The new points sit OUTSIDE [10s, 20s], so if the
+    // bounds ever stop applying the count jumps above 10.
+    debug!("Appending further out-of-bounds versions after the temporal bounds...");
+    for (i, t) in [100_i64, 200, 300, 400].into_iter().enumerate() {
+        let tx = persistence.begin_test().await?;
+        let wd = tx.root().await?;
+
+        use arrow_array::{Float64Array, RecordBatch, StringArray, TimestampSecondArray};
+        use arrow_schema::{DataType, Field, Schema, TimeUnit};
+        use std::sync::Arc;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Second, Some("+00:00".into())),
+                false,
+            ),
+            Field::new("value", DataType::Float64, false),
+            Field::new("sensor_id", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(TimestampSecondArray::from(vec![Some(t)]).with_timezone("+00:00")),
+                Arc::new(Float64Array::from(vec![900.0_f64 + i as f64])),
+                Arc::new(StringArray::from(vec!["sensor_001"])),
+            ],
+        )?;
+        _ = wd
+            .write_series_from_batch(series_path, &batch, Some("timestamp"))
+            .await?;
+        tx.commit_test().await?;
+    }
+
+    // Transaction 7: Collapse the series, then re-query.  The bounds must
+    // survive.
+    //
+    // Regression: a collapse output takes a fresh HIGHEST version while
+    // standing for content mid-stream, and merged rows never carry temporal
+    // overrides.  Resolving the override by `max_by_key(version)` therefore
+    // picked the merged run, found no override, and the caller fell back to
+    // (i64::MIN, i64::MAX) -- silently re-admitting the T=1s and T=50s rows
+    // that `set-temporal-bounds` exists to exclude, plus the new ones above.
+    debug!("Collapsing the series and re-checking temporal bounds...");
+    {
+        let tx = persistence.begin_test().await?;
+        {
+            let state = tx.state()?;
+            let candidates = state.list_collapsible_series(2).await?;
+            assert!(
+                !candidates.is_empty(),
+                "series should be collapsible after the appends above"
+            );
+            for id in candidates {
+                let stats = state.collapse_table_series(id, 2).await?;
+                assert!(stats.collapsed, "collapse should have merged a window");
+            }
+        }
+        tx.commit_test().await?;
+    }
+
+    {
+        let tx = persistence.begin_test().await?;
+        let wd = tx.root().await?;
+
+        let mut result_stream = execute_sql_on_file(
+            &wd,
+            series_path,
+            "SELECT COUNT(*) as row_count FROM source",
+            &tx.state()?.as_provider_context(),
+        )
+        .await?;
+
+        let mut total_count = 0_i64;
+        while let Some(batch_result) = result_stream.next().await {
+            let batch = batch_result?;
+            if batch.num_rows() > 0 {
+                let count_array = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .expect("COUNT(*) should return Int64Array");
+                total_count = count_array.value(0);
+            }
+        }
+
+        debug!("Count after collapse: {}", total_count);
+        assert_eq!(
+            total_count, 10,
+            "temporal bounds must survive a collapse; got {total_count} rows, which means \
+             the override was not found and filtering silently reverted to unbounded"
+        );
+    }
+
     debug!("SUCCESS: Temporal bounds test completed");
     debug!(
         "  - Created file series with data points at T=1,10,11,12,13,14,15,16,17,18,19,50 seconds"

--- a/crates/tlogfs/src/txn_metadata.rs
+++ b/crates/tlogfs/src/txn_metadata.rs
@@ -70,6 +70,29 @@ impl PondTxnMetadata {
         HashMap::from([("pond_txn".to_string(), pond_txn)])
     }
 
+    /// Convert to Delta commit metadata for a **maintenance** commit.
+    ///
+    /// Maintenance commits (reclaim's row deletes) are content-preserving and
+    /// represent no transaction of their own: they are the tail of a
+    /// transaction that has already committed and been recorded. Stamping them
+    /// under a distinct key keeps them attributable for forensics while making
+    /// them invisible to anything that reads transactions, which is what
+    /// `pond_txn` means.
+    ///
+    /// This matters because [`Self::from_delta_metadata`] is how
+    /// `reconstruct_txn_history` decides what a transaction *was*: a
+    /// maintenance commit carrying `pond_txn` would be replayed as a second
+    /// (duplicate) lifecycle record at a sequence that already has one. Seq
+    /// recovery on open is unaffected -- it takes the per-pond MAX over all
+    /// `pond_txn` commits, and the originating transaction's own commit still
+    /// carries that seq.
+    #[must_use]
+    pub fn to_delta_maintenance_metadata(&self) -> HashMap<String, serde_json::Value> {
+        let meta = serde_json::to_value(self).expect("Failed to serialize PondTxnMetadata");
+
+        HashMap::from([("pond_maintenance".to_string(), meta)])
+    }
+
     /// Extract from Delta Lake commit metadata (for reading backups)
     ///
     /// Returns None if pond_txn field is missing or malformed.

--- a/testsuite/tests/050-temporal-reduce-collapse-lateness.sh
+++ b/testsuite/tests/050-temporal-reduce-collapse-lateness.sh
@@ -1,33 +1,41 @@
 #!/bin/bash
 # EXPERIMENT: temporal-reduce rollup vs. `maintain --collapse-versions` --
-#   allowed_lateness governs whether a collapsed source tail is tolerated.
+#   a collapsed source tail must never abort a read, at any allowed_lateness.
 #
 # DESCRIPTION:
 #   Reproduces the caspar.water site-staging outage where the whole sitegen
 #   build aborted for days. The water pond runs an hourly
 #   `maintain --compact --collapse-versions 100`, which rewrites roughly the
 #   last ~100 versions (~4 days) of each reduced series' source into a single
-#   merged version. A downstream temporal-reduce rollup that has already sealed
-#   buckets under the DEFAULT 1-day allowed_lateness then sees that merged tail
-#   as data landing behind its sealed watermark and hard-fails:
+#   merged version. A downstream temporal-reduce rollup that had already sealed
+#   buckets then saw that merged tail as data landing behind its sealed
+#   watermark and hard-failed:
 #
 #     temporal-reduce rollup: source data backfills an already-sealed bucket
 #     (earliest new output bucket ... precedes the sealed watermark ...;
 #     allowed_lateness = 86400s). ... Re-run the export with --rebuild ...
 #
-#   which aborts the entire transaction until a manual `--rebuild`. The
-#   durable fix is to raise allowed_lateness so the collapse window stays
-#   inside the unsealed hot window (config/water.yaml sets 14d on every
-#   reduced instrument).
+#   The original mitigation was to raise allowed_lateness so the collapse
+#   window stays inside the unsealed hot window (config/water.yaml sets 14d on
+#   every reduced instrument). That mitigation hid a deeper defect: the merged
+#   version's partial was ADDED to the rollup partials directory while the
+#   superseded versions' partials stayed, so at 14d the read did not fail --
+#   it silently summed the collapsed window twice (see test 733).
+#
+#   The real fix is reconciliation: the partials directory is now a projection
+#   of the source node's LIVE versions, so a collapse DELETES the superseded
+#   partials. A sealed run built from partials that no longer exist is no
+#   longer a valid incremental base, so the level is rebuilt from the live
+#   partials rather than either erroring or double-counting.
 #
 #   Both reduced nodes below read the SAME collapsed source; only their
 #   allowed_lateness differs, isolating the knob under test.
 #
 # EXPECTED:
-#   - Default (1d) lateness: after the source versions are collapsed, reading
-#     the reduced series raises the sealed-bucket error.
-#   - allowed_lateness=14d: the same collapse is tolerated; the reduced series
-#     reads cleanly with every bucket present.
+#   - Neither lateness setting errors after the collapse: allowed_lateness
+#     governs genuinely late data, not version collapse.
+#   - Both read every bucket exactly once -- 96 buckets, and a total sample
+#     count equal to the 96 points ingested, not 192.
 set -e
 source check.sh
 
@@ -83,6 +91,8 @@ resolutions: ["1h"]
 aggregations:
   - type: "avg"
     columns: ["well_depth_value"]
+  - type: "count"
+    columns: ["well_depth_value"]
 YAML
 
 cat > /tmp/050-reduce-late.yaml << 'YAML'
@@ -93,6 +103,8 @@ resolutions: ["1h"]
 allowed_lateness: 14d
 aggregations:
   - type: "avg"
+    columns: ["well_depth_value"]
+  - type: "count"
     columns: ["well_depth_value"]
 YAML
 
@@ -116,19 +128,22 @@ echo ""
 echo "--- maintain --collapse-versions 1 (rewrites the source tail) ---"
 pond maintain --collapse-versions 1 2>&1 | tee /tmp/050-collapse.log | grep -i collapse
 
-# ---- Second read: default lateness must fail, 14d lateness must succeed -----
+# ---- Second read: neither lateness may error, neither may double-count ------
 echo ""
 echo "--- Second read: default (1d) lateness ---"
 DEFAULT_OUT=$(pond cat /reduced-default/data/res=1h.series --format=table \
-  --sql "SELECT COUNT(*) AS c FROM source" 2>&1 || true)
+  --sql "SELECT COUNT(*) AS c, SUM(\"well_depth_value.count\") AS n FROM source" 2>&1 || true)
 echo "$DEFAULT_OUT"
+DEFAULT_ROWS=$(echo "$DEFAULT_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$2); print $2}')
+DEFAULT_N=$(echo "$DEFAULT_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
 
 echo ""
 echo "--- Second read: allowed_lateness=14d ---"
 LATE_OUT=$(pond cat /reduced-late/data/res=1h.series --format=table \
-  --sql "SELECT COUNT(*) AS c FROM source" 2>&1 || true)
+  --sql "SELECT COUNT(*) AS c, SUM(\"well_depth_value.count\") AS n FROM source" 2>&1 || true)
 echo "$LATE_OUT"
-LATE_ROWS=$(echo "$LATE_OUT" | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+LATE_ROWS=$(echo "$LATE_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$2); print $2}')
+LATE_N=$(echo "$LATE_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
 
 # ---- Verify -----------------------------------------------------------------
 echo ""
@@ -143,13 +158,18 @@ check 'grep -qE "collapse: [1-9][0-9]* file\(s\) collapsed" /tmp/050-collapse.lo
 check '[ "${SEAL_DEFAULT}" = "96" ] && [ "${SEAL_LATE}" = "96" ]' \
   "both rollups read all 96 buckets on the sealing pass"
 
-check 'echo "$DEFAULT_OUT" | grep -qi "backfills an already-sealed bucket"' \
-  "default 1d lateness rejects the collapsed tail (reproduces the outage)"
+check '! echo "$DEFAULT_OUT" | grep -qiE "backfills|--rebuild"' \
+  "default 1d lateness no longer rejects the collapsed tail (the outage is gone)"
 
-check '! echo "$LATE_OUT" | grep -qiE "backfills|sealed|--rebuild"' \
-  "allowed_lateness=14d tolerates the collapsed tail (the fix)"
+check '! echo "$LATE_OUT" | grep -qiE "backfills|--rebuild"' \
+  "allowed_lateness=14d tolerates the collapsed tail"
 
-check '[ "${LATE_ROWS}" = "96" ]' \
-  "14d reduced series still reads all 96 buckets after collapse, got ${LATE_ROWS}"
+check '[ "${DEFAULT_ROWS}" = "96" ] && [ "${LATE_ROWS}" = "96" ]' \
+  "both reduced series still read all 96 buckets after collapse, got ${DEFAULT_ROWS} / ${LATE_ROWS}"
+
+# The mitigation-era blind spot: avg and bucket count are both invariant under
+# doubling, so only a total count catches a superseded partial being re-summed.
+check '[ "${DEFAULT_N}" = "96" ] && [ "${LATE_N}" = "96" ]' \
+  "each source point is counted exactly once after collapse, got ${DEFAULT_N} / ${LATE_N} (192 = double-counted)"
 
 check_finish

--- a/testsuite/tests/729-collapse-reclaims-blobs.sh
+++ b/testsuite/tests/729-collapse-reclaims-blobs.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# EXPERIMENT: `pond maintain --collapse-versions` actually reclaims disk
+#
+# DESCRIPTION:
+#   Collapse merges a window of series versions into one run row, but the rows
+#   it superseded survive -- and each one still references its `_large_files`
+#   blob. Until those rows are deleted, collapse bounds a pond's growth RATE
+#   without ever returning a byte. This test drives the whole reclamation path
+#   through the CLI: it grows a series whose every version exceeds the
+#   large-file threshold (64 KiB) so each lands as its own blob, collapses, and
+#   asserts that blobs and BYTES on disk actually go down.
+#
+#   The dangerous failure mode is the opposite one: sweeping a blob that is
+#   still live. That is silent -- the pond looks fine until something reads it
+#   -- so the test re-reads the content and runs `pond fsck`, whose content
+#   pass re-validates every surviving row against its blob.
+#
+# EXPECTED:
+#   - Each ingest version externalizes its own blob under data/_large_files.
+#   - `pond maintain --collapse-versions 1` reports collapsed files AND a
+#     reclaim line with deleted rows and freed blobs.
+#   - Blob count and total bytes both fall.
+#   - Series content is byte-identical afterwards and `pond fsck` is clean.
+#   - Once settled, a further pass reclaims nothing (a sweep that keeps
+#     finding garbage is a sweep that is eating live data).
+#
+# History:
+#   Added on jmacd/analysis8 with reclamation, the second half of collapse.
+set -e
+source check.sh
+
+echo "=== Experiment: collapse reclaims large-file blobs ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+LARGE_FILES=/pond/data/_large_files
+
+count_blobs() {
+    find "${LARGE_FILES}" -name 'blake3=*.parquet' 2>/dev/null | wc -l | tr -d ' '
+}
+blob_bytes() {
+    find "${LARGE_FILES}" -name 'blake3=*.parquet' -printf '%s\n' 2>/dev/null |
+        awk '{t+=$1} END {print t+0}'
+}
+
+mkdir -p /var/log/app
+cat > /tmp/729-ingest.yaml << 'EOF'
+archived_pattern: /var/log/app/events.log.*
+active_pattern: /var/log/app/events.log
+pond_path: /logs/app
+EOF
+pond mkdir -p /system/run >/dev/null 2>&1
+pond mkdir -p /logs/app >/dev/null 2>&1
+pond mknod logfile-ingest /system/run/10-events --config-path /tmp/729-ingest.yaml >/dev/null 2>&1
+
+echo "--- Step 1: 12 versions, each above the 64 KiB large-file threshold ---"
+: > /var/log/app/events.log
+for i in $(seq 1 12); do
+    # ~96 KiB of DISTINCT bytes per version: identical content would dedup to a
+    # single content-addressed blob and quietly weaken every assertion below.
+    head -c 98304 /dev/urandom | base64 | tr -d '\n' | head -c 98304 >> /var/log/app/events.log
+    printf '\nversion %d\n' "$i" >> /var/log/app/events.log
+    pond run /system/run/10-events >/dev/null 2>&1
+done
+
+BEFORE_BLOBS=$(count_blobs)
+BEFORE_BYTES=$(blob_bytes)
+echo "before: ${BEFORE_BLOBS} blobs, ${BEFORE_BYTES} bytes"
+check '[ "'"${BEFORE_BLOBS}"'" -ge 12 ]' "each version externalized its own blob (${BEFORE_BLOBS})"
+
+POND_SIZE=$(pond cat /logs/app/events.log 2>/dev/null | wc -c | tr -d ' ')
+HOST_SIZE=$(wc -c < /var/log/app/events.log | tr -d ' ')
+check '[ "'"${POND_SIZE}"'" = "'"${HOST_SIZE}"'" ]' "ingested series matches host log (${POND_SIZE} bytes)"
+
+BEFORE_MD5=$(pond cat /logs/app/events.log 2>/dev/null | md5sum | awk '{print $1}')
+check '[ -n "'"${BEFORE_MD5}"'" ]' "pre-collapse content md5 computed"
+
+echo "--- Step 2: collapse, which must also reclaim ---"
+pond maintain --collapse-versions 1 > /tmp/729-collapse.log 2>&1
+cat /tmp/729-collapse.log
+check 'grep -qE "collapse: [1-9][0-9]* file\(s\) collapsed" /tmp/729-collapse.log' "maintain collapsed >=1 file"
+check 'grep -qE "reclaim: [1-9][0-9]* superseded row\(s\) deleted" /tmp/729-collapse.log' "reclaim deleted superseded rows"
+check 'grep -qE "reclaim: .* [1-9][0-9]* blob\(s\) freed" /tmp/729-collapse.log' "reclaim freed blobs"
+
+AFTER_BLOBS=$(count_blobs)
+AFTER_BYTES=$(blob_bytes)
+echo "after: ${AFTER_BLOBS} blobs, ${AFTER_BYTES} bytes"
+check '[ "'"${AFTER_BLOBS}"'" -lt "'"${BEFORE_BLOBS}"'" ]' "blob count fell ${BEFORE_BLOBS} -> ${AFTER_BLOBS}"
+check '[ "'"${AFTER_BYTES}"'" -lt "'"${BEFORE_BYTES}"'" ]' "bytes on disk fell ${BEFORE_BYTES} -> ${AFTER_BYTES}"
+
+echo "--- Step 3: nothing live was swept ---"
+AFTER_MD5=$(pond cat /logs/app/events.log 2>/dev/null | md5sum | awk '{print $1}')
+check '[ "'"${AFTER_MD5}"'" = "'"${BEFORE_MD5}"'" ]' "content byte-identical after reclamation"
+
+# A clean fsck exits 0 and prints its root hash; a content failure exits
+# non-zero naming the missing blob.
+if pond fsck > /tmp/729-fsck.log 2>&1; then FSCK_RC=0; else FSCK_RC=1; fi
+cat /tmp/729-fsck.log
+check '[ "'"${FSCK_RC}"'" = "0" ]' "fsck exits clean after reclamation"
+check 'grep -qE "^[0-9a-f]{64}$" /tmp/729-fsck.log' "fsck printed a root hash over the surviving rows"
+
+echo "--- Step 4: settle, then a further pass must reclaim nothing ---"
+for _ in 1 2 3 4 5; do
+    pond maintain --collapse-versions 1 > /tmp/729-settle.log 2>&1
+    grep -qE "collapse: 0 file\(s\) collapsed" /tmp/729-settle.log && break
+done
+SETTLED_BLOBS=$(count_blobs)
+pond maintain --collapse-versions 1 > /tmp/729-again.log 2>&1
+cat /tmp/729-again.log
+check '! grep -q "reclaim:" /tmp/729-again.log' "settled pond reclaims nothing"
+check '[ "$(find '"${LARGE_FILES}"' -name "blake3=*.parquet" | wc -l | tr -d " ")" = "'"${SETTLED_BLOBS}"'" ]' \
+    "blob set is stable once settled (${SETTLED_BLOBS})"
+
+FINAL_MD5=$(pond cat /logs/app/events.log 2>/dev/null | md5sum | awk '{print $1}')
+check '[ "'"${FINAL_MD5}"'" = "'"${BEFORE_MD5}"'" ]' "content still intact after repeated passes"
+
+check_finish

--- a/testsuite/tests/730-materialize-series.sh
+++ b/testsuite/tests/730-materialize-series.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# EXPERIMENT: `materialize-series` turns a derived signal into a physical
+#             table:series, incrementally.
+#
+# DESCRIPTION:
+#   Watertown's typed signals are normally DERIVED: a `sql-derived-series` node
+#   recomputes its output from the ingested bytes on every read. That costs no
+#   storage and can never go stale, but it means a pond built purely from log
+#   ingest -- selfmon, for example -- contains no `TablePhysicalSeries` at all,
+#   so half the storage engine goes unexercised by the pond whose whole job is
+#   to exercise it.
+#
+#   `materialize-series` stores that signal instead. Each run it asks the target
+#   how far it has already been materialized, takes only the source rows past
+#   that watermark, and appends them as ONE new version. The shape that produces
+#   -- append-only, one version per tick -- is the same one `hydrovu` produces,
+#   and therefore the same one collapse and reclamation operate on.
+#
+#   The incrementality is the point. A snapshot-and-replace materializer would
+#   rewrite the whole history every tick, which is precisely the O(N^2) write
+#   amplification that size-tiered collapse exists to remove.
+#
+# EXPECTED:
+#   - The target is a TablePhysicalSeries, created on the first run.
+#   - Each tick with new source rows appends exactly ONE version holding only
+#     the new rows.
+#   - A tick with no new source rows appends NOTHING (no empty versions).
+#   - The materialized content equals what the derived node computes.
+#   - The result is a genuine collapse candidate.
+#
+# History:
+#   Added on jmacd/analysis8 with the materialize-series factory, closing the
+#   selfmon coverage gap that let a table:series collapse bug (#121) ship.
+set -e
+source check.sh
+
+echo "=== Experiment: materialize a derived series into table:series ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+version_count() {
+    pond describe /metrics/cpu.series 2>/dev/null | grep -cE '^ *Version [0-9]+:' || true
+}
+
+# Emit one metrics line, shaped like config/scripts/measure-pond.sh output.
+emit() {
+    printf '{"ts":"%s","peak_rss.bytes":"%s","list.seconds":"%s"}\n' "$1" "$2" "$3" \
+        >> /var/log/metrics/pond.jsonl
+}
+
+mkdir -p /var/log/metrics
+: > /var/log/metrics/pond.jsonl
+
+pond mkdir -p /system/etc >/dev/null 2>&1
+pond mkdir -p /measure >/dev/null 2>&1
+pond mkdir -p /metrics >/dev/null 2>&1
+
+# ---- The selfmon pipeline in miniature -------------------------------------
+# 1. logfile-ingest mirrors the host jsonl into a FilePhysicalSeries.
+cat > /tmp/730-ingest.yaml << 'EOF'
+archived_pattern: /var/log/metrics/pond.jsonl.*
+active_pattern: /var/log/metrics/pond.jsonl
+pond_path: /measure
+EOF
+pond mknod logfile-ingest /system/etc/ingest --config-path /tmp/730-ingest.yaml >/dev/null 2>&1
+
+# 2. sql-derived-series types it (jsonlogs returns all-Utf8, hence the CASTs).
+cat > /tmp/730-derived.yaml << 'EOF'
+patterns:
+  m: "jsonlogs:///measure/pond.jsonl"
+query: >-
+  SELECT
+    CAST(ts AS TIMESTAMP)                    as timestamp,
+    CAST("peak_rss.bytes" AS BIGINT)         as "peak_rss.bytes",
+    CAST("list.seconds" AS DOUBLE)           as "list.seconds"
+  FROM m
+  ORDER BY timestamp
+EOF
+pond mknod sql-derived-series /derived-cpu --config-path /tmp/730-derived.yaml >/dev/null 2>&1
+
+# 3. materialize-series stores it as a physical table:series.
+cat > /tmp/730-materialize.yaml << 'EOF'
+source: "series:///derived-cpu"
+target: /metrics/cpu.series
+time_column: timestamp
+EOF
+pond mknod materialize-series /system/etc/materialize --config-path /tmp/730-materialize.yaml >/dev/null 2>&1
+
+echo "--- Step 1: first tick creates the physical series ---"
+emit "2024-01-01T00:00:00Z" 1000 0.1
+emit "2024-01-01T00:01:00Z" 1100 0.2
+pond run /system/etc/ingest >/dev/null 2>&1
+pond run /system/etc/materialize > /tmp/730-run1.log 2>&1
+cat /tmp/730-run1.log
+
+pond describe /metrics/cpu.series > /tmp/730-describe1.txt 2>&1
+cat /tmp/730-describe1.txt
+check 'grep -q "Type: TablePhysicalSeries" /tmp/730-describe1.txt' \
+    "materialize-series created a TablePhysicalSeries"
+check '[ "$(pond describe /metrics/cpu.series | grep -cE "^ *Version [0-9]+:")" = "1" ]' \
+    "first tick wrote exactly one version"
+check 'grep -qE "^ *Version [0-9]+: 2 rows" /tmp/730-describe1.txt' \
+    "that version holds both source rows"
+
+echo "--- Step 2: a tick with no new rows must append nothing ---"
+pond run /system/etc/ingest >/dev/null 2>&1
+pond run /system/etc/materialize > /tmp/730-run2.log 2>&1
+cat /tmp/730-run2.log
+check '[ "$(pond describe /metrics/cpu.series | grep -cE "^ *Version [0-9]+:")" = "1" ]' \
+    "no empty version was burned when the source was unchanged"
+
+echo "--- Step 3: each new tick appends ONLY the new rows ---"
+emit "2024-01-01T00:02:00Z" 1200 0.3
+pond run /system/etc/ingest >/dev/null 2>&1
+pond run /system/etc/materialize > /tmp/730-run3.log 2>&1
+cat /tmp/730-run3.log
+pond describe /metrics/cpu.series > /tmp/730-describe3.txt 2>&1
+cat /tmp/730-describe3.txt
+check '[ "$(pond describe /metrics/cpu.series | grep -cE "^ *Version [0-9]+:")" = "2" ]' \
+    "second batch of data added exactly one more version"
+check 'grep -qE "^ *Version [0-9]+: 1 rows" /tmp/730-describe3.txt' \
+    "the new version holds ONLY the new row (incremental, not a rewrite)"
+
+echo "--- Step 4: materialized content equals the derived content ---"
+# --format table: the default is raw parquet bytes for a table:series.
+pond cat --format table /metrics/cpu.series > /tmp/730-materialized.txt 2>&1
+pond cat --format table /derived-cpu > /tmp/730-derived.txt 2>&1
+cat /tmp/730-materialized.txt
+MAT_ROWS=$(grep -c "2024-01-01" /tmp/730-materialized.txt || true)
+DER_ROWS=$(grep -c "2024-01-01" /tmp/730-derived.txt || true)
+check '[ "'"${MAT_ROWS}"'" = "3" ]' "materialized series reads back all 3 rows"
+check '[ "'"${MAT_ROWS}"'" = "'"${DER_ROWS}"'" ]' \
+    "materialized row count matches the derived node (${MAT_ROWS} = ${DER_ROWS})"
+check 'grep -q "1200" /tmp/730-materialized.txt' "latest value is present after append"
+
+echo "--- Step 5: the result is a real collapse candidate ---"
+for i in 3 4 5 6 7 8; do
+    emit "2024-01-01T00:0${i}:00Z" "$((1200 + i * 100))" "0.${i}"
+    pond run /system/etc/ingest >/dev/null 2>&1
+    pond run /system/etc/materialize >/dev/null 2>&1
+done
+BEFORE_VERSIONS=$(version_count)
+check '[ "'"${BEFORE_VERSIONS}"'" -ge 6 ]' "accumulated ${BEFORE_VERSIONS} versions to collapse"
+
+pond maintain --collapse-versions 1 > /tmp/730-collapse.log 2>&1
+cat /tmp/730-collapse.log
+check 'grep -qE "collapse: [1-9][0-9]* file\(s\) collapsed" /tmp/730-collapse.log' \
+    "the materialized series is collapsible like any other table:series"
+
+AFTER_ROWS=$(pond cat --format table /metrics/cpu.series 2>/dev/null | grep -c "2024-01-01" || true)
+check '[ "'"${AFTER_ROWS}"'" = "9" ]' \
+    "collapse preserved every materialized row (${AFTER_ROWS})"
+
+check_finish

--- a/testsuite/tests/730-materialize-series.sh
+++ b/testsuite/tests/730-materialize-series.sh
@@ -27,6 +27,8 @@
 #   - A tick with no new source rows appends NOTHING (no empty versions).
 #   - The materialized content equals what the derived node computes.
 #   - The result is a genuine collapse candidate.
+#   - It works when the source lives inside a `dynamic-dir`, which is the
+#     topology selfmon actually uses (config/watershop-selfmon.yaml:/derived).
 #
 # History:
 #   Added on jmacd/analysis8 with the materialize-series factory, closing the
@@ -151,5 +153,62 @@ check 'grep -qE "collapse: [1-9][0-9]* file\(s\) collapsed" /tmp/730-collapse.lo
 AFTER_ROWS=$(pond cat --format table /metrics/cpu.series 2>/dev/null | grep -c "2024-01-01" || true)
 check '[ "'"${AFTER_ROWS}"'" = "9" ]' \
     "collapse preserved every materialized row (${AFTER_ROWS})"
+
+echo "--- Step 6: source inside a dynamic-dir (selfmon's real topology) ---"
+# selfmon does not put its derived nodes at the pond root: they are entries of
+# a `dynamic-dir` at /derived, addressed as series:///derived/p-<pond>. Those
+# children are synthesized on directory read rather than being real nodes, so
+# path resolution reaches them differently. Materializing a root-level node
+# proves nothing about the configuration we are actually going to deploy.
+cat > /tmp/730-dyndir.yaml << 'EOF'
+entries:
+  - name: "p-testpond"
+    factory: "sql-derived-series"
+    config:
+      patterns:
+        m: "jsonlogs:///measure/pond.jsonl"
+      query: >-
+        SELECT
+          CAST(ts AS TIMESTAMP)                    as timestamp,
+          CAST("peak_rss.bytes" AS BIGINT)         as "peak_rss.bytes",
+          CAST("list.seconds" AS DOUBLE)           as "list.seconds"
+        FROM m
+        ORDER BY timestamp
+EOF
+pond mknod dynamic-dir /derived --config-path /tmp/730-dyndir.yaml >/dev/null 2>&1
+
+pond cat --format table /derived/p-testpond > /tmp/730-dyn-read.txt 2>&1
+check 'grep -q "2024-01-01" /tmp/730-dyn-read.txt' \
+    "the dynamic-dir child is readable before we try to materialize it"
+
+cat > /tmp/730-mat2.yaml << 'EOF'
+source: "series:///derived/p-testpond"
+target: /metrics/dyn.series
+time_column: timestamp
+EOF
+pond mknod materialize-series /system/etc/materialize-dyn --config-path /tmp/730-mat2.yaml >/dev/null 2>&1
+
+pond run /system/etc/materialize-dyn > /tmp/730-run-dyn.log 2>&1 || true
+cat /tmp/730-run-dyn.log
+check '! grep -qi "error" /tmp/730-run-dyn.log' \
+    "materializing a dynamic-dir child does not error"
+
+pond describe /metrics/dyn.series > /tmp/730-describe-dyn.txt 2>&1 || true
+cat /tmp/730-describe-dyn.txt
+check 'grep -q "Type: TablePhysicalSeries" /tmp/730-describe-dyn.txt' \
+    "a dynamic-dir source yields a TablePhysicalSeries too"
+
+DYN_ROWS=$(pond cat --format table /metrics/dyn.series 2>/dev/null | grep -c "2024-01-01" || true)
+check '[ "'"${DYN_ROWS}"'" = "9" ]' \
+    "all 9 rows materialized through the dynamic-dir path (${DYN_ROWS})"
+
+# Incrementality must survive the indirection, not just the happy path.
+emit "2024-01-01T00:09:00Z" 2100 0.9
+pond run /system/etc/ingest >/dev/null 2>&1
+pond run /system/etc/materialize-dyn > /tmp/730-run-dyn2.log 2>&1
+pond describe /metrics/dyn.series > /tmp/730-describe-dyn2.txt 2>&1
+cat /tmp/730-describe-dyn2.txt
+check 'grep -qE "^ *Version [0-9]+: 1 rows" /tmp/730-describe-dyn2.txt' \
+    "the dynamic-dir path appends only the new row"
 
 check_finish

--- a/testsuite/tests/731-collapse-format-cache.sh
+++ b/testsuite/tests/731-collapse-format-cache.sh
@@ -96,7 +96,11 @@ DERIVED_AGAIN=$(pond cat --format table /derived-cpu 2>/dev/null | grep -c "2024
 check '[ "'"${DERIVED_AGAIN}"'" = "9" ]' \
     "a second collapse pass keeps the count at 9 (${DERIVED_AGAIN})"
 
+# Capture the status immediately: `check` evaluates its argument later, by
+# which point `$?` reflects check's own machinery, not fsck -- so an inline
+# `[ $? -eq 0 ]` is vacuously true and would pass even when fsck fails.
 pond fsck > /tmp/731-fsck.log 2>&1
-check '[ $? -eq 0 ]' "pond fsck passes after collapse"
+FSCK_RC=$?
+check '[ "'"${FSCK_RC}"'" -eq 0 ]' "pond fsck passes after collapse (rc=${FSCK_RC})"
 
 check_finish

--- a/testsuite/tests/731-collapse-format-cache.sh
+++ b/testsuite/tests/731-collapse-format-cache.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# EXPERIMENT: version collapse must not double-count format-cached reads.
+#
+# DESCRIPTION:
+#   External-format URLs (jsonlogs, oteljson, csv, weblog, excelhtml) are read
+#   through the format cache: each version of the source file is converted once
+#   to Parquet under {POND}/cache/{scheme}_{node}/v{N}_{hash}.parquet, and the
+#   query runs over those Parquets.
+#
+#   That cache was read by GLOBBING the node's cache directory, which is only
+#   correct while "every Parquet ever written" equals "every version that is
+#   live". Version collapse breaks exactly that equality: it replaces a run of
+#   versions with ONE merged version carrying the same bytes. The superseded
+#   versions' Parquets stay on disk, so the glob returned the merged version
+#   AND the versions it stands for -- every row counted twice.
+#
+#   The bug is silent. `pond cat` reads the pond directly and stays correct, so
+#   the raw file looks fine; only the typed/derived read doubles. It scales with
+#   collapse, so it grows precisely on the ponds that ingest the most.
+#
+# EXPECTED:
+#   - A derived series over a jsonlogs source reads the same row count before
+#     and after `pond maintain --collapse-versions`.
+#   - The raw bytes are unaffected either way.
+#
+# History:
+#   Found on jmacd/analysis8 while testing materialize-series against selfmon's
+#   topology: the materialized output held 18 rows for 9 distinct timestamps.
+#   Regression for the fix that names live version Parquets explicitly instead
+#   of globbing the cache directory.
+set -e
+source check.sh
+
+echo "=== Experiment: collapse + format cache must not duplicate rows ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+mkdir -p /var/log/metrics
+: > /var/log/metrics/pond.jsonl
+emit() {
+    printf '{"ts":"%s","peak_rss.bytes":"%s","list.seconds":"%s"}\n' "$1" "$2" "$3" \
+        >> /var/log/metrics/pond.jsonl
+}
+
+pond mkdir -p /system/etc >/dev/null 2>&1
+pond mkdir -p /measure >/dev/null 2>&1
+
+cat > /tmp/731-ingest.yaml << 'EOF'
+archived_pattern: /var/log/metrics/pond.jsonl.*
+active_pattern: /var/log/metrics/pond.jsonl
+pond_path: /measure
+EOF
+pond mknod logfile-ingest /system/etc/ingest --config-path /tmp/731-ingest.yaml >/dev/null 2>&1
+
+cat > /tmp/731-derived.yaml << 'EOF'
+patterns:
+  m: "jsonlogs:///measure/pond.jsonl"
+query: >-
+  SELECT
+    CAST(ts AS TIMESTAMP)            as timestamp,
+    CAST("peak_rss.bytes" AS BIGINT) as "peak_rss.bytes"
+  FROM m
+  ORDER BY timestamp
+EOF
+pond mknod sql-derived-series /derived-cpu --config-path /tmp/731-derived.yaml >/dev/null 2>&1
+
+# One version per tick is what makes this a collapse candidate.
+for i in 0 1 2 3 4 5 6 7 8; do
+    emit "2024-01-01T00:0${i}:00Z" "$((1000 + i))" "0.${i}"
+    pond run /system/etc/ingest >/dev/null 2>&1
+done
+
+echo "--- before collapse ---"
+RAW_BEFORE=$(pond cat /measure/pond.jsonl 2>/dev/null | grep -c "2024-01-01" || true)
+DERIVED_BEFORE=$(pond cat --format table /derived-cpu 2>/dev/null | grep -c "2024-01-01" || true)
+check '[ "'"${RAW_BEFORE}"'" = "9" ]' "raw series holds 9 lines (${RAW_BEFORE})"
+check '[ "'"${DERIVED_BEFORE}"'" = "9" ]' "derived series reads 9 rows (${DERIVED_BEFORE})"
+
+echo "--- collapse ---"
+pond maintain --collapse-versions 1 > /tmp/731-collapse.log 2>&1
+grep -E "collapse|reclaim" /tmp/731-collapse.log
+check 'grep -qE "collapse: [1-9][0-9]* file\(s\) collapsed" /tmp/731-collapse.log' \
+    "the ingested series was actually collapsed"
+
+echo "--- after collapse ---"
+RAW_AFTER=$(pond cat /measure/pond.jsonl 2>/dev/null | grep -c "2024-01-01" || true)
+DERIVED_AFTER=$(pond cat --format table /derived-cpu 2>/dev/null | grep -c "2024-01-01" || true)
+check '[ "'"${RAW_AFTER}"'" = "9" ]' "raw series still holds 9 lines (${RAW_AFTER})"
+check '[ "'"${DERIVED_AFTER}"'" = "9" ]' \
+    "derived series still reads 9 rows, not 18 (${DERIVED_AFTER})"
+
+# A second collapse pass must not compound the error either.
+pond maintain --collapse-versions 1 >/dev/null 2>&1 || true
+DERIVED_AGAIN=$(pond cat --format table /derived-cpu 2>/dev/null | grep -c "2024-01-01" || true)
+check '[ "'"${DERIVED_AGAIN}"'" = "9" ]' \
+    "a second collapse pass keeps the count at 9 (${DERIVED_AGAIN})"
+
+pond fsck > /tmp/731-fsck.log 2>&1
+check '[ $? -eq 0 ]' "pond fsck passes after collapse"
+
+check_finish

--- a/testsuite/tests/732-reduce-materialized.sh
+++ b/testsuite/tests/732-reduce-materialized.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# EXPERIMENT: temporal-reduce over a materialized table:series.
+#
+# DESCRIPTION:
+#   selfmon exports its `perf` timeseries-join at raw 1-minute resolution:
+#   525k rows x 94 columns in a single parquet row group, which the browser
+#   must decode in one shot before it can draw anything. Every other dashboard
+#   (water, septic) exports a temporal-reduce tree instead and lets chart.js
+#   pick a resolution, so this is the missing step.
+#
+#   selfmon cannot reduce its raw source directly: jsonlogs returns all-Utf8,
+#   and the CASTs live in the sql-derived-series layer. The materialized
+#   table:series is the first TYPED, PHYSICAL thing in that pipeline, so it is
+#   the natural reduce input.
+#
+#   Note what this does NOT get: try_rollup_table_provider (temporal_reduce.rs
+#   ~:450) bails unless the input scheme has a FormatProvider, and series/file/
+#   table/data are builtin schemes, not format providers. So reducing over a
+#   pond-native series never engages the rollup cache. The win here is that the
+#   source scan is bytes off a parquet series instead of a recomputed join.
+#
+# EXPECTED:
+#   - temporal-reduce accepts a `series:///` physical table:series input.
+#   - It emits one series per configured resolution.
+#   - Coarser resolutions really do hold fewer rows than the source.
+#   - Values are aggregated, not truncated: a 1h bucket averages its samples.
+#
+# History:
+#   Added on jmacd/analysis8 to check the selfmon metrics.html load-time fix
+#   before touching caspar.water config.
+set -e
+source check.sh
+
+echo "=== Experiment: reduce a materialized series ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+mkdir -p /var/log/metrics
+: > /var/log/metrics/pond.jsonl
+emit() {
+    printf '{"ts":"%s","peak_rss.bytes":"%s","list.seconds":"%s"}\n' "$1" "$2" "$3" \
+        >> /var/log/metrics/pond.jsonl
+}
+
+pond mkdir -p /system/etc >/dev/null 2>&1
+pond mkdir -p /measure >/dev/null 2>&1
+pond mkdir -p /metrics >/dev/null 2>&1
+
+cat > /tmp/732-ingest.yaml << 'EOF'
+archived_pattern: /var/log/metrics/pond.jsonl.*
+active_pattern: /var/log/metrics/pond.jsonl
+pond_path: /measure
+EOF
+pond mknod logfile-ingest /system/etc/ingest --config-path /tmp/732-ingest.yaml >/dev/null 2>&1
+
+cat > /tmp/732-derived.yaml << 'EOF'
+patterns:
+  m: "jsonlogs:///measure/pond.jsonl"
+query: >-
+  SELECT
+    CAST(ts AS TIMESTAMP)            as timestamp,
+    CAST("peak_rss.bytes" AS BIGINT) as "peak_rss.bytes",
+    CAST("list.seconds" AS DOUBLE)   as "list.seconds"
+  FROM m
+  ORDER BY timestamp
+EOF
+pond mknod sql-derived-series /derived-cpu --config-path /tmp/732-derived.yaml >/dev/null 2>&1
+
+cat > /tmp/732-materialize.yaml << 'EOF'
+source: "series:///derived-cpu"
+target: /metrics/perf.series
+time_column: timestamp
+EOF
+pond mknod materialize-series /system/etc/materialize --config-path /tmp/732-materialize.yaml >/dev/null 2>&1
+
+# 120 samples one minute apart = two full hours, so 1h buckets are unambiguous.
+MIN=0
+while [ $MIN -lt 120 ]; do
+    H=$((MIN / 60)); M=$((MIN % 60))
+    emit "$(printf '2024-01-01T%02d:%02d:00Z' $H $M)" "$((1000 + MIN))" "0.5"
+    MIN=$((MIN + 1))
+done
+pond run /system/etc/ingest >/dev/null 2>&1
+pond run /system/etc/materialize >/dev/null 2>&1
+
+SRC_ROWS=$(pond cat --format table /metrics/perf.series 2>/dev/null | grep -c "2024-01-01" || true)
+check '[ "'"${SRC_ROWS}"'" = "120" ]' "materialized source holds 120 one-minute samples (${SRC_ROWS})"
+
+echo "--- reduce over the materialized series ---"
+cat > /tmp/732-reduce.yaml << 'EOF'
+entries:
+  - name: "perf"
+    factory: "temporal-reduce"
+    config:
+      in_pattern: "series:///metrics/perf.series"
+      out_pattern: "data"
+      time_column: "timestamp"
+      resolutions: [1m, 10m, 1h]
+      aggregations:
+        - type: "avg"
+EOF
+pond mknod dynamic-dir /reduced --config-path /tmp/732-reduce.yaml >/dev/null 2>&1
+
+pond list "/reduced/perf/data/*" > /tmp/732-list.txt 2>&1 || true
+cat /tmp/732-list.txt
+check 'grep -q "res=1h" /tmp/732-list.txt' "temporal-reduce accepted the series:/// input and emitted res=1h"
+check 'grep -q "res=10m" /tmp/732-list.txt' "res=10m emitted"
+check 'grep -q "res=1m" /tmp/732-list.txt' "res=1m emitted"
+
+count_rows() {
+    pond cat --format table "$1" 2>/dev/null | grep -c "2024-01-01" || true
+}
+R1M=$(count_rows /reduced/perf/data/res=1m.series)
+R10M=$(count_rows /reduced/perf/data/res=10m.series)
+R1H=$(count_rows /reduced/perf/data/res=1h.series)
+echo "rows: 1m=${R1M} 10m=${R10M} 1h=${R1H}"
+
+check '[ "'"${R1M}"'" = "120" ]' "res=1m keeps every sample (${R1M})"
+check '[ "'"${R10M}"'" = "12" ]' "res=10m collapses to 12 buckets (${R10M})"
+check '[ "'"${R1H}"'" = "2" ]' "res=1h collapses to 2 buckets (${R1H})"
+check '[ "'"${R1H}"'" -lt "'"${R1M}"'" ]' "coarser resolution really is smaller"
+
+# The point of reducing is aggregation, not sampling: minute k carries
+# peak_rss 1000+k, so hour 0 must average to 1000+29.5 = 1029.5.
+pond cat --format table /reduced/perf/data/res=1h.series > /tmp/732-1h.txt 2>&1
+cat /tmp/732-1h.txt
+check 'grep -q "1029.5" /tmp/732-1h.txt' "the 1h bucket AVERAGES its 60 samples (1029.5)"
+
+echo "--- Step 2: the real selfmon shape (join -> materialize -> reduce) ---"
+# selfmon does not export a single pond's series: it exports `perf`, a
+# timeseries-join FULL OUTER joining every pond on timestamp. That join is the
+# node we would materialize in production, and a join is a different factory
+# from the sql-derived-series covered above -- so cover it here rather than
+# assume the two behave alike.
+: > /var/log/metrics/other.jsonl
+emit_other() {
+    printf '{"ts":"%s","peak_rss.bytes":"%s","list.seconds":"%s"}\n' "$1" "$2" "$3" \
+        >> /var/log/metrics/other.jsonl
+}
+MIN=0
+while [ $MIN -lt 120 ]; do
+    H=$((MIN / 60)); M=$((MIN % 60))
+    emit_other "$(printf '2024-01-01T%02d:%02d:00Z' $H $M)" "$((5000 + MIN))" "0.9"
+    MIN=$((MIN + 1))
+done
+
+cat > /tmp/732-ingest2.yaml << 'EOF'
+archived_pattern: /var/log/metrics/other.jsonl.*
+active_pattern: /var/log/metrics/other.jsonl
+pond_path: /measure
+EOF
+pond mknod logfile-ingest /system/etc/ingest2 --config-path /tmp/732-ingest2.yaml >/dev/null 2>&1
+pond run /system/etc/ingest2 >/dev/null 2>&1
+
+cat > /tmp/732-derived2.yaml << 'EOF'
+patterns:
+  m: "jsonlogs:///measure/other.jsonl"
+query: >-
+  SELECT
+    CAST(ts AS TIMESTAMP)            as timestamp,
+    CAST("peak_rss.bytes" AS BIGINT) as "peak_rss.bytes",
+    CAST("list.seconds" AS DOUBLE)   as "list.seconds"
+  FROM m
+  ORDER BY timestamp
+EOF
+pond mknod sql-derived-series /derived-other --config-path /tmp/732-derived2.yaml >/dev/null 2>&1
+
+cat > /tmp/732-join.yaml << 'EOF'
+inputs:
+  - pattern: "series:///derived-cpu"
+    scope: "pond-a"
+  - pattern: "series:///derived-other"
+    scope: "pond-b"
+EOF
+pond mknod timeseries-join /perf --config-path /tmp/732-join.yaml >/dev/null 2>&1
+
+pond cat --format table /perf > /tmp/732-join.txt 2>&1
+head -5 /tmp/732-join.txt
+check 'grep -q "pond-a" /tmp/732-join.txt' "the join scopes columns per pond"
+check 'grep -q "pond-b" /tmp/732-join.txt' "both ponds are present in the join"
+
+cat > /tmp/732-mat-join.yaml << 'EOF'
+source: "series:///perf"
+target: /metrics/joined.series
+time_column: timestamp
+EOF
+pond mknod materialize-series /system/etc/materialize-join --config-path /tmp/732-mat-join.yaml >/dev/null 2>&1
+pond run /system/etc/materialize-join > /tmp/732-matjoin.log 2>&1
+cat /tmp/732-matjoin.log
+check '! grep -qi "error" /tmp/732-matjoin.log' "a timeseries-join can be materialized"
+
+pond describe /metrics/joined.series > /tmp/732-desc-join.txt 2>&1
+check 'grep -q "Type: TablePhysicalSeries" /tmp/732-desc-join.txt' \
+    "the materialized join is a TablePhysicalSeries"
+JOIN_ROWS=$(count_rows /metrics/joined.series)
+check '[ "'"${JOIN_ROWS}"'" = "120" ]' "the materialized join holds all 120 joined rows (${JOIN_ROWS})"
+
+cat > /tmp/732-reduce2.yaml << 'EOF'
+entries:
+  - name: "perf"
+    factory: "temporal-reduce"
+    config:
+      in_pattern: "series:///metrics/joined.series"
+      out_pattern: "data"
+      time_column: "timestamp"
+      resolutions: [1m, 10m, 1h]
+      aggregations:
+        - type: "avg"
+EOF
+pond mknod dynamic-dir /reduced-join --config-path /tmp/732-reduce2.yaml >/dev/null 2>&1
+
+pond cat --format table "/reduced-join/perf/data/res=1h.series" > /tmp/732-join-1h.txt 2>&1
+cat /tmp/732-join-1h.txt
+JR1H=$(grep -c "2024-01-01" /tmp/732-join-1h.txt || true)
+check '[ "'"${JR1H}"'" = "2" ]' "the joined+materialized series reduces to 2 hourly buckets (${JR1H})"
+check 'grep -q "1029.5" /tmp/732-join-1h.txt' "pond-a averages correctly through the whole chain"
+check 'grep -q "5029.5" /tmp/732-join-1h.txt' "pond-b averages correctly through the whole chain"
+
+check_finish

--- a/testsuite/tests/733-collapse-rollup-partials.sh
+++ b/testsuite/tests/733-collapse-rollup-partials.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# EXPERIMENT: version collapse must not double-count temporal-reduce rollup
+#   partials.
+#
+# DESCRIPTION:
+#   This is the same defect as 731, one layer over. 731 fixed the FORMAT cache,
+#   which globbed a node's cache directory and so returned both a merged
+#   version and the superseded versions it stands for. The ROLLUP cache has the
+#   identical structure and was not fixed:
+#
+#     - rollup_cache::find_uncached_members() writes one partial per LIVE source
+#       version, named {node}_v{version}_{blake3}.parquet. It only ever ADDS;
+#       nothing removes the partial of a version that later becomes superseded.
+#     - temporal_reduce.rs registers the whole directory via
+#       rollup_cache::listing_table_from_dir(&glob_dir, ctx) -- a plain glob.
+#     - the read-side merge is SUM(__p_sum_i), SUM(__p_count_i) GROUP BY bucket.
+#
+#   So after `maintain --collapse-versions` merges source versions [lo,hi] into
+#   one run, the run is a new version with a new blake3, gets its own partial,
+#   and the hi-lo+1 superseded partials are still on disk and still summed.
+#   Every row in the collapsed window is counted twice, and again on each later
+#   collapse.
+#
+#   Why this survived: the rollup cache is only engaged when the input scheme
+#   has a FormatProvider (temporal_reduce.rs try_rollup_table_provider), i.e.
+#   oteljson/jsonlogs/csv -- NOT the builtin series:/// scheme. The existing
+#   collapse-vs-rollup test (050) uses oteljson and so does reach it, but it
+#   asserts only on `avg` and on bucket COUNT, and both are invariant under
+#   doubling: avg = SUM(sum)/SUM(count) is unchanged when sum and count both
+#   double, and GROUP BY collapses duplicate buckets back to the same row count.
+#   `sum` and `count` are the aggregations that expose it, and nothing used them
+#   over a collapsed source.
+#
+#   Live in production: config/water.yaml and config/septic.yaml reduce over
+#   "oteljson:///ingest/*.json" -- logfile-ingest FilePhysicalSeries that are
+#   exactly what list_collapsible_series targets -- while config/scripts/run.sh
+#   runs `maintain --compact --collapse-versions 100` hourly.
+#
+# EXPECTED (currently FAILS -- this pins the bug before the fix):
+#   - Before collapse, the reduced series totals 96 samples summing to 96.0.
+#   - `maintain --collapse-versions` merges the source versions.
+#   - After collapse those totals are UNCHANGED. Today they double to 192 / 192.0
+#     because the superseded versions' partials are still in the glob dir.
+#
+# History:
+#   Added on jmacd/analysis8 while reviewing the size-tiered collapse work. The
+#   defect predates that branch -- temporal_reduce.rs and rollup_cache.rs are
+#   untouched by it -- but tiering makes collapse fire more often, and the
+#   branch fixed the sibling instance of this bug in the format cache only.
+set -e
+source check.sh
+
+echo "=== Experiment: collapse must not double-count rollup partials ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+# ---- Source: 96 hourly OTelJSON samples, every value exactly 1.0 ------------
+# A constant 1.0 makes the arithmetic unambiguous: over the whole series
+# SUM(well_depth_value.sum) must be 96.0 and SUM(well_depth_value.count) must
+# be 96, whatever the bucketing. Any deviation is double-counting, not rounding.
+mkdir -p /var/log/well
+awk 'BEGIN {
+    start = 1784073600;   # 2026-07-15T00:00:00Z
+    for (i = 0; i < 96; i++) {
+        e = start + i * 3600;
+        printf "{\"resourceMetrics\":[{\"resource\":{},\"scopeMetrics\":[{\"scope\":{\"name\":\"water\"},\"metrics\":[{\"name\":\"well_depth_value\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"%d000000000\",\"asDouble\":1.0}]}}]}]}]}\n", e;
+    }
+}' > /tmp/733-all.jsonl
+
+cat > /tmp/733-ingest.yaml << 'EOF'
+archived_pattern: /var/log/well/well.json.*
+active_pattern: /var/log/well/well.json
+pond_path: /ingest
+EOF
+
+pond mkdir -p /system/run >/dev/null
+pond mkdir -p /ingest >/dev/null
+pond mknod logfile-ingest /system/run/10-well --config-path /tmp/733-ingest.yaml >/dev/null
+
+# ---- Accumulate several source versions (24 samples per ingest run) ---------
+# One append version per run, so `maintain --collapse-versions` has a real run
+# of adjacent versions to merge -- the hourly-ingest shape of water/septic.
+: > /var/log/well/well.json
+split -l 24 /tmp/733-all.jsonl /tmp/733-chunk.
+for c in /tmp/733-chunk.*; do
+    cat "$c" >> /var/log/well/well.json
+    pond run /system/run/10-well >/dev/null 2>&1
+done
+
+SRC_ROWS=$(pond cat oteljson:///ingest/well.json --format=table \
+  --sql "SELECT COUNT(*) AS c FROM source" 2>&1 \
+  | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+check '[ "'"${SRC_ROWS}"'" = "96" ]' "source ingested 96 points across versions (${SRC_ROWS})"
+
+# `pond describe` reports a FilePhysicalSeries' highest version, and each ingest
+# run appends exactly one, so >1 means there is a real run of adjacent versions
+# for collapse to merge. (Note this differs from 730's per-version listing,
+# which is the TablePhysicalSeries shape.)
+SRC_VERSIONS=$(pond describe /ingest/well.json 2>/dev/null \
+  | grep -E '^ *Version:' | grep -oE '[0-9]+' | head -1)
+echo "source series is at version ${SRC_VERSIONS}"
+check '[ "'"${SRC_VERSIONS}"'" -ge 2 ]' \
+    "the source really has multiple versions to collapse (v${SRC_VERSIONS})"
+
+# ---- A rollup that uses sum and count, the aggregations that expose it ------
+# allowed_lateness=14d keeps the collapsed tail inside the unsealed hot window,
+# so this test isolates double-counting rather than re-testing the sealed-bucket
+# rejection already covered by 050.
+cat > /tmp/733-reduce.yaml << 'YAML'
+in_pattern: "oteljson:///ingest/well.json"
+out_pattern: "data"
+time_column: "timestamp"
+resolutions: ["1h"]
+allowed_lateness: 14d
+aggregations:
+  - type: "sum"
+    columns: ["well_depth_value"]
+  - type: "count"
+    columns: ["well_depth_value"]
+YAML
+pond mknod temporal-reduce /reduced --config-path /tmp/733-reduce.yaml >/dev/null
+
+totals() {
+    # Whole-series totals, independent of how many buckets the rollup emits.
+    pond cat /reduced/data/res=1h.series --format=table \
+      --sql 'SELECT CAST(SUM("well_depth_value.sum") AS BIGINT) AS s, CAST(SUM("well_depth_value.count") AS BIGINT) AS n FROM source' 2>&1
+}
+
+# ---- First read: builds the rollup partials, one per live source version ----
+echo ""
+echo "--- Before collapse ---"
+BEFORE_OUT=$(totals)
+echo "$BEFORE_OUT"
+BEFORE_SUM=$(echo "$BEFORE_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$2); print $2}')
+BEFORE_N=$(echo "$BEFORE_OUT"   | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+
+check '[ "'"${BEFORE_SUM}"'" = "96" ]'  "before collapse the rollup sums 96 samples of 1.0 (${BEFORE_SUM})"
+check '[ "'"${BEFORE_N}"'" = "96" ]'    "before collapse the rollup counts 96 samples (${BEFORE_N})"
+
+# ---- Collapse the source versions (the hourly production trigger) -----------
+echo ""
+echo "--- maintain --collapse-versions 1 ---"
+pond maintain --collapse-versions 1 > /tmp/733-collapse.log 2>&1
+grep -iE "collapse|reclaim" /tmp/733-collapse.log || true
+check 'grep -qE "collapse: [1-9][0-9]* file\(s\) collapsed" /tmp/733-collapse.log' \
+    "maintain actually collapsed the source series"
+
+# ---- Second read: the merged run adds a partial; the old ones remain --------
+echo ""
+echo "--- After collapse ---"
+AFTER_OUT=$(totals)
+echo "$AFTER_OUT"
+AFTER_SUM=$(echo "$AFTER_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$2); print $2}')
+AFTER_N=$(echo "$AFTER_OUT"   | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+
+check '[ "'"${AFTER_SUM}"'" = "96" ]' \
+    "collapse must not change the rollup sum (want 96, got ${AFTER_SUM})"
+check '[ "'"${AFTER_N}"'" = "96" ]' \
+    "collapse must not change the rollup count (want 96, got ${AFTER_N})"
+
+# ---- A second collapse must not compound the error either -------------------
+pond maintain --collapse-versions 1 >/dev/null 2>&1 || true
+AGAIN_OUT=$(totals)
+AGAIN_N=$(echo "$AGAIN_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+check '[ "'"${AGAIN_N}"'" = "96" ]' \
+    "a second collapse pass keeps the count at 96 (${AGAIN_N})"
+
+# ---- Control: avg is why this went unnoticed --------------------------------
+# Every sample is 1.0, so the mean is 1.0 before and after -- doubling sum and
+# count together leaves it untouched. Recorded here so the next reader does not
+# "fix" this test by asserting on avg.
+AVG_OUT=$(pond cat /reduced/data/res=1h.series --format=table \
+  --sql 'SELECT CAST(SUM("well_depth_value.sum") / SUM("well_depth_value.count") AS BIGINT) AS a FROM source' 2>&1 || true)
+echo "$AVG_OUT"
+AVG_V=$(echo "$AVG_OUT" | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+check '[ "'"${AVG_V}"'" = "1" ]' \
+    "avg stays 1.0 whether or not partials doubled -- this is the blind spot (${AVG_V})"
+
+check_finish


### PR DESCRIPTION
Selfmon exists to exercise watertown and surface its inefficiencies, and it did:
on the live instance, `_large_files` held **8.2 GB for 386.6 MB of live content**
(~21x amplification). Chasing that produced the first half of this branch. Reviewing
that work produced the second half, which is the part worth reading carefully —
it found a **live, silent data-corruption bug** and several defects that had no test.

Full working notes, with measurements, are in `SELFMON-FINDINGS.md`.

## Part 1 — the storage work

- **Size-tiered collapse** for both physical series kinds. Collapse used to merge
  everything into one run, so each pass rewrote the whole accumulated blob to absorb
  a little new data — an O(N^2) write amplifier. It now merges only runs in the same
  size class, leaving the hot tail loose.
- **Reclamation**, the missing second half of collapse. Collapse wrote the merged
  version but never deleted the versions it superseded or their blobs. That leak was
  the 8.2 GB.
- A **`materialize-series`** factory, plus testsuite coverage for it.

## Part 2 — what reviewing that work turned up

### The live one: reading a collapsed series double-counted every row

Collapse breaks an invariant the whole codebase quietly assumed: before it,
`{every artifact ever written} == {currently live artifacts}`, and version order is
byte order. After it, neither holds — superseded artifacts remain on disk, and a
merged run takes a fresh *highest* version while representing *mid-stream* content.

`format_cache` had been fixed for this. `rollup_cache` — a near-identical copy, one
function even documented as *"Mirrors `format_cache::cache_version_path` keying
exactly"* — had not. It only ever **added** per-version partials and the read side
**globbed the directory**, so after a collapse the merged version's partial joined
the superseded ones and `SUM(__p_sum), SUM(__p_count)` counted everything twice,
compounding on each later collapse. `water.yaml` / `septic.yaml` were affected;
selfmon's own pipeline was not (the rollup cache only engages behind a
`FormatProvider`).

**Why it survived:** testsuite `050` already ran the exact sequence — collapse, then
an oteljson reduce — but asserted only on `avg` and bucket count. `avg` is
`SUM(sum)/SUM(count)`, unchanged when both double; `GROUP BY` re-collapses the
duplicate buckets. Both assertions were invariant under precisely this corruption.

Rather than patch the second copy, both caches now sit behind one named abstraction
(`crates/provider/src/version_cache.rs`) built so the bug class is *unwritable*:
`LiveVersions` makes "is this the live set?" a type question, `SidecarDir::reconcile`
both adds **and removes**, and `CachedSet` is the only route to a `TableProvider` —
there is deliberately no `fn(&Path) -> TableProvider`, because every instance of this
bug has been exactly that function. Net **-254 lines**.

### The second silent one: collapse destroyed `set-temporal-bounds`

Manual bounds are stored on a dedicated **zero-byte** version. Collapse excludes
zero-byte rows from its merge window, but the merged run's `[lo, hi]` range still
**spans** their version numbers, so they were retired anyway — bounds deleted, never
carried anywhere. Because a missing override maps to `(i64::MIN, i64::MAX)`, the
series silently reverted to **unbounded** filtering, re-admitting exactly the rows
the operator had excluded. The lookup was independently wrong in the same family,
resolving the override by `max_by_key(version)`.

### And four more with no test

- **reclaim's deletes were replayed as transactions.** They carried the collapse's
  seq under `pond_txn`, so `pond rebuild` replayed N+1 duplicate lifecycle records at
  one sequence. Now `pond_maintenance`.
- **reclaim asserted nothing about what it deleted.** The strictly safer `compact`
  verifies its `root_tree_hash`; reclaim, which deletes rows and sweeps blobs
  permanently, did not. It now checks the content root **before** the sweep — deleted
  rows are recoverable from Delta history or a mirror, a swept blob is not.
- **A corrupt bao outboard silently produced a wrong baseline** via `.ok()`, falling
  back to the first-version baseline that the adjacent comment says is wrong for a
  later run. Now a hard error.
- **The collapse backstop rewrote the largest run** (`0..FANOUT`, and after any prior
  collapse index 0 *is* the accumulated run) — the O(N^2) behaviour tiering exists to
  prevent. Now merges the cheapest window.

Plus a latent reclaim scope mismatch (scanned every `pond_id`, guarded only the
local one) and a `reconcile` delete race that aborted concurrent reads.

## The recurring failure mode

Twice this branch shipped a test that ran the right scenario but asserted something
**invariant under the bug** — testsuite 050's `avg`, and the reclaim content-root
test, where a single collapse round leaves the merged run holding the highest
version so range containment and a watermark select identically. Both are fixed and
now fail on revert; the second does so *through* the content-root guard, which
correctly refused the delete and skipped the sweep.

## Behaviour change to be aware of

With superseded partials now deleted, a sealed run built from them is no longer a
valid incremental base, so a level **rebuilds** instead of hard-failing with
*"backfills an already-sealed bucket"* — the error behind the site-staging outage
that raising `allowed_lateness` to 14d only suppressed.

## Deployment note

Reconciliation fixes future reads only. **water/septic sealed runs already froze
doubled values and need a one-time `--rebuild` or a `cfg_hash` bump.** The
caspar.water submodule pointer is intentionally not moved here.

## Verification

`cargo test -p tlogfs -p steward -p provider` (24 suites, 0 failures); `fmt` and
`clippy` as CI runs them; testsuite 046, 050, 712, 716, 717, 720, 728, 729, 730,
731, 732, 733, and 534 against MinIO.
