### PR TITLE
Key the rollup cache on time range, not on per-version partials

### DIFF
--- a/SELFMON-FINDINGS.md
+++ b/SELFMON-FINDINGS.md
@@ -34,7 +34,8 @@ This is what it found.
 | Selfmon has no `TablePhysicalSeries`, so that collapse path is never exercised | **high** (coverage) | **fixed** in config; NOT YET DEPLOYED |
 | **Tick steps failed silently, and a failed read published as a fast read** (§11) | **high** | **fixed** in caspar.water |
 | `logfile-ingest` silently truncates a series when its active file is rotated (§11) | medium | open, latent |
-| Stale format-cache parquets are never pruned (§10) | low | **fixed** §12 (rollup); format cache still leaks disk only |
+| Stale format-cache parquets are never pruned (§10) | low | **fixed** — §12 for the rollup, and the format cache now reconciles (`docs/rollup-storage-redesign.md` P4) |
+| **The rollup cache stored one tiny Parquet per source version per build** — tens of thousands of small files, and a collapse looked like a change because the cache was keyed by version number | **high** | **fixed** — cache re-keyed on content and stored as size-gated, compacted segments (`docs/rollup-storage-redesign.md`) |
 | `libpod-conmon-*` journal files unbounded in count; one is 165.8 MB | medium | open (item 4) |
 | `pond copy` versions identical content — 9,769 versions of a 19-byte file | medium | open (item 5) |
 | `_minio-admin.env` measured as if it were a pond (duplicate + dead data) | low | open (item 7) |
@@ -417,12 +418,15 @@ everything, including the hot tail that `version_gt` depends on.
    is unbounded in count.
 5. Make `pond copy` a no-op when the content hash is unchanged (fixes §2
    Source 3 generically, not just here).
-6. Document/enforce the `--collapse-versions` bounds: it is bounded **below** by
-   `allowed_lateness` (rewrite depth → sealed-bucket outages) and **above** by
-   read cost (~58 ms/version), and lowering it *increases* O(N²) write
-   amplification. Neither bound is enforced in code today. Note that tiering
-   (1) largely retires this hazard: merges touch only old, sealed windows and
-   never reach back toward the `allowed_lateness` horizon.
+6. ~~Document/enforce the `--collapse-versions` lower bound.~~ **RETIRED.** The
+   lower bound existed because a collapse reaching below the rollup's sealed
+   watermark was a hard error demanding `--rebuild`. The rollup cache is now
+   keyed by the time range each segment covers rather than by source version, so
+   a collapse is content-identical and reads as *unchanged*, and genuine late
+   data unseals the affected segments instead of failing
+   (`docs/rollup-storage-redesign.md`). The **upper** bound still stands: read
+   cost is ~58 ms/version, and lowering `--collapse-versions` still increases
+   O(N²) write amplification, though tiering already bounds that.
 
 **caspar.water**
 

--- a/crates/cmd/src/commands/export.rs
+++ b/crates/cmd/src/commands/export.rs
@@ -68,10 +68,11 @@ pub async fn export_command(
     print_export_start(patterns, output_dir, temporal);
     validate_export_inputs(patterns, output_dir, temporal)?;
 
-    // --rebuild drops the throwaway rollup partial-aggregate cache so the next
-    // read recomputes every temporal-reduce partial from scratch. This is the
-    // recovery path for a sequentiality violation, where a non-sequential input
-    // version would otherwise be a hard error on the incremental path.
+    // --rebuild drops the throwaway rollup aggregate cache so the next read
+    // recomputes every temporal-reduce level from source. The cache is derived
+    // state and is now self-correcting -- late data unseals the segments it
+    // affects rather than failing -- so this is a maintenance escape hatch, not
+    // a required recovery step.
     if rebuild {
         let cache_dir = ship_context.resolve_pond_path()?.join("cache");
         let dropped = provider::rollup_cache::drop_all(&cache_dir)

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -481,7 +481,8 @@ enum Commands {
         #[arg(long)]
         end_time: Option<String>,
         /// Drop the temporal-reduce rollup cache before exporting, forcing a
-        /// full recompute. Recovery path for a sequentiality violation.
+        /// full recompute. A maintenance escape hatch: the cache is derived
+        /// state, so discarding it can only cost time.
         #[arg(long)]
         rebuild: bool,
     },

--- a/crates/provider/src/export.rs
+++ b/crates/provider/src/export.rs
@@ -695,7 +695,7 @@ async fn export_one_partition(
             e
         )
     })?;
-    file_blake3(abs_file)
+    Ok(crate::version_cache::file_blake3(abs_file)?)
 }
 
 /// Full-rewrite export via a single `COPY ... PARTITIONED BY` (one source scan).
@@ -784,7 +784,7 @@ async fn full_rewrite_partitioned(
                 )
             })?;
         }
-        let digest = file_blake3(&dst_abs)?;
+        let digest = crate::version_cache::file_blake3(&dst_abs)?;
         manifest.partitions.push(ManifestPartition {
             file: file_rel.clone(),
             digest,
@@ -805,18 +805,10 @@ async fn full_rewrite_partitioned(
     Ok((results, manifest))
 }
 
-/// blake3 hex digest of a file's bytes.
-fn file_blake3(path: &Path) -> Result<String> {
-    let mut hasher = blake3::Hasher::new();
-    let mut file = std::fs::File::open(path)?;
-    let _copied = std::io::copy(&mut file, &mut hasher)?;
-    Ok(hasher.finalize().to_hex().to_string())
-}
-
 /// Verify a partition file's bytes match a recorded digest, hard-failing on a
 /// mismatch so a corrupted or externally modified partition is never reused.
 fn verify_partition_digest(abs_file: &Path, expected: &str, source_label: &str) -> Result<()> {
-    let actual = file_blake3(abs_file)?;
+    let actual = crate::version_cache::file_blake3(abs_file)?;
     if actual != expected {
         return Err(anyhow::anyhow!(
             "Export partition '{}' for '{}' does not match its recorded digest \
@@ -1525,7 +1517,10 @@ mod tests {
         assert_eq!(manifest.partitions.len(), 2);
         assert!(manifest.digest.is_none());
         for p in &manifest.partitions {
-            assert_eq!(p.digest, file_blake3(&base.join(&p.file)).unwrap());
+            assert_eq!(
+                p.digest,
+                crate::version_cache::file_blake3(&base.join(&p.file)).unwrap()
+            );
         }
     }
 

--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -913,7 +913,6 @@ impl SqlDerivedFile {
     async fn build_format_provider_table(
         &self,
         pattern_name: &str,
-        pattern: &crate::Url,
         scheme: &str,
         queryable_files: &[tinyfs::NodePath],
     ) -> TinyFSResult<Arc<dyn TableProvider>> {
@@ -970,29 +969,23 @@ impl SqlDerivedFile {
                 let format_provider = crate::FormatRegistry::get_provider(scheme)
                     .ok_or_else(|| tinyfs::Error::Other(format!("Unknown format: {}", scheme)))?;
 
-                let pat_hash = crate::format_cache::pattern_hash(&pattern.to_string());
-                let glob_dir = crate::format_cache::cache_glob_dir(cache_dir, scheme, &pat_hash);
-                crate::format_cache::reset_glob_dir(&glob_dir).map_other()?;
-
+                let mut nodes = Vec::with_capacity(queryable_files.len());
                 for node_path in queryable_files {
                     let file_url_str = Self::node_file_url(scheme, node_path);
                     let file_url = crate::Url::parse(&file_url_str).map_other()?;
 
-                    let (node_id, versions) = provider_api
-                        .ensure_url_cached(&file_url, format_provider.as_ref(), cache_dir)
-                        .await
-                        .map_other()?;
-
-                    let _ = crate::format_cache::ensure_glob_symlinks(
-                        cache_dir, scheme, &node_id, &versions, &glob_dir,
-                    )
-                    .map_other()?;
+                    nodes.push(
+                        provider_api
+                            .ensure_url_cached(&file_url, format_provider.as_ref(), cache_dir)
+                            .await
+                            .map_other()?,
+                    );
                 }
 
-                let provider =
-                    crate::format_cache::listing_table_from_glob_cache(&glob_dir, &datafusion_ctx)
-                        .await
-                        .map_other()?;
+                let provider = crate::format_cache::glob_cached_set(cache_dir, scheme, &nodes)
+                    .table_provider()
+                    .await
+                    .map_other()?;
 
                 debug!(
                     "[OK] SQL-DERIVED: Glob cache ListingTable for {} files (pattern '{}')",
@@ -1309,7 +1302,7 @@ impl SqlDerivedFile {
         let is_format_provider = crate::FormatRegistry::get_provider(scheme).is_some();
 
         let listing_table_provider = if is_format_provider {
-            self.build_format_provider_table(pattern_name, pattern, scheme, &queryable_files)
+            self.build_format_provider_table(pattern_name, scheme, &queryable_files)
                 .await?
         } else if queryable_files.len() == 1 {
             self.build_single_file_provider(pattern_name, &queryable_files[0], context)

--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -3081,6 +3081,9 @@ query: ""
                 }],
                 transforms: None,
                 allowed_lateness: None,
+                // Seal on every advance, as before the size gate existed: these
+                // tests assert seal MECHANICS on datasets far under any real target.
+                seal_target_bytes: Some(0),
             };
 
             TemporalReduceDirectory::new(config, context).unwrap()
@@ -3380,6 +3383,9 @@ query: ""
                 }],
                 transforms: None,
                 allowed_lateness: None,
+                // Seal on every advance, as before the size gate existed: these
+                // tests assert seal MECHANICS on datasets far under any real target.
+                seal_target_bytes: Some(0),
             };
 
             // Create temporal reduce directory within the same transaction that will access it

--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -3084,6 +3084,7 @@ query: ""
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
+                max_live_runs: None,
             };
 
             TemporalReduceDirectory::new(config, context).unwrap()
@@ -3386,6 +3387,7 @@ query: ""
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
+                max_live_runs: None,
             };
 
             // Create temporal reduce directory within the same transaction that will access it

--- a/crates/provider/src/factory/sql_derived.rs
+++ b/crates/provider/src/factory/sql_derived.rs
@@ -3084,7 +3084,7 @@ query: ""
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
-                max_live_runs: None,
+                max_live_segments: None,
             };
 
             TemporalReduceDirectory::new(config, context).unwrap()
@@ -3387,7 +3387,7 @@ query: ""
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
-                max_live_runs: None,
+                max_live_segments: None,
             };
 
             // Create temporal reduce directory within the same transaction that will access it

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -151,6 +151,31 @@ pub struct TemporalReduceConfig {
     /// (sealed-runs) cache, which is rebuilt from the retained partials.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_lateness: Option<String>,
+
+    /// Minimum accumulated size before frozen buckets are sealed into an
+    /// immutable run file. Accepts a byte count; defaults to
+    /// [`crate::rollup_cache::SEAL_TARGET_BYTES`].
+    ///
+    /// Unlike `allowed_lateness`, changing this does NOT invalidate the cache:
+    /// a run already sealed is correct at any target, so the new value simply
+    /// governs the next seal. Exposed mainly so the tradeoff can be measured
+    /// against real data -- larger means fewer files but a heavier hot-window
+    /// recompute each build.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seal_target_bytes: Option<u64>,
+}
+
+/// The two knobs governing how the sealed layout advances, carried together so
+/// they stay in step: `lateness_secs` decides WHICH buckets may freeze, and
+/// `target_bytes` decides WHEN enough have frozen to be worth a file.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SealPolicy {
+    /// Maximum allowed lateness in seconds; recorded in the manifest because a
+    /// change to it invalidates the cache.
+    pub lateness_secs: i64,
+    /// Seal threshold in bytes; deliberately NOT recorded, because a change to
+    /// it invalidates nothing.
+    pub target_bytes: u64,
 }
 
 /// Default maximum allowed lateness when `allowed_lateness` is unset: one day.
@@ -171,6 +196,13 @@ impl TemporalReduceConfig {
             None => DEFAULT_ALLOWED_LATENESS,
         };
         Ok(dur.as_secs() as i64)
+    }
+
+    /// Resolve the seal threshold in bytes, defaulting to
+    /// [`crate::rollup_cache::SEAL_TARGET_BYTES`].
+    fn seal_target_bytes(&self) -> u64 {
+        self.seal_target_bytes
+            .unwrap_or(crate::rollup_cache::SEAL_TARGET_BYTES)
     }
 }
 
@@ -645,7 +677,10 @@ impl TemporalReduceSqlFile {
         // resolution, so a consumer of any resolution transparently materializes
         // the finer levels it depends on. Each level reuses its cache when
         // unchanged, so this is cheap after the first cold build.
-        let lateness_secs = filled.allowed_lateness_secs()?;
+        let policy = SealPolicy {
+            lateness_secs: filled.allowed_lateness_secs()?,
+            target_bytes: filled.seal_target_bytes(),
+        };
         let merged_dir = crate::rollup_cache::merged_dir(&cache_dir, &cfg_hash, &site_node_id);
 
         // Levels to build: finest .. this file's resolution (inclusive).
@@ -671,7 +706,7 @@ impl TemporalReduceSqlFile {
                     &res_dir,
                     &partials_table,
                     &glob_dir,
-                    lateness_secs,
+                    policy,
                 )
                 .await?
             } else {
@@ -697,7 +732,7 @@ impl TemporalReduceSqlFile {
                         &finer_table,
                         &finer_digest,
                         finer_rebuilt,
-                        lateness_secs,
+                        policy,
                     )
                     .await;
                 let _ = ctx.deregister_table(finer_table.as_str()).map_other()?;
@@ -958,6 +993,7 @@ impl TemporalReduceSqlFile {
         input_table: &str,
         in_bucket_col: &str,
         m: &mut crate::rollup_cache::SealedManifest,
+        policy: SealPolicy,
     ) -> TinyFSResult<()> {
         // Event-time frontier: newest output bucket over the input (epoch
         // seconds). Bounded MAX scan, no per-bucket state.
@@ -968,10 +1004,21 @@ impl TemporalReduceSqlFile {
         let watermark = data_hi_secs
             .map(|hi| (hi - m.allowed_lateness_secs).div_euclid(interval_secs) * interval_secs);
 
-        // Seal buckets [sealed_hi, watermark) into a new immutable run when the
-        // watermark advances. Bounded to the newly-frozen span.
+        // Seal buckets [sealed_hi, watermark) into a new immutable run once
+        // enough has accumulated to be worth freezing. Bounded to the
+        // newly-frozen span.
+        //
+        // The size gate is what keeps the run count proportional to data rather
+        // than to build frequency. `hot` currently spans [sealed_hi, inf), which
+        // contains the frozen span [sealed_hi, wm) a seal would write, so
+        // `hot_bytes` from the previous build is an upper bound on the seal's
+        // size: under target, there is nothing worth sealing and we skip without
+        // writing a candidate to find out. The buckets are not lost -- they stay
+        // in `hot`, which is recomputed from the input below, and are sealed in
+        // one larger run on a later build.
         if let Some(wm) = watermark
             && m.sealed_hi_secs.is_none_or(|sh| wm > sh)
+            && m.hot_bytes >= policy.target_bytes
         {
             let seal_sql = pieces.merge_partials_sql(
                 output_interval,
@@ -985,11 +1032,13 @@ impl TemporalReduceSqlFile {
             let run_file = crate::rollup_cache::run_path(res_dir, &name);
             let (run_digest, rows) = self.write_merge_to(ctx, &seal_sql, &run_file).await?;
             if rows > 0 {
+                let bytes = tokio::fs::metadata(&run_file).await.map_other()?.len();
                 m.runs.push(crate::rollup_cache::SealedRun {
                     name,
                     lo_secs: m.sealed_hi_secs,
                     hi_secs: wm,
                     digest: run_digest,
+                    bytes,
                 });
                 m.next_seq += 1;
             } else {
@@ -1014,6 +1063,10 @@ impl TemporalReduceSqlFile {
         let hot_file = crate::rollup_cache::hot_path(res_dir);
         let (hot_digest, _rows) = self.write_merge_to(ctx, &hot_sql, &hot_file).await?;
         m.hot_digest = Some(hot_digest);
+        m.hot_bytes = tokio::fs::metadata(&hot_file)
+            .await
+            .map(|md| md.len())
+            .unwrap_or(0);
         Ok(())
     }
 
@@ -1032,11 +1085,11 @@ impl TemporalReduceSqlFile {
         res_dir: &std::path::Path,
         partials_table: &str,
         glob_dir: &std::path::Path,
-        lateness_secs: i64,
+        policy: SealPolicy,
     ) -> TinyFSResult<LevelBuild> {
         let manifest = match crate::rollup_cache::read_sealed_manifest(res_dir).map_other()? {
             Some(m)
-                if m.allowed_lateness_secs == lateness_secs
+                if m.allowed_lateness_secs == policy.lateness_secs
                     && m.format == crate::rollup_cache::SEALED_FORMAT =>
             {
                 Some(m)
@@ -1110,7 +1163,7 @@ impl TemporalReduceSqlFile {
                          {}s). Data older than the watermark cannot reopen a \
                          sealed run. Re-run the export with --rebuild to \
                          recompute the rollup cache from scratch.",
-                        dl, sealed_hi, lateness_secs
+                        dl, sealed_hi, policy.lateness_secs
                     )));
                 }
                 (m, dirty_lo_secs)
@@ -1120,7 +1173,7 @@ impl TemporalReduceSqlFile {
                 (
                     crate::rollup_cache::SealedManifest {
                         format: crate::rollup_cache::SEALED_FORMAT.to_string(),
-                        allowed_lateness_secs: lateness_secs,
+                        allowed_lateness_secs: policy.lateness_secs,
                         ..Default::default()
                     },
                     None,
@@ -1137,6 +1190,7 @@ impl TemporalReduceSqlFile {
             partials_table,
             "time_bucket",
             &mut m,
+            policy,
         )
         .await?;
         m.covered = current_names;
@@ -1179,11 +1233,11 @@ impl TemporalReduceSqlFile {
         finer_table: &str,
         finer_digest: &str,
         finer_rebuilt: bool,
-        lateness_secs: i64,
+        policy: SealPolicy,
     ) -> TinyFSResult<LevelBuild> {
         let manifest = match crate::rollup_cache::read_sealed_manifest(res_dir).map_other()? {
             Some(m)
-                if m.allowed_lateness_secs == lateness_secs
+                if m.allowed_lateness_secs == policy.lateness_secs
                     && m.format == crate::rollup_cache::SEALED_FORMAT =>
             {
                 Some(m)
@@ -1227,7 +1281,7 @@ impl TemporalReduceSqlFile {
             (
                 crate::rollup_cache::SealedManifest {
                     format: crate::rollup_cache::SEALED_FORMAT.to_string(),
-                    allowed_lateness_secs: lateness_secs,
+                    allowed_lateness_secs: policy.lateness_secs,
                     ..Default::default()
                 },
                 None,
@@ -1244,6 +1298,7 @@ impl TemporalReduceSqlFile {
             finer_table,
             ts,
             &mut m,
+            policy,
         )
         .await?;
         m.covered = std::collections::BTreeSet::new();
@@ -2618,6 +2673,9 @@ mod tests {
             aggregations,
             transforms: None,
             allowed_lateness: None,
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         }
     }
 
@@ -3028,6 +3086,9 @@ mod tests {
                 ],
                 transforms: None,
                 allowed_lateness: None,
+                // Seal on every advance, as before the size gate existed: these
+                // tests assert seal MECHANICS on datasets far under any real target.
+                seal_target_bytes: Some(0),
             };
 
             let context = test_context(&provider_context, FileID::root());
@@ -3238,6 +3299,9 @@ mod tests {
                 aggregations: vec![],
                 transforms: None,
                 allowed_lateness: None,
+                // Seal on every advance, as before the size gate existed: these
+                // tests assert seal MECHANICS on datasets far under any real target.
+                seal_target_bytes: Some(0),
             };
             TemporalReduceSqlFile::new(
                 config,
@@ -3368,6 +3432,9 @@ mod tests {
                 ],
                 transforms: None,
                 allowed_lateness: None,
+                // Seal on every advance, as before the size gate existed: these
+                // tests assert seal MECHANICS on datasets far under any real target.
+                seal_target_bytes: Some(0),
             };
 
             let context = test_context(&provider_context, FileID::root());
@@ -3528,6 +3595,9 @@ mod tests {
             ],
             transforms: None,
             allowed_lateness: None,
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -3716,6 +3786,9 @@ mod tests {
             ],
             transforms: None,
             allowed_lateness: None,
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -3884,6 +3957,9 @@ mod tests {
             aggregations: vec![agg(AggregationType::Max, &["temperature"])],
             transforms: None,
             allowed_lateness: Some("1d".to_string()),
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4011,6 +4087,9 @@ mod tests {
             aggregations: vec![agg(AggregationType::Avg, &["temperature"])],
             transforms: None,
             allowed_lateness: None,
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4109,6 +4188,9 @@ mod tests {
             ],
             transforms: None,
             allowed_lateness: None,
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4239,6 +4321,9 @@ mod tests {
             ],
             transforms: None,
             allowed_lateness: None,
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -4435,6 +4520,9 @@ mod tests {
             aggregations: vec![agg(AggregationType::Max, &["temperature"])],
             transforms: None,
             allowed_lateness: None,
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         };
 
         let make_ctx = |cache: std::path::PathBuf| {
@@ -4566,6 +4654,9 @@ mod tests {
             aggregations: vec![agg(AggregationType::Max, &["temperature"])],
             transforms: None,
             allowed_lateness: lateness.map(str::to_string),
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         }
     }
 
@@ -4730,6 +4821,9 @@ mod tests {
             aggregations: vec![agg(AggregationType::Avg, &["temperature"])],
             transforms: None,
             allowed_lateness: Some("1d".to_string()),
+            // Seal on every advance, as before the size gate existed: these
+            // tests assert seal MECHANICS on datasets far under any real target.
+            seal_target_bytes: Some(0),
         };
 
         // Grow history so the watermark advances and buckets seal into runs.
@@ -4868,6 +4962,81 @@ mod tests {
                 rows
             );
         }
+    }
+
+    /// Under the DEFAULT seal target, four days of a handful of rows each never
+    /// accumulate enough bytes to be worth freezing, so no run file is written
+    /// at all -- yet the query still returns every day correctly, because the
+    /// unsealed buckets simply stay in the recomputed hot window.
+    ///
+    /// This is the point of the size gate. Sealing used to fire whenever the
+    /// watermark moved, so a pond rebuilt on a timer grew one small file per
+    /// build regardless of how little data had arrived. The companion test
+    /// `test_sealed_runs_advance_as_history_grows` pins the mechanics with the
+    /// gate disabled; this one pins the policy, and together they show that
+    /// whether a bucket is sealed or hot is invisible to the answer.
+    #[tokio::test]
+    async fn small_data_seals_nothing_yet_still_reads_correctly() {
+        let _ = env_logger::try_init();
+        let persistence = tinyfs::MemoryPersistence::default();
+        let fs = tinyfs::FS::new(persistence.clone()).await.unwrap();
+        {
+            let root = fs.root().await.unwrap();
+            _ = root.create_dir_path("/ingest").await.unwrap();
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+
+        // Same shape as the mechanics test, but leaving seal_target_bytes unset
+        // so the real default (SEAL_TARGET_BYTES) applies.
+        let default_target = || {
+            let mut c = lateness_config(Some("1d"));
+            c.seal_target_bytes = None;
+            c
+        };
+
+        for day in 1..=4u32 {
+            append_day_series(&fs, "/ingest/weather.csv", day).await;
+            let rows = daily_max(&reduce_ctx(&persistence, &cache_dir), default_target())
+                .await
+                .expect("append within lateness window must succeed");
+            assert_eq!(rows.len(), day as usize, "day {day}: one bucket per day");
+        }
+
+        let runs = walk_find(&cache_dir, &|n| {
+            n.starts_with("run-") && n.ends_with(".parquet")
+        });
+        assert!(
+            runs.is_empty(),
+            "a few rows per day is far under {} bytes, so nothing should have \
+             been sealed; found {:?}",
+            crate::rollup_cache::SEAL_TARGET_BYTES,
+            runs
+        );
+
+        // Unsealed does not mean unavailable: every day is still answered, from
+        // the hot window alone.
+        let rows = daily_max(&reduce_ctx(&persistence, &cache_dir), default_target())
+            .await
+            .unwrap();
+        let approx = |a: f64, b: f64| (a - b).abs() < 1e-9;
+        assert_eq!(rows.len(), 4, "all four days still present without any run");
+        for (i, day) in (1..=4u32).enumerate() {
+            assert!(
+                approx(rows[i], 43.5 + day as f64 * 100.0),
+                "day {day} max wrong: {rows:?}"
+            );
+        }
+
+        // And the watermark still advanced: the buckets are frozen-but-unsealed,
+        // waiting to be written as one larger run rather than four tiny ones.
+        let manifests = walk_find(&cache_dir, &|n| n == "manifest.json");
+        assert_eq!(manifests.len(), 1, "one manifest for the single resolution");
+        let m: Value = serde_json::from_slice(&std::fs::read(&manifests[0]).unwrap()).unwrap();
+        assert!(
+            m["runs"].as_array().is_some_and(Vec::is_empty),
+            "manifest must record no runs: {m}"
+        );
     }
 
     /// A backfill that lands INSIDE the allowed_lateness window (nothing older

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -1292,7 +1292,7 @@ impl TemporalReduceSqlFile {
             })
             .map_err(|e| crate::error::Error::Arrow(e.to_string()))
         });
-        let digest = crate::rollup_cache::write_parquet_atomic(path, schema, Box::pin(mapped))
+        let digest = crate::version_cache::write_parquet_atomic(path, schema, Box::pin(mapped))
             .await
             .map_other()?;
         Ok((digest, rows.load(std::sync::atomic::Ordering::Relaxed)))

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -163,6 +163,13 @@ pub struct TemporalReduceConfig {
     /// recompute each build.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seal_target_bytes: Option<u64>,
+
+    /// Maximum number of sealed run files to leave live per resolution before
+    /// compaction merges them regardless of size class. Defaults to
+    /// [`crate::rollup_cache::MAX_LIVE_RUNS`]. Like `seal_target_bytes`, changing
+    /// it invalidates nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_live_runs: Option<usize>,
 }
 
 /// The two knobs governing how the sealed layout advances, carried together so
@@ -176,6 +183,10 @@ pub(crate) struct SealPolicy {
     /// Seal threshold in bytes; deliberately NOT recorded, because a change to
     /// it invalidates nothing.
     pub target_bytes: u64,
+    /// Compaction backstop: how many sealed runs may stay live before adjacent
+    /// runs are merged regardless of size class. Also not recorded, for the same
+    /// reason.
+    pub max_runs: usize,
 }
 
 /// Default maximum allowed lateness when `allowed_lateness` is unset: one day.
@@ -203,6 +214,15 @@ impl TemporalReduceConfig {
     fn seal_target_bytes(&self) -> u64 {
         self.seal_target_bytes
             .unwrap_or(crate::rollup_cache::SEAL_TARGET_BYTES)
+    }
+
+    /// Resolve the compaction backstop, defaulting to
+    /// [`crate::rollup_cache::MAX_LIVE_RUNS`]. Clamped to at least 1 so a
+    /// nonsense setting cannot make compaction spin.
+    fn max_live_runs(&self) -> usize {
+        self.max_live_runs
+            .unwrap_or(crate::rollup_cache::MAX_LIVE_RUNS)
+            .max(1)
     }
 }
 
@@ -680,6 +700,7 @@ impl TemporalReduceSqlFile {
         let policy = SealPolicy {
             lateness_secs: filled.allowed_lateness_secs()?,
             target_bytes: filled.seal_target_bytes(),
+            max_runs: filled.max_live_runs(),
         };
         let merged_dir = crate::rollup_cache::merged_dir(&cache_dir, &cfg_hash, &site_node_id);
 
@@ -994,7 +1015,7 @@ impl TemporalReduceSqlFile {
         in_bucket_col: &str,
         m: &mut crate::rollup_cache::SealedManifest,
         policy: SealPolicy,
-    ) -> TinyFSResult<()> {
+    ) -> TinyFSResult<Vec<std::path::PathBuf>> {
         // Event-time frontier: newest output bucket over the input (epoch
         // seconds). Bounded MAX scan, no per-bucket state.
         let data_hi_secs = self
@@ -1067,7 +1088,94 @@ impl TemporalReduceSqlFile {
             .await
             .map(|md| md.len())
             .unwrap_or(0);
-        Ok(())
+
+        self.compact_runs(ctx, pieces, ts, output_interval, res_dir, m, policy)
+            .await
+    }
+
+    /// Merge adjacent sealed runs until the size-tiered policy is satisfied,
+    /// returning the run files the merges superseded.
+    ///
+    /// Sealing alone only stops the count growing per build; without compaction
+    /// it still grows without bound as data accumulates, and every query opens
+    /// every live run. This is what actually bounds read fan-out.
+    ///
+    /// The window is chosen by [`crate::size_tier::choose_merge_window`] -- the
+    /// same function tlogfs uses to collapse series versions, not a second
+    /// implementation of the same idea. Its two properties are what make this
+    /// affordable: only same-size-class neighbours merge, so a large accumulated
+    /// run is not rewritten to absorb a few kilobytes; and the ragged-input
+    /// backstop merges the CHEAPEST window rather than the oldest, because after
+    /// any previous merge the oldest run IS the large one.
+    ///
+    /// Superseded files are NOT deleted here. They are returned so the caller can
+    /// delete them only after the manifest naming their replacement is durable;
+    /// see [`crate::rollup_cache::remove_superseded`].
+    #[allow(clippy::too_many_arguments)]
+    async fn compact_runs(
+        &self,
+        ctx: &datafusion::prelude::SessionContext,
+        pieces: &AggSqlPieces,
+        ts: &str,
+        output_interval: Duration,
+        res_dir: &std::path::Path,
+        m: &mut crate::rollup_cache::SealedManifest,
+        policy: SealPolicy,
+    ) -> TinyFSResult<Vec<std::path::PathBuf>> {
+        let mut superseded: Vec<std::path::PathBuf> = Vec::new();
+        loop {
+            let sizes: Vec<u64> = m.runs.iter().map(|r| r.bytes).collect();
+            let Some(window) = crate::size_tier::choose_merge_window(&sizes, policy.max_runs)
+            else {
+                break;
+            };
+
+            let inputs: Vec<std::path::PathBuf> = m.runs[window.clone()]
+                .iter()
+                .map(|r| crate::rollup_cache::run_path(res_dir, &r.name))
+                .collect();
+            let table = crate::rollup_cache::listing_table_for_files(&inputs, res_dir, ts)
+                .await
+                .map_other()?;
+
+            // Re-merge the partials of just these runs. Merging partials is
+            // associative, so folding a window of runs into one gives exactly
+            // what folding the original inputs would have; this is the same
+            // property that lets a coarser resolution be built from a finer one.
+            let table_name = format!("__rollup_compact_{}", m.next_seq);
+            _ = ctx.register_table(&table_name, table).map_other()?;
+            let sql = pieces.merge_partials_sql(output_interval, ts, &table_name, ts, None, None);
+            let name = format!("run-{:08}.parquet", m.next_seq);
+            let out = crate::rollup_cache::run_path(res_dir, &name);
+            let merged = self.write_merge_to(ctx, &sql, &out).await;
+            _ = ctx.deregister_table(&table_name).map_other()?;
+            let (digest, rows) = merged?;
+
+            if rows == 0 {
+                // Cannot happen for non-empty runs (an empty run is never
+                // recorded), but if it did, dropping the inputs would delete
+                // data. Leave the layout untouched and stop.
+                tokio::fs::remove_file(&out).await.map_other()?;
+                log::warn!(
+                    "rollup compaction: merge of {} runs produced no rows; leaving them alone",
+                    inputs.len()
+                );
+                break;
+            }
+
+            let bytes = tokio::fs::metadata(&out).await.map_other()?.len();
+            let replacement = crate::rollup_cache::SealedRun {
+                name,
+                lo_secs: m.runs[window.start].lo_secs,
+                hi_secs: m.runs[window.end - 1].hi_secs,
+                digest,
+                bytes,
+            };
+            _ = m.runs.splice(window, [replacement]);
+            m.next_seq += 1;
+            superseded.extend(inputs);
+        }
+        Ok(superseded)
     }
 
     /// Build the finest resolution level by folding the shared finest partials.
@@ -1181,24 +1289,27 @@ impl TemporalReduceSqlFile {
             }
         };
 
-        self.seal_and_recompute(
-            ctx,
-            pieces,
-            ts,
-            output_interval,
-            res_dir,
-            partials_table,
-            "time_bucket",
-            &mut m,
-            policy,
-        )
-        .await?;
+        let superseded = self
+            .seal_and_recompute(
+                ctx,
+                pieces,
+                ts,
+                output_interval,
+                res_dir,
+                partials_table,
+                "time_bucket",
+                &mut m,
+                policy,
+            )
+            .await?;
         m.covered = current_names;
         m.source_digest = None;
 
         let digest = crate::rollup_cache::write_sealed_manifest(res_dir, &m)
             .await
             .map_other()?;
+        // Only now that the manifest naming the merged runs is durable.
+        crate::rollup_cache::remove_superseded(&superseded).await;
         let provider = crate::rollup_cache::listing_table_for_res_dir(res_dir, &m, ts)
             .await
             .map_other()?;
@@ -1289,24 +1400,27 @@ impl TemporalReduceSqlFile {
             )
         };
 
-        self.seal_and_recompute(
-            ctx,
-            pieces,
-            ts,
-            output_interval,
-            res_dir,
-            finer_table,
-            ts,
-            &mut m,
-            policy,
-        )
-        .await?;
+        let superseded = self
+            .seal_and_recompute(
+                ctx,
+                pieces,
+                ts,
+                output_interval,
+                res_dir,
+                finer_table,
+                ts,
+                &mut m,
+                policy,
+            )
+            .await?;
         m.covered = std::collections::BTreeSet::new();
         m.source_digest = Some(finer_digest.to_string());
 
         let digest = crate::rollup_cache::write_sealed_manifest(res_dir, &m)
             .await
             .map_other()?;
+        // Only now that the manifest naming the merged runs is durable.
+        crate::rollup_cache::remove_superseded(&superseded).await;
         let provider = crate::rollup_cache::listing_table_for_res_dir(res_dir, &m, ts)
             .await
             .map_other()?;
@@ -2676,6 +2790,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         }
     }
 
@@ -3089,6 +3204,7 @@ mod tests {
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
+                max_live_runs: None,
             };
 
             let context = test_context(&provider_context, FileID::root());
@@ -3302,6 +3418,7 @@ mod tests {
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
+                max_live_runs: None,
             };
             TemporalReduceSqlFile::new(
                 config,
@@ -3435,6 +3552,7 @@ mod tests {
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
+                max_live_runs: None,
             };
 
             let context = test_context(&provider_context, FileID::root());
@@ -3598,6 +3716,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -3789,6 +3908,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -3960,6 +4080,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4090,6 +4211,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4191,6 +4313,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4324,6 +4447,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -4523,6 +4647,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         };
 
         let make_ctx = |cache: std::path::PathBuf| {
@@ -4657,6 +4782,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         }
     }
 
@@ -4824,6 +4950,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
+            max_live_runs: None,
         };
 
         // Grow history so the watermark advances and buckets seal into runs.
@@ -4962,6 +5089,94 @@ mod tests {
                 rows
             );
         }
+    }
+
+    /// Compaction bounds the number of live run files, and the merged runs
+    /// answer exactly what the originals did.
+    ///
+    /// Seals on every advance and sets a tiny backstop so that many small runs
+    /// accumulate and the ragged-input path fires -- the situation a real pond
+    /// reaches over months, reproduced in a few dozen buckets. Without
+    /// compaction the run count grows forever and every query opens all of them.
+    ///
+    /// The load-bearing assertion is not the file count but the VALUES: merging
+    /// partials is associative, so folding a window of runs into one must give
+    /// bit-for-bit the same answer as leaving them apart. If it did not, the
+    /// symptom would be a silently wrong aggregate, which is why the check is on
+    /// every day's maximum rather than on the shape of the cache.
+    #[tokio::test]
+    async fn compaction_bounds_run_count_without_changing_answers() {
+        let _ = env_logger::try_init();
+        let persistence = tinyfs::MemoryPersistence::default();
+        let fs = tinyfs::FS::new(persistence.clone()).await.unwrap();
+        {
+            let root = fs.root().await.unwrap();
+            _ = root.create_dir_path("/ingest").await.unwrap();
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+
+        const DAYS: u32 = 16;
+        let compacting = || {
+            let mut c = lateness_config(Some("1d"));
+            c.seal_target_bytes = Some(0); // seal on every advance
+            c.max_live_runs = Some(2); // force the backstop constantly
+            c
+        };
+
+        for day in 1..=DAYS {
+            append_day_series(&fs, "/ingest/weather.csv", day).await;
+            let rows = daily_max(&reduce_ctx(&persistence, &cache_dir), compacting())
+                .await
+                .expect("append within lateness window must succeed");
+            assert_eq!(rows.len(), day as usize, "day {day}: one bucket per day");
+        }
+
+        // Every day is still answered correctly after repeated merges.
+        let rows = daily_max(&reduce_ctx(&persistence, &cache_dir), compacting())
+            .await
+            .unwrap();
+        let approx = |a: f64, b: f64| (a - b).abs() < 1e-9;
+        assert_eq!(rows.len(), DAYS as usize, "all days survive compaction");
+        for (i, day) in (1..=DAYS).enumerate() {
+            assert!(
+                approx(rows[i], 43.5 + f64::from(day) * 100.0),
+                "day {day} max wrong after compaction: {rows:?}"
+            );
+        }
+
+        // The run count is bounded well below one-per-sealed-advance.
+        let manifests = walk_find(&cache_dir, &|n| n == "manifest.json");
+        assert_eq!(manifests.len(), 1, "one manifest for the single resolution");
+        let m: Value = serde_json::from_slice(&std::fs::read(&manifests[0]).unwrap()).unwrap();
+        let live = m["runs"].as_array().expect("runs array").len();
+        // Tight on purpose: the backstop merges until the count is back within
+        // max_live_runs, so anything above it means compaction did not run to
+        // completion. A loose bound like `live < DAYS` would pass even with
+        // compaction disabled entirely, since sealing alone yields one run per
+        // day -- which is exactly the growth this phase exists to stop.
+        assert!(
+            live <= 2,
+            "compaction left {live} runs; max_live_runs was 2 (after {DAYS} days)"
+        );
+
+        // Superseded inputs were actually deleted, not merely unlinked from the
+        // manifest -- otherwise compaction would trade read cost for unbounded
+        // disk. Every run file on disk must be one the manifest names.
+        let named: std::collections::BTreeSet<String> = m["runs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r["name"].as_str().unwrap().to_string())
+            .collect();
+        let on_disk = walk_find(&cache_dir, &|n| {
+            n.starts_with("run-") && n.ends_with(".parquet")
+        });
+        for f in &on_disk {
+            let n = f.file_name().unwrap().to_str().unwrap();
+            assert!(named.contains(n), "orphaned run left on disk: {n}");
+        }
+        assert_eq!(on_disk.len(), live, "disk and manifest must agree");
     }
 
     /// Under the DEFAULT seal target, four days of a handful of rows each never

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -1037,6 +1037,17 @@ impl TemporalReduceSqlFile {
                 // Cannot happen for non-empty segments (an empty segment is never
                 // recorded), but if it did, dropping the inputs would delete
                 // data. Leave the layout untouched and stop.
+                //
+                // The invariant that makes this unreachable is enforced in the
+                // seal path, not here, so assert it: a build that starts
+                // recording empty segments should fail loudly under test rather
+                // than quietly stop compacting and grow its segment count.
+                debug_assert!(
+                    rows > 0,
+                    "compaction of {} non-empty segments produced no rows; \
+                     an empty segment must never be recorded",
+                    inputs.len()
+                );
                 tokio::fs::remove_file(&out).await.map_other()?;
                 log::warn!(
                     "rollup compaction: merge of {} segments produced no rows; leaving them alone",
@@ -5144,6 +5155,34 @@ mod tests {
         w.shutdown().await.unwrap();
     }
 
+    /// Give the version just appended by [`append_day_series`] the event-time
+    /// bounds tlogfs records on a real series version.
+    ///
+    /// `MemoryPersistence` records none, so `source_range` returns `UNKNOWN` for
+    /// every version and `dirty_lo_us` is therefore always `None` -- "the dirty
+    /// range reaches the beginning of time". That is safe (it degrades to
+    /// reading everything) but it makes an append unseal the ENTIRE history, so
+    /// a test built on the bare helper never accumulates more than one segment
+    /// and can never reach compaction. Setting the bounds restores the partial
+    /// unsealing the branch exists to provide.
+    ///
+    /// Only the latest version is touched, which is the one the append just
+    /// created; earlier versions keep the bounds they were given.
+    async fn set_day_bounds(fs: &tinyfs::FS, path: &str, day: u32) {
+        let day_start_secs = i64::from(day - 1) * 86_400;
+        let mut attrs = HashMap::new();
+        _ = attrs.insert(
+            "min_event_time".to_string(),
+            (day_start_secs * 1_000_000).to_string(),
+        );
+        _ = attrs.insert(
+            "max_event_time".to_string(),
+            ((day_start_secs + 23 * 3600) * 1_000_000).to_string(),
+        );
+        let root = fs.root().await.unwrap();
+        root.set_extended_attributes(path, attrs).await.unwrap();
+    }
+
     fn lateness_config(lateness: Option<&str>) -> TemporalReduceConfig {
         TemporalReduceConfig {
             in_pattern: crate::Url::parse("csv:///ingest/weather.csv").unwrap(),
@@ -5728,6 +5767,11 @@ mod tests {
     /// bit-for-bit the same answer as leaving them apart. If it did not, the
     /// symptom would be a silently wrong aggregate, which is why the check is on
     /// every day's maximum rather than on the shape of the cache.
+    ///
+    /// Each append is given real event-time bounds ([`set_day_bounds`]). Without
+    /// them the dirty range is unbounded, every append unseals the whole
+    /// history, and the cache never holds two segments at once -- so nothing
+    /// reaches compaction and this test asserts nothing about it.
     #[tokio::test]
     async fn compaction_bounds_segment_count_without_changing_answers() {
         let _ = env_logger::try_init();
@@ -5750,6 +5794,7 @@ mod tests {
 
         for day in 1..=DAYS {
             append_day_series(&fs, "/ingest/weather.csv", day).await;
+            set_day_bounds(&fs, "/ingest/weather.csv", day).await;
             let rows = daily_max(&reduce_ctx(&persistence, &cache_dir), compacting())
                 .await
                 .expect("append within lateness window must succeed");
@@ -5803,9 +5848,19 @@ mod tests {
         // completion. A loose bound like `live < DAYS` would pass even with
         // compaction disabled entirely, since sealing alone yields one run per
         // day -- which is exactly the growth this phase exists to stop.
-        assert!(
-            live <= 2,
-            "compaction left {live} runs; max_live_segments was 2 (after {DAYS} days)"
+        //
+        // Equality, not `<=`, and for a second reason. This test used to be
+        // vacuous: without per-version event-time bounds every append unsealed
+        // the whole history, so the cache never held two segments at once,
+        // choose_merge_window always returned None, and the count was 1 for a
+        // reason that had nothing to do with compaction -- a `panic!` at the top
+        // of the merge did not fire anywhere in the provider suite. Landing
+        // exactly ON the limit is the fingerprint of accumulate-then-merge;
+        // landing below it means the segments never accumulated at all.
+        assert_eq!(
+            live, 2,
+            "compaction left {live} runs; max_live_segments was 2 (after {DAYS} days). \
+             Fewer than 2 means segments never accumulated and the merge never ran."
         );
 
         // Superseded inputs were actually deleted, not merely unlinked from the

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -140,36 +140,36 @@ pub struct TemporalReduceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transforms: Option<Vec<String>>,
 
-    /// Maximum allowed lateness for the sealed-runs rollup cache: how far behind
+    /// Maximum allowed lateness for the segment rollup cache: how far behind
     /// the newest bucket a late/backfilled sample may still land before its
     /// output bucket is treated as sealed. Buckets older than
-    /// `newest_bucket - allowed_lateness` are frozen into immutable run files and
+    /// `newest_bucket - allowed_lateness` are frozen into immutable segment files and
     /// never recomputed, which bounds the rollup's working set to this window
     /// instead of all history. Parsed with `humantime::parse_duration`; defaults
     /// to one day. Data arriving older than the sealed watermark is a hard error
     /// (re-run with `--rebuild`). Changing this value invalidates the merged
-    /// (sealed-runs) cache, which is rebuilt from the retained partials.
+    /// (segment) cache, which is rebuilt from the retained partials.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_lateness: Option<String>,
 
     /// Minimum accumulated size before frozen buckets are sealed into an
-    /// immutable run file. Accepts a byte count; defaults to
+    /// immutable segment file. Accepts a byte count; defaults to
     /// [`crate::rollup_cache::SEAL_TARGET_BYTES`].
     ///
     /// Unlike `allowed_lateness`, changing this does NOT invalidate the cache:
-    /// a run already sealed is correct at any target, so the new value simply
+    /// a segment already sealed is correct at any target, so the new value simply
     /// governs the next seal. Exposed mainly so the tradeoff can be measured
     /// against real data -- larger means fewer files but a heavier hot-window
     /// recompute each build.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seal_target_bytes: Option<u64>,
 
-    /// Maximum number of sealed run files to leave live per resolution before
+    /// Maximum number of segment files to leave live per resolution before
     /// compaction merges them regardless of size class. Defaults to
-    /// [`crate::rollup_cache::MAX_LIVE_RUNS`]. Like `seal_target_bytes`, changing
+    /// [`crate::rollup_cache::MAX_LIVE_SEGMENTS`]. Like `seal_target_bytes`, changing
     /// it invalidates nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_live_runs: Option<usize>,
+    pub max_live_segments: Option<usize>,
 }
 
 /// The two knobs governing how the sealed layout advances, carried together so
@@ -183,10 +183,10 @@ pub(crate) struct SealPolicy {
     /// Seal threshold in bytes; deliberately NOT recorded, because a change to
     /// it invalidates nothing.
     pub target_bytes: u64,
-    /// Compaction backstop: how many sealed runs may stay live before adjacent
-    /// runs are merged regardless of size class. Also not recorded, for the same
+    /// Compaction backstop: how many segments may stay live before adjacent
+    /// segments are merged regardless of size class. Also not recorded, for the same
     /// reason.
-    pub max_runs: usize,
+    pub max_segments: usize,
 }
 
 /// Default maximum allowed lateness when `allowed_lateness` is unset: one day.
@@ -217,11 +217,11 @@ impl TemporalReduceConfig {
     }
 
     /// Resolve the compaction backstop, defaulting to
-    /// [`crate::rollup_cache::MAX_LIVE_RUNS`]. Clamped to at least 1 so a
+    /// [`crate::rollup_cache::MAX_LIVE_SEGMENTS`]. Clamped to at least 1 so a
     /// nonsense setting cannot make compaction spin.
-    fn max_live_runs(&self) -> usize {
-        self.max_live_runs
-            .unwrap_or(crate::rollup_cache::MAX_LIVE_RUNS)
+    fn max_live_segments(&self) -> usize {
+        self.max_live_segments
+            .unwrap_or(crate::rollup_cache::MAX_LIVE_SEGMENTS)
             .max(1)
     }
 }
@@ -230,8 +230,8 @@ impl TemporalReduceConfig {
 /// Deferred SQL file that generates temporal reduction SQL when schema is discovered
 /// This avoids the marker-based approach by deferring SQL generation until
 /// the source schema can be properly discovered
-/// Result of building one resolution level of the sealed-runs cache. The
-/// `partials_provider` is the `ListingTable` over that level's runs + hot (in
+/// Result of building one resolution level of the segment cache. The
+/// `provider` is the `ListingTable` over that level's segments + hot (in
 /// mergeable-partials form), which the next-coarser level folds and which the
 /// final level wraps in a read-time reconstruction view. `digest` is the level's
 /// manifest digest (the coarser level records it as its `source_digest`);
@@ -239,7 +239,7 @@ impl TemporalReduceConfig {
 /// wiped and rebuilt from scratch (a non-append change), which forces the next
 /// coarser level to rebuild too.
 struct LevelBuild {
-    partials_provider: Arc<dyn datafusion::catalog::TableProvider>,
+    provider: Arc<dyn datafusion::catalog::TableProvider>,
     digest: String,
     changed_since: Option<i64>,
     rebuilt: bool,
@@ -593,7 +593,7 @@ impl TemporalReduceSqlFile {
         let ctx = &context.datafusion_session;
 
         // Let a consumer's full-history `ORDER BY {ts}` over the reduced series
-        // stream via a k-way `SortPreservingMergeExec` of the sealed runs + hot
+        // stream via a k-way `SortPreservingMergeExec` of the segments + hot
         // file (each declared pre-sorted in `listing_table_for_res_dir`) instead
         // of a `SortExec` that buffers the whole series in memory. DataFusion only
         // splits a ListingTable's files into per-partition, statistics-ordered
@@ -617,14 +617,14 @@ impl TemporalReduceSqlFile {
 
         let ts = filled.time_column.clone();
 
-        // Sealed-runs merged cache (Phase 2) + hierarchical rollup (Phase 3
+        // Segment cache (Phase 2) + hierarchical rollup (Phase 3
         // step 2). Each output resolution freezes buckets below a watermark into
-        // immutable append-only runs and recomputes only the open hot window, so
+        // immutable append-only segments and recomputes only the open hot window, so
         // per-build cost is bounded to ~allowed_lateness instead of all history.
         //
         // Resolutions form a nesting chain (finest .. coarsest). The finest
         // resolution aggregates the SOURCE directly; every coarser resolution is
-        // built by folding the *next-finer resolution's* runs + hot
+        // built by folding the *next-finer resolution's* segments + hot
         // (exponentially less input than rescanning the source), which is exact
         // because the stored partials are associative and the intervals nest. We build the chain finest-first up to this file's
         // resolution, so a consumer of any resolution transparently materializes
@@ -633,7 +633,7 @@ impl TemporalReduceSqlFile {
         let policy = SealPolicy {
             lateness_secs: filled.allowed_lateness_secs()?,
             target_bytes: filled.seal_target_bytes(),
-            max_runs: filled.max_live_runs(),
+            max_segments: filled.max_live_segments(),
         };
         let merged_dir = crate::rollup_cache::merged_dir(&cache_dir, &cfg_hash, &site_node_id);
 
@@ -649,7 +649,7 @@ impl TemporalReduceSqlFile {
         let mut final_level: Option<LevelBuild> = None;
 
         for (idx, level) in levels.iter().copied().enumerate() {
-            let res_dir = crate::rollup_cache::sealed_res_dir(&merged_dir, level.as_secs());
+            let res_dir = crate::rollup_cache::segment_res_dir(&merged_dir, level.as_secs());
             let built = if idx == 0 {
                 // Finest resolution: aggregate the sources directly.
                 self.build_level_from_source(
@@ -667,7 +667,7 @@ impl TemporalReduceSqlFile {
                 )
                 .await?
             } else {
-                // Coarser resolution: fold the next-finer resolution's runs+hot.
+                // Coarser resolution: fold the next-finer resolution's segments+hot.
                 let (finer_digest, finer_provider) =
                     finer.take().expect("non-finest level has a finer level");
                 let finer_table = format!(
@@ -696,21 +696,21 @@ impl TemporalReduceSqlFile {
                 out?
             };
             finer_rebuilt = built.rebuilt;
-            finer = Some((built.digest.clone(), built.partials_provider.clone()));
+            finer = Some((built.digest.clone(), built.provider.clone()));
             final_level = Some(built);
         }
 
         let final_level = final_level.expect("at least the finest level is always built");
         let (table_provider, digest, changed_since) = (
-            final_level.partials_provider,
+            final_level.provider,
             final_level.digest,
             final_level.changed_since,
         );
 
-        // The sealed runs + hot file store mergeable partials
+        // The segments + hot file store mergeable partials
         // (SEALED_FORMAT = partials-v2); reconstruct the output columns at read
         // time so consumers see identical output (same names, order, values,
-        // including Avg = Sum / Count) while the on-disk runs stay associatively
+        // including Avg = Sum / Count) while the on-disk segments stay associatively
         // foldable for the coarser-from-finer rollup (design §3 / Phase 3). The
         // reconstruction is a passthrough-projection view over the partials
         // listing table: the timestamp column flows through unchanged so the
@@ -764,7 +764,7 @@ impl TemporalReduceSqlFile {
     /// the watermark. A single bounded MAX scan; no per-bucket accumulator.
     /// `None` when the table holds no rows. `bucket_col` is `time_bucket` for the
     /// shared finest partials or the output `ts` column for a finer resolution's
-    /// runs+hot.
+    /// segments+hot.
     async fn max_output_bucket_secs(
         &self,
         ctx: &datafusion::prelude::SessionContext,
@@ -805,12 +805,12 @@ impl TemporalReduceSqlFile {
 
     /// Advance the sealed layout in `res_dir` by folding `input_table` (its
     /// bucket-timestamp column is `in_bucket_col`) into `output_interval`: seal
-    /// buckets that have crossed the watermark into a new immutable run, then
-    /// recompute the open hot window. Mutates and persists nothing but the run /
-    /// hot files; updates `m.sealed_hi_secs`, `m.runs`, `m.next_seq`,
+    /// buckets that have crossed the watermark into a new immutable segment, then
+    /// recompute the open hot window. Mutates and persists nothing but the segment /
+    /// hot files; updates `m.sealed_hi_secs`, `m.segments`, `m.next_seq`,
     /// `m.hot_digest`. Bounded to the newly-frozen span + the hot window. Shared
     /// by the finest fold (input = shared partials, `time_bucket`) and every
-    /// coarser fold (input = the next-finer runs+hot, `ts`).
+    /// coarser fold (input = the next-finer segments+hot, `ts`).
     async fn seal_and_recompute(
         &self,
         ctx: &datafusion::prelude::SessionContext,
@@ -820,7 +820,7 @@ impl TemporalReduceSqlFile {
         res_dir: &std::path::Path,
         input_table: &str,
         in_bucket_col: &str,
-        m: &mut crate::rollup_cache::SealedManifest,
+        m: &mut crate::rollup_cache::SegmentManifest,
         policy: SealPolicy,
     ) -> TinyFSResult<Vec<std::path::PathBuf>> {
         // Event-time frontier: newest output bucket over the input (epoch
@@ -832,18 +832,18 @@ impl TemporalReduceSqlFile {
         let watermark = data_hi_secs
             .map(|hi| (hi - m.allowed_lateness_secs).div_euclid(interval_secs) * interval_secs);
 
-        // Seal buckets [sealed_hi, watermark) into a new immutable run once
+        // Seal buckets [sealed_hi, watermark) into a new immutable segment once
         // enough has accumulated to be worth freezing. Bounded to the
         // newly-frozen span.
         //
-        // The size gate is what keeps the run count proportional to data rather
+        // The size gate is what keeps the segment count proportional to data rather
         // than to build frequency. `hot` currently spans [sealed_hi, inf), which
         // contains the frozen span [sealed_hi, wm) a seal would write, so
         // `hot_bytes` from the previous build is an upper bound on the seal's
         // size: under target, there is nothing worth sealing and we skip without
         // writing a candidate to find out. The buckets are not lost -- they stay
         // in `hot`, which is recomputed from the input below, and are sealed in
-        // one larger run on a later build.
+        // one larger segment on a later build.
         if let Some(wm) = watermark
             && m.sealed_hi_secs.is_none_or(|sh| wm > sh)
             && m.hot_bytes >= policy.target_bytes
@@ -856,23 +856,23 @@ impl TemporalReduceSqlFile {
                 m.sealed_hi_secs,
                 Some(wm),
             );
-            let name = format!("run-{:08}.parquet", m.next_seq);
-            let run_file = crate::rollup_cache::run_path(res_dir, &name);
-            let (run_digest, rows) = self.write_merge_to(ctx, &seal_sql, &run_file).await?;
+            let name = format!("seg-{:08}.parquet", m.next_seq);
+            let seg_file = crate::rollup_cache::segment_path(res_dir, &name);
+            let (seg_digest, rows) = self.write_merge_to(ctx, &seal_sql, &seg_file).await?;
             if rows > 0 {
-                let bytes = tokio::fs::metadata(&run_file).await.map_other()?.len();
-                m.runs.push(crate::rollup_cache::SealedRun {
+                let bytes = tokio::fs::metadata(&seg_file).await.map_other()?.len();
+                m.segments.push(crate::rollup_cache::Segment {
                     name,
                     lo_secs: m.sealed_hi_secs,
                     hi_secs: wm,
-                    digest: run_digest,
+                    digest: seg_digest,
                     bytes,
                 });
                 m.next_seq += 1;
             } else {
                 // Empty span (a gap with no data): advance the watermark without
-                // recording an empty run file.
-                tokio::fs::remove_file(&run_file).await.map_other()?;
+                // recording an empty segment file.
+                tokio::fs::remove_file(&seg_file).await.map_other()?;
             }
             m.sealed_hi_secs = Some(wm);
         }
@@ -896,89 +896,89 @@ impl TemporalReduceSqlFile {
             .map(|md| md.len())
             .unwrap_or(0);
 
-        self.compact_runs(ctx, pieces, ts, output_interval, res_dir, m, policy)
+        self.compact_segments(ctx, pieces, ts, output_interval, res_dir, m, policy)
             .await
     }
 
-    /// Merge adjacent sealed runs until the size-tiered policy is satisfied,
-    /// returning the run files the merges superseded.
+    /// Merge adjacent segments until the size-tiered policy is satisfied,
+    /// returning the segment files the merges superseded.
     ///
     /// Sealing alone only stops the count growing per build; without compaction
     /// it still grows without bound as data accumulates, and every query opens
-    /// every live run. This is what actually bounds read fan-out.
+    /// every live segment. This is what actually bounds read fan-out.
     ///
     /// The window is chosen by [`crate::size_tier::choose_merge_window`] -- the
     /// same function tlogfs uses to collapse series versions, not a second
     /// implementation of the same idea. Its two properties are what make this
     /// affordable: only same-size-class neighbours merge, so a large accumulated
-    /// run is not rewritten to absorb a few kilobytes; and the ragged-input
+    /// segment is not rewritten to absorb a few kilobytes; and the ragged-input
     /// backstop merges the CHEAPEST window rather than the oldest, because after
-    /// any previous merge the oldest run IS the large one.
+    /// any previous merge the oldest segment IS the large one.
     ///
     /// Superseded files are NOT deleted here. They are returned so the caller can
     /// delete them only after the manifest naming their replacement is durable;
     /// see [`crate::rollup_cache::remove_superseded`].
     #[allow(clippy::too_many_arguments)]
-    async fn compact_runs(
+    async fn compact_segments(
         &self,
         ctx: &datafusion::prelude::SessionContext,
         pieces: &AggSqlPieces,
         ts: &str,
         output_interval: Duration,
         res_dir: &std::path::Path,
-        m: &mut crate::rollup_cache::SealedManifest,
+        m: &mut crate::rollup_cache::SegmentManifest,
         policy: SealPolicy,
     ) -> TinyFSResult<Vec<std::path::PathBuf>> {
         let mut superseded: Vec<std::path::PathBuf> = Vec::new();
         loop {
-            let sizes: Vec<u64> = m.runs.iter().map(|r| r.bytes).collect();
-            let Some(window) = crate::size_tier::choose_merge_window(&sizes, policy.max_runs)
+            let sizes: Vec<u64> = m.segments.iter().map(|r| r.bytes).collect();
+            let Some(window) = crate::size_tier::choose_merge_window(&sizes, policy.max_segments)
             else {
                 break;
             };
 
-            let inputs: Vec<std::path::PathBuf> = m.runs[window.clone()]
+            let inputs: Vec<std::path::PathBuf> = m.segments[window.clone()]
                 .iter()
-                .map(|r| crate::rollup_cache::run_path(res_dir, &r.name))
+                .map(|r| crate::rollup_cache::segment_path(res_dir, &r.name))
                 .collect();
             let table = crate::rollup_cache::listing_table_for_files(&inputs, res_dir, ts)
                 .await
                 .map_other()?;
 
-            // Re-merge the partials of just these runs. Merging partials is
-            // associative, so folding a window of runs into one gives exactly
+            // Re-merge the partials of just these segments. Merging partials is
+            // associative, so folding a window of segments into one gives exactly
             // what folding the original inputs would have; this is the same
             // property that lets a coarser resolution be built from a finer one.
             let table_name = format!("__rollup_compact_{}", m.next_seq);
             _ = ctx.register_table(&table_name, table).map_other()?;
             let sql = pieces.merge_partials_sql(output_interval, ts, &table_name, ts, None, None);
-            let name = format!("run-{:08}.parquet", m.next_seq);
-            let out = crate::rollup_cache::run_path(res_dir, &name);
+            let name = format!("seg-{:08}.parquet", m.next_seq);
+            let out = crate::rollup_cache::segment_path(res_dir, &name);
             let merged = self.write_merge_to(ctx, &sql, &out).await;
             _ = ctx.deregister_table(&table_name).map_other()?;
             let (digest, rows) = merged?;
 
             if rows == 0 {
-                // Cannot happen for non-empty runs (an empty run is never
+                // Cannot happen for non-empty segments (an empty segment is never
                 // recorded), but if it did, dropping the inputs would delete
                 // data. Leave the layout untouched and stop.
                 tokio::fs::remove_file(&out).await.map_other()?;
                 log::warn!(
-                    "rollup compaction: merge of {} runs produced no rows; leaving them alone",
+                    "rollup compaction: merge of {} segments produced no rows; leaving them alone",
                     inputs.len()
                 );
                 break;
             }
 
             let bytes = tokio::fs::metadata(&out).await.map_other()?.len();
-            let replacement = crate::rollup_cache::SealedRun {
+            let replacement = crate::rollup_cache::Segment {
                 name,
-                lo_secs: m.runs[window.start].lo_secs,
-                hi_secs: m.runs[window.end - 1].hi_secs,
+                lo_secs: m.segments[window.start].lo_secs,
+                hi_secs: m.segments[window.end - 1].hi_secs,
                 digest,
                 bytes,
             };
-            _ = m.runs.splice(window, [replacement]);
+            _ = m.segments.splice(window, [replacement]);
             m.next_seq += 1;
             superseded.extend(inputs);
         }
@@ -1013,7 +1013,7 @@ impl TemporalReduceSqlFile {
         source_table: &str,
         policy: SealPolicy,
     ) -> TinyFSResult<LevelBuild> {
-        let manifest = match crate::rollup_cache::read_sealed_manifest(res_dir).map_other()? {
+        let manifest = match crate::rollup_cache::read_segment_manifest(res_dir).map_other()? {
             Some(m)
                 if m.allowed_lateness_secs == policy.lateness_secs
                     && m.format == crate::rollup_cache::SEALED_FORMAT =>
@@ -1021,7 +1021,7 @@ impl TemporalReduceSqlFile {
                 Some(m)
             }
             Some(_) => {
-                crate::rollup_cache::wipe_sealed_res_dir(res_dir).map_other()?;
+                crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
                 None
             }
             None => None,
@@ -1055,9 +1055,9 @@ impl TemporalReduceSqlFile {
             let provider = crate::rollup_cache::listing_table_for_res_dir(res_dir, m, ts)
                 .await
                 .map_other()?;
-            let digest = crate::rollup_cache::sealed_manifest_digest(m).map_other()?;
+            let digest = crate::rollup_cache::segment_manifest_digest(m).map_other()?;
             return Ok(LevelBuild {
-                partials_provider: provider,
+                provider,
                 digest,
                 changed_since: None,
                 rebuilt: false,
@@ -1084,9 +1084,9 @@ impl TemporalReduceSqlFile {
                 (m, unsealed, dirty_lo_secs)
             }
             _ => {
-                crate::rollup_cache::wipe_sealed_res_dir(res_dir).map_other()?;
+                crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
                 (
-                    crate::rollup_cache::SealedManifest {
+                    crate::rollup_cache::SegmentManifest {
                         format: crate::rollup_cache::SEALED_FORMAT.to_string(),
                         allowed_lateness_secs: policy.lateness_secs,
                         ..Default::default()
@@ -1155,24 +1155,24 @@ impl TemporalReduceSqlFile {
         m.sources = now.clone();
         m.source_digest = None;
 
-        let digest = crate::rollup_cache::write_sealed_manifest(res_dir, &m)
+        let digest = crate::rollup_cache::write_segment_manifest(res_dir, &m)
             .await
             .map_other()?;
-        // Only now that the manifest naming the merged runs is durable.
+        // Only now that the manifest naming the merged segments is durable.
         unsealed.extend(superseded);
         crate::rollup_cache::remove_superseded(&unsealed).await;
         let provider = crate::rollup_cache::listing_table_for_res_dir(res_dir, &m, ts)
             .await
             .map_other()?;
         Ok(LevelBuild {
-            partials_provider: provider,
+            provider,
             digest,
             changed_since,
             rebuilt,
         })
     }
 
-    /// Build a coarser resolution level by folding the next-finer level's runs +
+    /// Build a coarser resolution level by folding the next-finer level's segments +
     /// hot (`finer_table`, bucket column `ts`) into `output_interval` (Phase 3
     /// step 2). Freshness is keyed on the finer level's manifest digest
     /// (`finer_digest`) plus whether it was rebuilt:
@@ -1197,7 +1197,7 @@ impl TemporalReduceSqlFile {
         finer_rebuilt: bool,
         policy: SealPolicy,
     ) -> TinyFSResult<LevelBuild> {
-        let manifest = match crate::rollup_cache::read_sealed_manifest(res_dir).map_other()? {
+        let manifest = match crate::rollup_cache::read_segment_manifest(res_dir).map_other()? {
             Some(m)
                 if m.allowed_lateness_secs == policy.lateness_secs
                     && m.format == crate::rollup_cache::SEALED_FORMAT =>
@@ -1205,7 +1205,7 @@ impl TemporalReduceSqlFile {
                 Some(m)
             }
             Some(_) => {
-                crate::rollup_cache::wipe_sealed_res_dir(res_dir).map_other()?;
+                crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
                 None
             }
             None => None,
@@ -1220,9 +1220,9 @@ impl TemporalReduceSqlFile {
             let provider = crate::rollup_cache::listing_table_for_res_dir(res_dir, m, ts)
                 .await
                 .map_other()?;
-            let digest = crate::rollup_cache::sealed_manifest_digest(m).map_other()?;
+            let digest = crate::rollup_cache::segment_manifest_digest(m).map_other()?;
             return Ok(LevelBuild {
-                partials_provider: provider,
+                provider,
                 digest,
                 changed_since: None,
                 rebuilt: false,
@@ -1230,7 +1230,7 @@ impl TemporalReduceSqlFile {
         }
 
         // Advance in place when the finer level only appended (its sealed history
-        // below our watermark is immutable, so our sealed runs stay valid);
+        // below our watermark is immutable, so our segments stay valid);
         // otherwise rebuild from empty.
         let can_advance = !finer_rebuilt && manifest.is_some();
         let (mut m, changed_since, rebuilt) = if can_advance {
@@ -1239,9 +1239,9 @@ impl TemporalReduceSqlFile {
             let changed_since = m.sealed_hi_secs;
             (m, changed_since, false)
         } else {
-            crate::rollup_cache::wipe_sealed_res_dir(res_dir).map_other()?;
+            crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
             (
-                crate::rollup_cache::SealedManifest {
+                crate::rollup_cache::SegmentManifest {
                     format: crate::rollup_cache::SEALED_FORMAT.to_string(),
                     allowed_lateness_secs: policy.lateness_secs,
                     ..Default::default()
@@ -1267,16 +1267,16 @@ impl TemporalReduceSqlFile {
         m.sources.clear();
         m.source_digest = Some(finer_digest.to_string());
 
-        let digest = crate::rollup_cache::write_sealed_manifest(res_dir, &m)
+        let digest = crate::rollup_cache::write_segment_manifest(res_dir, &m)
             .await
             .map_other()?;
-        // Only now that the manifest naming the merged runs is durable.
+        // Only now that the manifest naming the merged segments is durable.
         crate::rollup_cache::remove_superseded(&superseded).await;
         let provider = crate::rollup_cache::listing_table_for_res_dir(res_dir, &m, ts)
             .await
             .map_other()?;
         Ok(LevelBuild {
-            partials_provider: provider,
+            provider,
             digest,
             changed_since,
             rebuilt,
@@ -1285,8 +1285,8 @@ impl TemporalReduceSqlFile {
 
     /// Plan and execute `sql`, streaming the result to `path` atomically. Returns
     /// the written file's blake3 digest and its row count. The row count lets the
-    /// caller drop empty sealed runs (gaps with no data) rather than record an
-    /// empty run file, while still advancing the watermark.
+    /// caller drop empty segments (gaps with no data) rather than record an
+    /// empty segment file, while still advancing the watermark.
     async fn write_merge_to(
         &self,
         ctx: &datafusion::prelude::SessionContext,
@@ -1949,7 +1949,7 @@ impl AggSqlPieces {
     /// `min_output_bucket`'s `lo_secs`), so the comparison is independent of the
     /// partials' timestamp unit. Bounding the aggregate keeps the hash table to
     /// one accumulator per bucket in the window instead of one per bucket over
-    /// all history (design §1a / Phase 1), and lets Phase 2 compute a sealed run
+    /// all history (design §1a / Phase 1), and lets Phase 2 compute a segment
     /// `[lo, hi)` and the open hot window `[hi, ∞)` as two bounded merges. The
     /// predicate is pushed *into* the partials scan (a `WHERE` before the
     /// `GROUP BY`) so it prunes input rows rather than aggregation output. It is
@@ -2006,7 +2006,7 @@ impl AggSqlPieces {
     }
 
     /// Comma-separated list of the stored partial columns (`__p_*` aliases), in
-    /// declaration order. This is the on-disk column set of a sealed run / hot
+    /// declaration order. This is the on-disk column set of a segment / hot
     /// file under [`crate::rollup_cache::SEALED_FORMAT`] = `partials-v1`, and the
     /// input columns the read-time reconstruction ([`reconstruct_sql`]) consumes.
     fn partial_column_list(&self) -> String {
@@ -2019,16 +2019,16 @@ impl AggSqlPieces {
 
     /// Like [`merge_sql`], but the final projection emits the *merged partial*
     /// columns instead of the reconstructed output columns. This is what the
-    /// Phase 2 sealed runs and hot file store (design §3 / Phase 3 step 1): keeping
+    /// Phase 2 segments and hot file store (design §3 / Phase 3 step 1): keeping
     /// the mergeable partials (sum/count/min/max) on disk — rather than a
     /// reconstructed, non-associative `Avg` — lets a coarser resolution correctly
-    /// fold a finer resolution's runs (Phase 3 step 2) and preserves exact
-    /// cross-version/cross-run merge semantics. Output columns are rebuilt at read
+    /// fold a finer resolution's segments (Phase 3 step 2) and preserves exact
+    /// cross-version/cross-segment merge semantics. Output columns are rebuilt at read
     /// time by [`reconstruct_sql`]. Bounds behave exactly as in [`merge_sql`].
     ///
     /// `in_bucket_col` is the input table's bucket-timestamp column: `time_bucket`
     /// when folding the shared finest partials (finest resolution), or the output
-    /// timestamp column (`ts`) when folding a finer resolution's runs+hot, whose
+    /// timestamp column (`ts`) when folding a finer resolution's segments+hot, whose
     /// stored bucket column is that `ts`. Both are TIMESTAMP-typed and already
     /// aligned to the finer interval, so `date_bin` re-buckets them exactly into
     /// the coarser output interval (nesting guarantees no split).
@@ -2080,7 +2080,7 @@ impl AggSqlPieces {
     /// output columns (identical names, order, and values to [`merge_sql`]'s
     /// projection, including `Avg = Sum / Count`) from the merged partial columns
     /// written by [`merge_partials_sql`]. `partials_table` is the registered
-    /// listing table over the sealed runs + hot file; `ts` passes the timestamp
+    /// listing table over the segments + hot file; `ts` passes the timestamp
     /// column through unchanged so the scan's declared ordering (the streaming
     /// read path) is preserved.
     fn reconstruct_sql(&self, ts: &str, partials_table: &str) -> String {
@@ -2643,7 +2643,7 @@ fn dirty_lo_us(
 /// `dirty_lo_secs = None` means the dirty range reaches the beginning of time, so
 /// everything unseals -- which is a rebuild, expressed in the same terms.
 fn unseal_from(
-    m: &mut crate::rollup_cache::SealedManifest,
+    m: &mut crate::rollup_cache::SegmentManifest,
     dirty_lo_secs: Option<i64>,
     res_dir: &std::path::Path,
 ) -> TinyFSResult<Vec<std::path::PathBuf>> {
@@ -2656,14 +2656,14 @@ fn unseal_from(
     }
 
     // A segment covers [lo, hi); it is dirty iff it holds any bucket >= dirty_lo.
-    let dirty = |r: &crate::rollup_cache::SealedRun| match dirty_lo_secs {
+    let dirty = |r: &crate::rollup_cache::Segment| match dirty_lo_secs {
         Some(lo) => r.hi_secs > lo,
         None => true,
     };
-    let (dropped, kept): (Vec<_>, Vec<_>) = std::mem::take(&mut m.runs)
+    let (dropped, kept): (Vec<_>, Vec<_>) = std::mem::take(&mut m.segments)
         .into_iter()
         .partition(|r| dirty(r));
-    m.runs = kept;
+    m.segments = kept;
 
     // The new watermark is the dirty point, lowered further to the bottom edge
     // of any segment straddling it -- a segment is dropped whole, so everything
@@ -2695,7 +2695,7 @@ fn unseal_from(
 
     Ok(dropped
         .iter()
-        .map(|r| crate::rollup_cache::run_path(res_dir, &r.name))
+        .map(|r| crate::rollup_cache::segment_path(res_dir, &r.name))
         .collect())
 }
 
@@ -2750,7 +2750,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         }
     }
 
@@ -3164,7 +3164,7 @@ mod tests {
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
-                max_live_runs: None,
+                max_live_segments: None,
             };
 
             let context = test_context(&provider_context, FileID::root());
@@ -3378,7 +3378,7 @@ mod tests {
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
-                max_live_runs: None,
+                max_live_segments: None,
             };
             TemporalReduceSqlFile::new(
                 config,
@@ -3512,7 +3512,7 @@ mod tests {
                 // Seal on every advance, as before the size gate existed: these
                 // tests assert seal MECHANICS on datasets far under any real target.
                 seal_target_bytes: Some(0),
-                max_live_runs: None,
+                max_live_segments: None,
             };
 
             let context = test_context(&provider_context, FileID::root());
@@ -3676,7 +3676,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -3818,7 +3818,7 @@ mod tests {
             1,
             "one manifest, for the single resolution"
         );
-        let m = crate::rollup_cache::read_sealed_manifest(manifests[0].parent().unwrap())
+        let m = crate::rollup_cache::read_segment_manifest(manifests[0].parent().unwrap())
             .unwrap()
             .unwrap();
         assert_eq!(m.sources.len(), 2, "one source entry per source file");
@@ -3887,7 +3887,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -4039,7 +4039,7 @@ mod tests {
     /// Phase 3 step 2: requesting only the coarsest resolution transparently
     /// materializes the finer levels it folds from. The finest level folds the
     /// shared partials; each coarser level folds the next-finer level's sealed
-    /// runs + hot (not the raw partials), so every intermediate `res{secs}` dir
+    /// segments + hot (not the raw partials), so every intermediate `res{secs}` dir
     /// must exist on disk with its own manifest + hot file, and the coarse
     /// manifest must record the finer digest it folded (`source_digest`).
     #[tokio::test]
@@ -4070,7 +4070,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4113,7 +4113,7 @@ mod tests {
                 .and_then(|n| n.strip_prefix("res"))
                 .and_then(|s| s.parse().ok())
                 .unwrap();
-            let m = crate::rollup_cache::read_sealed_manifest(res_dir)
+            let m = crate::rollup_cache::read_segment_manifest(res_dir)
                 .unwrap()
                 .unwrap();
             if secs == 3600 {
@@ -4196,20 +4196,20 @@ mod tests {
     /// ordinary seal path recomputes those buckets from source.
     #[test]
     fn test_unseal_from_drops_segments_covering_the_dirty_point() {
-        let seg = |name: &str, lo: Option<i64>, hi: i64| crate::rollup_cache::SealedRun {
+        let seg = |name: &str, lo: Option<i64>, hi: i64| crate::rollup_cache::Segment {
             name: name.to_string(),
             lo_secs: lo,
             hi_secs: hi,
             digest: "d".to_string(),
             bytes: 100,
         };
-        let base = crate::rollup_cache::SealedManifest {
+        let base = crate::rollup_cache::SegmentManifest {
             format: crate::rollup_cache::SEALED_FORMAT.to_string(),
             sealed_hi_secs: Some(300),
-            runs: vec![
-                seg("run-0", None, 100),
-                seg("run-1", Some(100), 200),
-                seg("run-2", Some(200), 300),
+            segments: vec![
+                seg("seg-0", None, 100),
+                seg("seg-1", Some(100), 200),
+                seg("seg-2", Some(200), 300),
             ],
             hot_bytes: 7,
             ..Default::default()
@@ -4219,7 +4219,7 @@ mod tests {
         // Dirty above the watermark: nothing sealed is affected.
         let mut m = base.clone();
         assert!(unseal_from(&mut m, Some(400), dir).unwrap().is_empty());
-        assert_eq!(m.runs.len(), 3);
+        assert_eq!(m.segments.len(), 3);
         assert_eq!(m.sealed_hi_secs, Some(300));
 
         // Dirty inside the middle segment: it and everything after it are
@@ -4227,8 +4227,8 @@ mod tests {
         // the dirty point, because a segment is dropped whole.
         let mut m = base.clone();
         let dropped = unseal_from(&mut m, Some(150), dir).unwrap();
-        assert_eq!(dropped.len(), 2, "run-1 and run-2");
-        assert_eq!(m.runs.len(), 1);
+        assert_eq!(dropped.len(), 2, "seg-1 and seg-2");
+        assert_eq!(m.segments.len(), 1);
         assert_eq!(m.sealed_hi_secs, Some(100));
         assert_eq!(m.hot_bytes, 207, "unsealed bytes are hot again");
 
@@ -4236,15 +4236,15 @@ mod tests {
         let mut m = base.clone();
         let dropped = unseal_from(&mut m, None, dir).unwrap();
         assert_eq!(dropped.len(), 3);
-        assert!(m.runs.is_empty());
+        assert!(m.segments.is_empty());
         assert_eq!(m.sealed_hi_secs, None);
 
         // A watermark advanced over an empty span records no segment file. The
         // watermark must still fall back to the dirty point, or the buckets
         // between them would be neither sealed nor recomputed -- silently lost.
-        let mut m = crate::rollup_cache::SealedManifest {
+        let mut m = crate::rollup_cache::SegmentManifest {
             sealed_hi_secs: Some(500),
-            runs: vec![seg("run-0", None, 100)],
+            segments: vec![seg("seg-0", None, 100)],
             ..Default::default()
         };
         let dropped = unseal_from(&mut m, Some(300), dir).unwrap();
@@ -4325,7 +4325,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4427,7 +4427,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4563,7 +4563,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         };
 
         let make_ctx = |cache: Option<std::path::PathBuf>| {
@@ -4754,7 +4754,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         };
 
         let make_ctx = |cache: std::path::PathBuf| {
@@ -4857,7 +4857,7 @@ mod tests {
         );
     }
 
-    // ---- Phase 2 sealed-runs / allowed_lateness tests ---------------------
+    // ---- Phase 2 segment / allowed_lateness tests ---------------------
 
     async fn append_day_series(fs: &tinyfs::FS, path: &str, day: u32) {
         use tokio::io::AsyncWriteExt;
@@ -4889,7 +4889,7 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         }
     }
 
@@ -5027,9 +5027,9 @@ mod tests {
         out
     }
 
-    /// Phase 3 step 1 invariant: sealed run + hot files store the *mergeable
+    /// Phase 3 step 1 invariant: segment + hot files store the *mergeable
     /// partials* (`__p_*`: sum/count/min/max), not the reconstructed output
-    /// columns. This is what makes a run associatively foldable (so a coarser
+    /// columns. This is what makes a segment associatively foldable (so a coarser
     /// resolution can later be built from a finer one without corrupting `Avg`),
     /// while consumers still read reconstructed output via the read-time view.
     #[tokio::test]
@@ -5057,10 +5057,10 @@ mod tests {
             // Seal on every advance, as before the size gate existed: these
             // tests assert seal MECHANICS on datasets far under any real target.
             seal_target_bytes: Some(0),
-            max_live_runs: None,
+            max_live_segments: None,
         };
 
-        // Grow history so the watermark advances and buckets seal into runs.
+        // Grow history so the watermark advances and buckets seal into segments.
         for day in 1..=4u32 {
             append_day_series(&fs, "/ingest/weather.csv", day).await;
             let context = test_context(&reduce_ctx(&persistence, &cache_dir), FileID::root());
@@ -5083,39 +5083,39 @@ mod tests {
             let _ = queryable.as_table_provider(file_id, &pctx).await;
         }
 
-        let runs = walk_find(&cache_dir, &|n| {
-            n.starts_with("run-") && n.ends_with(".parquet")
+        let segs = walk_find(&cache_dir, &|n| {
+            n.starts_with("seg-") && n.ends_with(".parquet")
         });
-        assert!(!runs.is_empty(), "expected at least one sealed run file");
+        assert!(!segs.is_empty(), "expected at least one segment file");
 
-        // Inspect the on-disk schema of a sealed run file.
+        // Inspect the on-disk schema of a segment file.
         let inspect = datafusion::prelude::SessionContext::new();
         inspect
             .register_parquet(
-                "run",
-                runs[0].to_string_lossy().as_ref(),
+                "seg",
+                segs[0].to_string_lossy().as_ref(),
                 datafusion::prelude::ParquetReadOptions::default(),
             )
             .await
             .unwrap();
-        let schema = inspect.table("run").await.unwrap().schema().clone();
+        let schema = inspect.table("seg").await.unwrap().schema().clone();
         let cols: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
 
         assert!(
             cols.iter().any(|c| c == "timestamp"),
-            "run must carry the timestamp column, got {cols:?}"
+            "segment must carry the timestamp column, got {cols:?}"
         );
         assert!(
             cols.iter().any(|c| c.starts_with("__p_sum_")),
-            "run must store the sum partial, got {cols:?}"
+            "segment must store the sum partial, got {cols:?}"
         );
         assert!(
             cols.iter().any(|c| c.starts_with("__p_count_")),
-            "run must store the count partial, got {cols:?}"
+            "segment must store the count partial, got {cols:?}"
         );
         assert!(
             !cols.iter().any(|c| c == "temperature.avg"),
-            "run must NOT store the reconstructed output column, got {cols:?}"
+            "segment must NOT store the reconstructed output column, got {cols:?}"
         );
 
         // And the read-time view still reconstructs the output column correctly.
@@ -5137,7 +5137,7 @@ mod tests {
 
     /// As history grows by append-only versions, the watermark advances and
     /// output buckets that fall out of the allowed_lateness window are frozen
-    /// into immutable `run-*.parquet` files; the query output still spans all
+    /// into immutable `seg-*.parquet` files; the query output still spans all
     /// days. This is the mechanism that bounds per-build memory to the hot
     /// window instead of all history.
     #[tokio::test]
@@ -5165,13 +5165,13 @@ mod tests {
         }
 
         // The watermark (data_hi - 1d) has advanced past the earliest days, so
-        // at least one sealed run file must exist on disk.
-        let runs = walk_find(&cache_dir, &|n| {
-            n.starts_with("run-") && n.ends_with(".parquet")
+        // at least one segment file must exist on disk.
+        let segs = walk_find(&cache_dir, &|n| {
+            n.starts_with("seg-") && n.ends_with(".parquet")
         });
         assert!(
-            !runs.is_empty(),
-            "expected sealed run files after history advanced, found none under {}",
+            !segs.is_empty(),
+            "expected segment files after history advanced, found none under {}",
             cache_dir.display()
         );
         // A hot file and a manifest must also be present.
@@ -5198,21 +5198,21 @@ mod tests {
         }
     }
 
-    /// Compaction bounds the number of live run files, and the merged runs
+    /// Compaction bounds the number of live segment files, and the merged segments
     /// answer exactly what the originals did.
     ///
-    /// Seals on every advance and sets a tiny backstop so that many small runs
+    /// Seals on every advance and sets a tiny backstop so that many small segments
     /// accumulate and the ragged-input path fires -- the situation a real pond
     /// reaches over months, reproduced in a few dozen buckets. Without
-    /// compaction the run count grows forever and every query opens all of them.
+    /// compaction the segment count grows forever and every query opens all of them.
     ///
     /// The load-bearing assertion is not the file count but the VALUES: merging
-    /// partials is associative, so folding a window of runs into one must give
+    /// partials is associative, so folding a window of segments into one must give
     /// bit-for-bit the same answer as leaving them apart. If it did not, the
     /// symptom would be a silently wrong aggregate, which is why the check is on
     /// every day's maximum rather than on the shape of the cache.
     #[tokio::test]
-    async fn compaction_bounds_run_count_without_changing_answers() {
+    async fn compaction_bounds_segment_count_without_changing_answers() {
         let _ = env_logger::try_init();
         let persistence = tinyfs::MemoryPersistence::default();
         let fs = tinyfs::FS::new(persistence.clone()).await.unwrap();
@@ -5227,7 +5227,7 @@ mod tests {
         let compacting = || {
             let mut c = lateness_config(Some("1d"));
             c.seal_target_bytes = Some(0); // seal on every advance
-            c.max_live_runs = Some(2); // force the backstop constantly
+            c.max_live_segments = Some(2); // force the backstop constantly
             c
         };
 
@@ -5252,32 +5252,32 @@ mod tests {
             );
         }
 
-        // The run count is bounded well below one-per-sealed-advance.
+        // The segment count is bounded well below one-per-sealed-advance.
         let manifests = walk_find(&cache_dir, &|n| n == "manifest.json");
         assert_eq!(manifests.len(), 1, "one manifest for the single resolution");
         let m: Value = serde_json::from_slice(&std::fs::read(&manifests[0]).unwrap()).unwrap();
-        let live = m["runs"].as_array().expect("runs array").len();
+        let live = m["segments"].as_array().expect("segments array").len();
         // Tight on purpose: the backstop merges until the count is back within
-        // max_live_runs, so anything above it means compaction did not run to
+        // max_live_segments, so anything above it means compaction did not run to
         // completion. A loose bound like `live < DAYS` would pass even with
         // compaction disabled entirely, since sealing alone yields one run per
         // day -- which is exactly the growth this phase exists to stop.
         assert!(
             live <= 2,
-            "compaction left {live} runs; max_live_runs was 2 (after {DAYS} days)"
+            "compaction left {live} runs; max_live_segments was 2 (after {DAYS} days)"
         );
 
         // Superseded inputs were actually deleted, not merely unlinked from the
         // manifest -- otherwise compaction would trade read cost for unbounded
-        // disk. Every run file on disk must be one the manifest names.
-        let named: std::collections::BTreeSet<String> = m["runs"]
+        // disk. Every segment file on disk must be one the manifest names.
+        let named: std::collections::BTreeSet<String> = m["segments"]
             .as_array()
             .unwrap()
             .iter()
             .map(|r| r["name"].as_str().unwrap().to_string())
             .collect();
         let on_disk = walk_find(&cache_dir, &|n| {
-            n.starts_with("run-") && n.ends_with(".parquet")
+            n.starts_with("seg-") && n.ends_with(".parquet")
         });
         for f in &on_disk {
             let n = f.file_name().unwrap().to_str().unwrap();
@@ -5287,7 +5287,7 @@ mod tests {
     }
 
     /// Under the DEFAULT seal target, four days of a handful of rows each never
-    /// accumulate enough bytes to be worth freezing, so no run file is written
+    /// accumulate enough bytes to be worth freezing, so no segment file is written
     /// at all -- yet the query still returns every day correctly, because the
     /// unsealed buckets simply stay in the recomputed hot window.
     ///
@@ -5325,15 +5325,15 @@ mod tests {
             assert_eq!(rows.len(), day as usize, "day {day}: one bucket per day");
         }
 
-        let runs = walk_find(&cache_dir, &|n| {
-            n.starts_with("run-") && n.ends_with(".parquet")
+        let segs = walk_find(&cache_dir, &|n| {
+            n.starts_with("seg-") && n.ends_with(".parquet")
         });
         assert!(
-            runs.is_empty(),
+            segs.is_empty(),
             "a few rows per day is far under {} bytes, so nothing should have \
              been sealed; found {:?}",
             crate::rollup_cache::SEAL_TARGET_BYTES,
-            runs
+            segs
         );
 
         // Unsealed does not mean unavailable: every day is still answered, from
@@ -5356,8 +5356,8 @@ mod tests {
         assert_eq!(manifests.len(), 1, "one manifest for the single resolution");
         let m: Value = serde_json::from_slice(&std::fs::read(&manifests[0]).unwrap()).unwrap();
         assert!(
-            m["runs"].as_array().is_some_and(Vec::is_empty),
-            "manifest must record no runs: {m}"
+            m["segments"].as_array().is_some_and(Vec::is_empty),
+            "manifest must record no segments: {m}"
         );
     }
 
@@ -5459,7 +5459,7 @@ mod tests {
         );
     }
 
-    /// Read-path memory bound: the sealed runs + hot file are declared sorted on
+    /// Read-path memory bound: the segments + hot file are declared sorted on
     /// the timestamp column, so a full-history `ORDER BY timestamp` over a
     /// multi-run reduced series is satisfied by a streaming k-way merge, never a
     /// `SortExec` that buffers the whole series. This is the O(1)-memory read
@@ -5489,18 +5489,18 @@ mod tests {
             .await
             .unwrap();
         }
-        // At least one sealed run plus the hot file, i.e. two separately-ordered
+        // At least one segment plus the hot file, i.e. two separately-ordered
         // inputs -- which is what the k-way merge has to reconcile. Only one run
         // survives here: MemoryPersistence records no event-time bounds, so every
         // source version reports an unknown range, every build's dirty range is
         // the whole axis, and the sealed segments are unsealed and re-sealed as
         // one. Under tlogfs the bounds are recorded and segments accumulate.
-        let runs = walk_find(&cache_dir, &|n| {
-            n.starts_with("run-") && n.ends_with(".parquet")
+        let segs = walk_find(&cache_dir, &|n| {
+            n.starts_with("seg-") && n.ends_with(".parquet")
         });
         assert!(
-            !runs.is_empty(),
-            "test needs a sealed run plus hot to exercise the merge, got none"
+            !segs.is_empty(),
+            "test needs a segment plus hot to exercise the merge, got none"
         );
 
         // Acquire the reduced table provider (built during the last rollup).
@@ -5528,7 +5528,7 @@ mod tests {
         drop(file_guard);
 
         // Fresh consumer session, independent of the build session, with enough
-        // target partitions that each sealed run + hot lands in its own scan
+        // target partitions that each segment + hot lands in its own scan
         // partition, and statistics-based file-group splitting enabled (as the
         // rollup build enables on the shared production session) so the declared
         // per-file ordering is honored.

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -2751,6 +2751,23 @@ register_dynamic_factory!(
 /// A version with no recorded blake3 falls back to node+version, which is
 /// unstable across a collapse and so degrades to "looks changed" -- a rebuild,
 /// never a stale reuse.
+///
+/// The map this feeds is a set, so the key must also be UNIQUE across a single
+/// node's live versions, or two of them collapse into one member and an append
+/// becomes invisible -- `sources == now` would reuse a cache that counted the
+/// payload once while a series read counts it twice. Two facts outside this
+/// module make that safe, and neither is local enough to be obvious:
+///
+///  - For series entry types the stored blake3 is the CUMULATIVE hash over
+///    every version's content, not that version's own bytes, so re-appending
+///    identical bytes still yields a different digest (tlogfs
+///    `extract_blake3_from_outboard`).
+///  - A non-series source with more than one live version is rejected before
+///    this is ever called, since its versions are overlapping re-snapshots.
+///
+/// `test_identical_content_appended_twice_is_not_mistaken_for_no_change` pins
+/// the consequence, so a change to either fact fails a test here rather than
+/// silently freezing the cache.
 fn source_version_key(node_id: &tinyfs::NodeID, v: &tinyfs::FileVersionInfo) -> String {
     match &v.blake3 {
         Some(h) => format!("{}:{}", node_id, h),
@@ -5252,6 +5269,77 @@ mod tests {
         }
         _ = ctx.deregister_table("reduced").unwrap();
         Ok(rows)
+    }
+
+    /// Guards the invariant the freshness key rests on: a set of content
+    /// digests is only a sound identity for the live version set if two live
+    /// versions can never share a digest.
+    ///
+    /// `sources` is a `BTreeMap` keyed on blake3, so a genuine duplicate would
+    /// collapse into one member and the append would look like no change at all
+    /// -- `sources == now` → reuse → the cache keeps serving the single-copy
+    /// answer while a direct read of the series counts both. That cannot happen
+    /// today for the two reasons spelled out at `source_version_key`: a series
+    /// stores the CUMULATIVE hash, which strictly changes on every append, and
+    /// a non-series source with more than one live version is rejected outright.
+    ///
+    /// Both reasons live far from this cache -- one in tlogfs's outboard, one in
+    /// a guard several hundred lines up -- so this pins the consequence. Append
+    /// the same bytes twice: two live versions, identical payload, and the sum
+    /// must double. Max would hide it entirely (`max(x, x) == x`); only an
+    /// additive statistic can tell. If someone ever makes the stored hash
+    /// per-version content rather than cumulative, this fails instead of the
+    /// rollup silently freezing.
+    #[tokio::test]
+    async fn test_identical_content_appended_twice_is_not_mistaken_for_no_change() {
+        let _ = env_logger::try_init();
+        let persistence = tinyfs::MemoryPersistence::default();
+        let fs = tinyfs::FS::new(persistence.clone()).await.unwrap();
+        {
+            let root = fs.root().await.unwrap();
+            _ = root.create_dir_path("/ingest").await.unwrap();
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+
+        // Build 1: one copy of day 5.
+        append_day_series(&fs, "/ingest/weather.csv", 5).await;
+        let first = daily_max_col(
+            &reduce_ctx(&persistence, &cache_dir),
+            lateness_config(Some("0s")),
+            "temperature.sum",
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.len(), 1, "one daily bucket, got {:?}", first);
+        let approx = |a: f64, b: f64| (a - b).abs() < 1e-6;
+        assert!(
+            approx(first[0], expected_day_sum(5)),
+            "seed sum wrong: {:?}",
+            first
+        );
+
+        // Append the SAME bytes again: a second live version, identical content,
+        // identical blake3, identical recorded event range.
+        append_day_series(&fs, "/ingest/weather.csv", 5).await;
+
+        // Build 2 must see a change. Max would hide this entirely
+        // (max(x, x) == x); only an additive statistic can tell.
+        let second = daily_max_col(
+            &reduce_ctx(&persistence, &cache_dir),
+            lateness_config(Some("0s")),
+            "temperature.sum",
+        )
+        .await
+        .unwrap();
+        assert_eq!(second.len(), 1, "still one daily bucket, got {:?}", second);
+        assert!(
+            approx(second[0], 2.0 * expected_day_sum(5)),
+            "a second live version with identical content is a real append and \
+             must be counted: got {:?}, want {}",
+            second,
+            2.0 * expected_day_sum(5)
+        );
     }
 
     fn walk_find(dir: &std::path::Path, pred: &dyn Fn(&str) -> bool) -> Vec<std::path::PathBuf> {

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -1201,21 +1201,7 @@ impl TemporalReduceSqlFile {
         // what `seal_and_recompute` folds, so it plays exactly the role the
         // partials directory used to -- as a query, not as a file population.
         let source_set = bounded_source_set(cache_dir, scheme, source_nodes, read_lo_us);
-        // This build is about to record `now` as the coverage of what it wrote.
-        // A live version whose sidecar vanished (a concurrent reconciler deleted
-        // it; neither side locks) would contribute no rows, and the manifest
-        // would then claim it was covered -- an undercount that agrees with
-        // itself forever, because the next build sees `sources == now` and
-        // reuses. Fail the build instead; the retry re-caches and succeeds.
-        if !source_set.missing().is_empty() {
-            return Err(tinyfs::Error::Other(format!(
-                "temporal-reduce rollup: {} live source version(s) have no cached \
-                 Parquet (first: {}). This is a lost race with cache \
-                 reconciliation, not a data error; re-run the read.",
-                source_set.missing().len(),
-                source_set.missing()[0].display(),
-            )));
-        }
+        require_complete_coverage(&source_set)?;
         let provider = source_set.table_provider().await.map_other()?;
         let available: std::collections::HashSet<String> = provider
             .schema()
@@ -2909,6 +2895,37 @@ fn bounded_source_set(
         tinyfs::SeriesReadBounds::from_event_time_lo(lo)
     });
     crate::format_cache::glob_cached_set_bounded(cache_dir, scheme, source_nodes, &bounds)
+}
+
+/// Reject a source set that does not cover every live version it will claim.
+///
+/// The build that follows records `now` -- the digest of every LIVE source
+/// version -- as the coverage of what it wrote. A live version whose sidecar
+/// vanished contributes no rows, so the manifest would assert coverage the
+/// cache does not have. That undercount then agrees with itself forever: the
+/// next build compares `sources == now`, finds them equal, reuses, and never
+/// recomputes. Failing here is what keeps a lost race from becoming permanent
+/// wrong output; the retry re-caches the version and succeeds.
+///
+/// It is a race, not a data error. `ensure_url_cached` writes a sidecar for
+/// every live version before this point, so a single build cannot reach this by
+/// itself -- only a concurrent reconciler deleting a sidecar this reader still
+/// considers live can, and neither side takes a lock.
+///
+/// Split out from the call site so the check has a name and a test: the
+/// condition it guards is by construction unreachable in-process, which is
+/// exactly the kind of guard that rots unnoticed.
+fn require_complete_coverage(set: &crate::version_cache::CachedSet) -> TinyFSResult<()> {
+    if set.missing().is_empty() {
+        return Ok(());
+    }
+    Err(tinyfs::Error::Other(format!(
+        "temporal-reduce rollup: {} live source version(s) have no cached \
+         Parquet (first: {}). This is a lost race with cache \
+         reconciliation, not a data error; re-run the read.",
+        set.missing().len(),
+        set.missing()[0].display(),
+    )))
 }
 
 /// Epoch microseconds -> epoch seconds, rounding DOWN (toward -inf, so it holds
@@ -5339,6 +5356,77 @@ mod tests {
              must be counted: got {:?}, want {}",
             second,
             2.0 * expected_day_sum(5)
+        );
+    }
+
+    /// The rollup aborts rather than aggregate a source set that is missing a
+    /// live version's sidecar.
+    ///
+    /// The condition is a lost race with cache reconciliation, so a single build
+    /// cannot produce it: `ensure_url_cached` writes a sidecar for every live
+    /// version before the read. That unreachability is why this is tested at the
+    /// check rather than through a build -- the alternative is no coverage at
+    /// all for a guard whose whole value is preventing a permanent undercount.
+    ///
+    /// Built through `glob_cached_set_bounded`, the same constructor the build
+    /// uses, so the sidecar naming and the retention filter are exercised too:
+    /// a hand-built `CachedSet` would prove only that the `if` works.
+    #[test]
+    fn a_source_set_missing_a_live_sidecar_aborts_the_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        let node_id = tinyfs::NodeID::new("00000000-0000-7000-8000-00000000002a".to_string());
+
+        let mk = |v: u64, hash: &str| tinyfs::FileVersionInfo {
+            version: v,
+            timestamp: 1_700_000_000_000_000,
+            size: 128,
+            blake3: Some(hash.to_string()),
+            entry_type: EntryType::FilePhysicalSeries,
+            extended_metadata: None,
+        };
+        let versions = vec![mk(1, "aaa"), mk(2, "bbb")];
+        let nodes = vec![(node_id, versions.clone())];
+
+        // Both live versions cached: the ordinary state, and the build proceeds.
+        for v in &versions {
+            let p = crate::format_cache::cache_version_path(&cache_dir, "csv", &node_id, v);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, b"parquet").unwrap();
+        }
+        let set = bounded_source_set(&cache_dir, "csv", &nodes, None);
+        assert_eq!(set.files().len(), 2, "both sidecars are present");
+        assert!(
+            require_complete_coverage(&set).is_ok(),
+            "a fully cached source set must not abort"
+        );
+
+        // A concurrent reconciler deletes one, mid-read.
+        let gone =
+            crate::format_cache::cache_version_path(&cache_dir, "csv", &node_id, &versions[1]);
+        std::fs::remove_file(&gone).unwrap();
+
+        let set = bounded_source_set(&cache_dir, "csv", &nodes, None);
+        assert_eq!(
+            set.files().len(),
+            1,
+            "the surviving sidecar would still aggregate -- silently, and short \
+             by one version"
+        );
+        let err = require_complete_coverage(&set)
+            .expect_err("a live version with no sidecar must abort, not undercount");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no cached"),
+            "message must say what is wrong: {msg}"
+        );
+        assert!(
+            msg.contains(&gone.display().to_string()),
+            "message must name the missing sidecar: {msg}"
+        );
+        assert!(
+            msg.contains("re-run"),
+            "the operator must be told this is retryable, not a data error: {msg}"
         );
     }
 

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -146,9 +146,10 @@ pub struct TemporalReduceConfig {
     /// `newest_bucket - allowed_lateness` are frozen into immutable segment files and
     /// never recomputed, which bounds the rollup's working set to this window
     /// instead of all history. Parsed with `humantime::parse_duration`; defaults
-    /// to one day. Data arriving older than the sealed watermark is a hard error
-    /// (re-run with `--rebuild`). Changing this value invalidates the merged
-    /// (segment) cache, which is rebuilt from the retained partials.
+    /// to one day. Data arriving older than the sealed watermark is not an
+    /// error: the segments covering it are unsealed and recomputed from source.
+    /// Changing this value invalidates the merged (segment) cache, which is
+    /// rebuilt from the cached source versions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_lateness: Option<String>,
 
@@ -235,14 +236,57 @@ impl TemporalReduceConfig {
 /// mergeable-partials form), which the next-coarser level folds and which the
 /// final level wraps in a read-time reconstruction view. `digest` is the level's
 /// manifest digest (the coarser level records it as its `source_digest`);
-/// `changed_since` feeds the export hint; `rebuilt` is true when this level was
+/// `changed` feeds the export hint and the coarser level's unsealing;
+/// `rebuilt` is true when this level was
 /// wiped and rebuilt from scratch (a non-append change), which forces the next
 /// coarser level to rebuild too.
 struct LevelBuild {
     provider: Arc<dyn datafusion::catalog::TableProvider>,
     digest: String,
-    changed_since: Option<i64>,
+    changed: LevelChange,
     rebuilt: bool,
+}
+
+/// Which output buckets a level changed this build.
+///
+/// This used to be a bare `Option<i64>` carrying three different meanings on
+/// the same `None`: "nothing changed" (reuse), "everything changed" (rebuild),
+/// and "the dirty range is unbounded" (a source version with no recorded event
+/// range). That conflation is harmless for the export hint, which treats every
+/// `None` as "rewrite all", but it is not harmless for the coarser level, which
+/// must unseal EVERYTHING in the last two cases and NOTHING in the first.
+/// Spelling the three out keeps a reader of one from silently behaving like a
+/// reader of another.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LevelChange {
+    /// Nothing changed; the level was served from cache untouched.
+    Nothing,
+    /// Every bucket at or after this one (epoch seconds, bucket-aligned).
+    Since(i64),
+    /// The whole axis: a rebuild, or a dirty range with no lower bound.
+    Everything,
+}
+
+impl LevelChange {
+    /// The dirty point to hand `unseal_from`, whose `None` means "the whole
+    /// axis". Returns `None` for [`LevelChange::Nothing`] too, so callers must
+    /// check that case before calling.
+    fn dirty_lo(self) -> Option<i64> {
+        match self {
+            LevelChange::Since(s) => Some(s),
+            LevelChange::Nothing | LevelChange::Everything => None,
+        }
+    }
+
+    /// The export hint's `changed_since`, where `None` means "rewrite every
+    /// partition". Unchanged levels are reported as `None` as well; the hint's
+    /// digest is what lets the exporter skip them.
+    fn export_hint(self) -> Option<i64> {
+        match self {
+            LevelChange::Since(s) => Some(s),
+            LevelChange::Nothing | LevelChange::Everything => None,
+        }
+    }
 }
 
 pub struct TemporalReduceSqlFile {
@@ -646,6 +690,9 @@ impl TemporalReduceSqlFile {
 
         let mut finer: Option<(String, Arc<dyn datafusion::catalog::TableProvider>)> = None;
         let mut finer_rebuilt = false;
+        // The finer level's dirty point, so a backfill propagates up the chain
+        // instead of stopping at the finest resolution.
+        let mut finer_changed: LevelChange = LevelChange::Nothing;
         let mut final_level: Option<LevelBuild> = None;
 
         for (idx, level) in levels.iter().copied().enumerate() {
@@ -689,6 +736,7 @@ impl TemporalReduceSqlFile {
                         &finer_table,
                         &finer_digest,
                         finer_rebuilt,
+                        finer_changed,
                         policy,
                     )
                     .await;
@@ -696,6 +744,7 @@ impl TemporalReduceSqlFile {
                 out?
             };
             finer_rebuilt = built.rebuilt;
+            finer_changed = built.changed;
             finer = Some((built.digest.clone(), built.provider.clone()));
             final_level = Some(built);
         }
@@ -704,7 +753,7 @@ impl TemporalReduceSqlFile {
         let (table_provider, digest, changed_since) = (
             final_level.provider,
             final_level.digest,
-            final_level.changed_since,
+            final_level.changed.export_hint(),
         );
 
         // The segments + hot file store mergeable partials
@@ -1013,19 +1062,20 @@ impl TemporalReduceSqlFile {
         source_table: &str,
         policy: SealPolicy,
     ) -> TinyFSResult<LevelBuild> {
-        let manifest = match crate::rollup_cache::read_segment_manifest(res_dir).map_other()? {
-            Some(m)
-                if m.allowed_lateness_secs == policy.lateness_secs
-                    && m.format == crate::rollup_cache::SEALED_FORMAT =>
-            {
+        let manifest =
+            match crate::rollup_cache::read_verified_segment_manifest(res_dir).map_other()? {
                 Some(m)
-            }
-            Some(_) => {
-                crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
-                None
-            }
-            None => None,
-        };
+                    if m.allowed_lateness_secs == policy.lateness_secs
+                        && m.format == crate::rollup_cache::SEALED_FORMAT =>
+                {
+                    Some(m)
+                }
+                Some(_) => {
+                    crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
+                    None
+                }
+                None => None,
+            };
 
         enum Plan {
             Reuse,
@@ -1059,16 +1109,29 @@ impl TemporalReduceSqlFile {
             return Ok(LevelBuild {
                 provider,
                 digest,
-                changed_since: None,
+                changed: LevelChange::Nothing,
                 rebuilt: false,
             });
         }
 
         let rebuilt = matches!(plan, Plan::Rebuild);
-        let (mut m, mut unsealed, changed_since) = match plan {
+        let (mut m, mut unsealed, changed) = match plan {
             Plan::Incremental { dirty_lo_us } => {
                 let mut m = manifest.expect("incremental implies a manifest");
-                let dirty_lo_secs = dirty_lo_us.map(floor_us_to_secs);
+                // Floor to the BUCKET, not just to the second. `sealed_hi_secs`
+                // is a bucket boundary everywhere else, and every consumer
+                // compares it against a bucket START (`merge_partials_sql`
+                // filters `date_bin(...) >= lo`). An unaligned watermark would
+                // leave the bucket containing the dirty point in neither a
+                // segment (they stop at the aligned edge below it) nor the hot
+                // window (it starts strictly above it), silently dropping that
+                // bucket -- including the very rows that made it dirty. It
+                // would also prune source versions at the unaligned point,
+                // dropping rows in [bucket_start, dirty_lo) that the bucket
+                // still needs.
+                let dirty_lo_secs = dirty_lo_us
+                    .map(floor_us_to_secs)
+                    .map(|s| floor_secs_to_bucket(s, output_interval));
                 // Late data is ordinary work now, not a --rebuild error. Buckets
                 // at or after the dirty point must be recomputed; those below
                 // sealed_hi live in immutable segments, so the segments covering
@@ -1081,7 +1144,12 @@ impl TemporalReduceSqlFile {
                 // Under the old version-keyed layout there was no way to find
                 // them again, which is exactly why it had to error instead.
                 let unsealed = unseal_from(&mut m, dirty_lo_secs, res_dir)?;
-                (m, unsealed, dirty_lo_secs)
+                let changed = match dirty_lo_secs {
+                    Some(lo) => LevelChange::Since(lo),
+                    // An unbounded dirty range is the whole axis, not "nothing".
+                    None => LevelChange::Everything,
+                };
+                (m, unsealed, changed)
             }
             _ => {
                 crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
@@ -1092,7 +1160,7 @@ impl TemporalReduceSqlFile {
                         ..Default::default()
                     },
                     Vec::new(),
-                    None,
+                    LevelChange::Everything,
                 )
             }
         };
@@ -1101,7 +1169,7 @@ impl TemporalReduceSqlFile {
         // [sealed_hi, inf) plus the dirty range. Pruning below this is what
         // keeps an incremental build off the whole history; pruning ABOVE it
         // would silently drop contributing rows, so take the lower of the two.
-        let read_lo_us = match (m.sealed_hi_secs, changed_since) {
+        let read_lo_us = match (m.sealed_hi_secs, changed.dirty_lo()) {
             (Some(sealed_hi), Some(dirty_lo)) => Some(secs_to_us(sealed_hi.min(dirty_lo))),
             // No watermark means every bucket is hot: read everything.
             (None, _) => None,
@@ -1112,6 +1180,21 @@ impl TemporalReduceSqlFile {
         // what `seal_and_recompute` folds, so it plays exactly the role the
         // partials directory used to -- as a query, not as a file population.
         let source_set = bounded_source_set(cache_dir, scheme, source_nodes, read_lo_us);
+        // This build is about to record `now` as the coverage of what it wrote.
+        // A live version whose sidecar vanished (a concurrent reconciler deleted
+        // it; neither side locks) would contribute no rows, and the manifest
+        // would then claim it was covered -- an undercount that agrees with
+        // itself forever, because the next build sees `sources == now` and
+        // reuses. Fail the build instead; the retry re-caches and succeeds.
+        if !source_set.missing().is_empty() {
+            return Err(tinyfs::Error::Other(format!(
+                "temporal-reduce rollup: {} live source version(s) have no cached \
+                 Parquet (first: {}). This is a lost race with cache \
+                 reconciliation, not a data error; re-run the read.",
+                source_set.missing().len(),
+                source_set.missing()[0].display(),
+            )));
+        }
         let provider = source_set.table_provider().await.map_other()?;
         let available: std::collections::HashSet<String> = provider
             .schema()
@@ -1167,7 +1250,7 @@ impl TemporalReduceSqlFile {
         Ok(LevelBuild {
             provider,
             digest,
-            changed_since,
+            changed,
             rebuilt,
         })
     }
@@ -1182,8 +1265,14 @@ impl TemporalReduceSqlFile {
     ///
     /// No beyond-window hard-fail is needed here: this level's watermark aligns
     /// down at least as far as the finer level's (coarser interval, same
-    /// lateness), so `coarse_sealed_hi ≤ finer_sealed_hi`, and the finest level
-    /// already enforces the append-only contract for the whole chain.
+    /// lateness), so `coarse_sealed_hi ≤ finer_sealed_hi`.
+    ///
+    /// `finer_changed` is what the finer level changed. Late data is NOT a
+    /// rebuild -- it takes the finer level's incremental path -- so
+    /// `finer_rebuilt` alone would leave this level's segments below its own
+    /// watermark holding pre-backfill values forever. This level therefore
+    /// unseals from the same point, or unseals entirely when the finer level's
+    /// dirty range was unbounded.
     #[allow(clippy::too_many_arguments)]
     async fn build_level_from_finer(
         &self,
@@ -1195,21 +1284,23 @@ impl TemporalReduceSqlFile {
         finer_table: &str,
         finer_digest: &str,
         finer_rebuilt: bool,
+        finer_changed: LevelChange,
         policy: SealPolicy,
     ) -> TinyFSResult<LevelBuild> {
-        let manifest = match crate::rollup_cache::read_segment_manifest(res_dir).map_other()? {
-            Some(m)
-                if m.allowed_lateness_secs == policy.lateness_secs
-                    && m.format == crate::rollup_cache::SEALED_FORMAT =>
-            {
+        let manifest =
+            match crate::rollup_cache::read_verified_segment_manifest(res_dir).map_other()? {
                 Some(m)
-            }
-            Some(_) => {
-                crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
-                None
-            }
-            None => None,
-        };
+                    if m.allowed_lateness_secs == policy.lateness_secs
+                        && m.format == crate::rollup_cache::SEALED_FORMAT =>
+                {
+                    Some(m)
+                }
+                Some(_) => {
+                    crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
+                    None
+                }
+                None => None,
+            };
 
         // Reuse: the finer level was reused (not rebuilt) and its digest matches
         // what this level last folded, so nothing downstream changed.
@@ -1224,7 +1315,7 @@ impl TemporalReduceSqlFile {
             return Ok(LevelBuild {
                 provider,
                 digest,
-                changed_since: None,
+                changed: LevelChange::Nothing,
                 rebuilt: false,
             });
         }
@@ -1233,11 +1324,33 @@ impl TemporalReduceSqlFile {
         // below our watermark is immutable, so our segments stay valid);
         // otherwise rebuild from empty.
         let can_advance = !finer_rebuilt && manifest.is_some();
-        let (mut m, changed_since, rebuilt) = if can_advance {
-            let m = manifest.expect("can_advance implies a manifest");
-            // Earliest coarse bucket that the hot recompute may change.
-            let changed_since = m.sealed_hi_secs;
-            (m, changed_since, false)
+        let (mut m, mut unsealed, changed, rebuilt) = if can_advance {
+            let mut m = manifest.expect("can_advance implies a manifest");
+            // Late data at the finest level lowered ITS watermark; ours must
+            // follow, or our segments keep their pre-backfill values forever.
+            // Align to our own (coarser) bucket so the watermark stays a bucket
+            // boundary -- see `floor_secs_to_bucket`.
+            let unsealed = match finer_changed {
+                // Nothing below our watermark moved, so our segments stand.
+                LevelChange::Nothing => Vec::new(),
+                // Align to OUR (coarser) bucket: a watermark must be a bucket
+                // boundary or the bucket straddling it belongs to neither the
+                // sealed nor the hot side. See `floor_secs_to_bucket`.
+                LevelChange::Since(lo) => unseal_from(
+                    &mut m,
+                    Some(floor_secs_to_bucket(lo, output_interval)),
+                    res_dir,
+                )?,
+                // Unbounded: unseal everything.
+                LevelChange::Everything => unseal_from(&mut m, None, res_dir)?,
+            };
+            // Post-unseal, so it already reflects any segments folded back in.
+            // No watermark left means the whole axis is hot.
+            let changed = match m.sealed_hi_secs {
+                Some(hi) => LevelChange::Since(hi),
+                None => LevelChange::Everything,
+            };
+            (m, unsealed, changed, false)
         } else {
             crate::rollup_cache::wipe_segment_res_dir(res_dir).map_other()?;
             (
@@ -1246,7 +1359,8 @@ impl TemporalReduceSqlFile {
                     allowed_lateness_secs: policy.lateness_secs,
                     ..Default::default()
                 },
-                None,
+                Vec::new(),
+                LevelChange::Everything,
                 true,
             )
         };
@@ -1271,14 +1385,15 @@ impl TemporalReduceSqlFile {
             .await
             .map_other()?;
         // Only now that the manifest naming the merged segments is durable.
-        crate::rollup_cache::remove_superseded(&superseded).await;
+        unsealed.extend(superseded);
+        crate::rollup_cache::remove_superseded(&unsealed).await;
         let provider = crate::rollup_cache::listing_table_for_res_dir(res_dir, &m, ts)
             .await
             .map_other()?;
         Ok(LevelBuild {
             provider,
             digest,
-            changed_since,
+            changed,
             rebuilt,
         })
     }
@@ -2718,6 +2833,16 @@ fn bounded_source_set(
 /// bounds, so a rounding error can only cause extra work, never dropped data.
 fn floor_us_to_secs(us: i64) -> i64 {
     us.div_euclid(1_000_000)
+}
+
+/// Epoch seconds -> the start of the output bucket containing them, rounding
+/// DOWN. `sealed_hi_secs` and every segment edge are bucket boundaries, and the
+/// read path filters on a bucket START, so any value used as a watermark must
+/// be aligned or the bucket straddling it belongs to neither the sealed nor the
+/// hot side.
+fn floor_secs_to_bucket(secs: i64, interval: Duration) -> i64 {
+    let i = interval.as_secs() as i64;
+    if i <= 0 { secs } else { secs.div_euclid(i) * i }
 }
 
 fn secs_to_us(secs: i64) -> i64 {
@@ -4250,6 +4375,43 @@ mod tests {
         let dropped = unseal_from(&mut m, Some(300), dir).unwrap();
         assert!(dropped.is_empty(), "no segment covers [300, 500)");
         assert_eq!(m.sealed_hi_secs, Some(300));
+
+        // The watermark this produces is exactly the dirty point, so the dirty
+        // point MUST already be bucket-aligned -- see `floor_secs_to_bucket` and
+        // the caller. An unaligned one would leave the bucket containing it in
+        // neither a segment (they stop at the aligned edge below) nor the hot
+        // window (it starts strictly at or above the watermark, because the read
+        // filters on a bucket START), dropping that bucket and the very rows
+        // that made it dirty.
+        let interval = Duration::from_secs(100);
+        let mut m = crate::rollup_cache::SegmentManifest {
+            sealed_hi_secs: Some(500),
+            segments: vec![seg("seg-0", None, 100)],
+            ..Default::default()
+        };
+        let unaligned = 350;
+        let _ = unseal_from(&mut m, Some(floor_secs_to_bucket(unaligned, interval)), dir).unwrap();
+        assert_eq!(
+            m.sealed_hi_secs,
+            Some(300),
+            "the watermark must fall to the START of the bucket holding the \
+             dirty point, not to the dirty point itself"
+        );
+    }
+
+    /// Watermarks are bucket boundaries; flooring must round toward -inf so it
+    /// holds for pre-epoch times too.
+    #[test]
+    fn test_floor_secs_to_bucket_rounds_down() {
+        let hour = Duration::from_secs(3600);
+        assert_eq!(floor_secs_to_bucket(3600, hour), 3600, "already aligned");
+        assert_eq!(floor_secs_to_bucket(3601, hour), 3600);
+        assert_eq!(floor_secs_to_bucket(7199, hour), 3600);
+        // Pre-epoch: -1s is in the bucket starting at -3600, not at 0.
+        assert_eq!(floor_secs_to_bucket(-1, hour), -3600);
+        assert_eq!(floor_secs_to_bucket(-3600, hour), -3600);
+        // A zero interval cannot divide; pass the value through rather than panic.
+        assert_eq!(floor_secs_to_bucket(42, Duration::from_secs(0)), 42);
     }
 
     /// Phase 3: non-nesting resolution sets are rejected so cascaded rollups can
@@ -4883,7 +5045,16 @@ mod tests {
             out_pattern: "weather".to_string(),
             time_column: "timestamp".to_string(),
             resolutions: vec!["1d".to_string()],
-            aggregations: vec![agg(AggregationType::Max, &["temperature"])],
+            // Max ALONE is invariant under both double-counting and dropping a
+            // duplicate: max(x, x) == x. It cannot distinguish "every row was
+            // read once" from "the sealed window was summed twice", which is
+            // exactly how the original double-count survived review (see
+            // testsuite 733, where the blind statistic was avg). Sum is carried
+            // alongside it so these tests can assert a total.
+            aggregations: vec![
+                agg(AggregationType::Max, &["temperature"]),
+                agg(AggregationType::Sum, &["temperature"]),
+            ],
             transforms: None,
             allowed_lateness: lateness.map(str::to_string),
             // Seal on every advance, as before the size gate existed: these
@@ -4952,6 +5123,14 @@ mod tests {
         }
         _ = ctx.deregister_table("reduced").unwrap();
         Ok(rows)
+    }
+
+    /// Each day appended by [`append_day_series`] holds 24 hourly rows of
+    /// `20.5 + hour + day * 100`, so its total is `768 + 2400 * day`. A rollup
+    /// that counted the day twice would report double this; one that dropped a
+    /// segment would report less. Unlike the daily max, this moves.
+    fn expected_day_sum(day: u32) -> f64 {
+        768.0 + 2400.0 * f64::from(day)
     }
 
     /// Like [`daily_max`] but reads an arbitrary output column, for aggregations
@@ -5249,6 +5428,30 @@ mod tests {
             assert!(
                 approx(rows[i], 43.5 + f64::from(day) * 100.0),
                 "day {day} max wrong after compaction: {rows:?}"
+            );
+        }
+
+        // The load-bearing assertion: a merge that duplicated or dropped rows
+        // leaves the daily max untouched but moves the daily sum.
+        let sums = daily_max_col(
+            &reduce_ctx(&persistence, &cache_dir),
+            compacting(),
+            "temperature.sum",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            sums.len(),
+            DAYS as usize,
+            "one sum per day after compaction"
+        );
+        for (i, day) in (1..=DAYS).enumerate() {
+            assert!(
+                approx(sums[i], expected_day_sum(day)),
+                "day {day} sum wrong after compaction (double-counted or dropped): \
+                 got {}, want {}",
+                sums[i],
+                expected_day_sum(day)
             );
         }
 

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -961,10 +961,15 @@ impl TemporalReduceSqlFile {
         let hot_file = crate::rollup_cache::hot_path(res_dir);
         let (hot_digest, _rows) = self.write_merge_to(ctx, &hot_sql, &hot_file).await?;
         m.hot_digest = Some(hot_digest);
-        m.hot_bytes = tokio::fs::metadata(&hot_file)
-            .await
-            .map(|md| md.len())
-            .unwrap_or(0);
+        // Fatal, like the identical stat on a just-sealed segment above.
+        // `write_merge_to` has just written this path atomically and a zero-row
+        // result still produces a file, so there is no benign way for this to
+        // fail -- and the value is not a passing hint: it is PERSISTED, and the
+        // seal gate reads it. Defaulting to 0 would record "nothing worth
+        // freezing" in the manifest, which disables sealing on the next build
+        // and lets the hot window grow unbounded, silently undoing the bound
+        // that sealing exists to provide.
+        m.hot_bytes = tokio::fs::metadata(&hot_file).await.map_other()?.len();
 
         self.compact_segments(ctx, pieces, ts, output_interval, res_dir, m, policy)
             .await
@@ -5894,6 +5899,28 @@ mod tests {
         assert!(
             m["segments"].as_array().is_some_and(Vec::is_empty),
             "manifest must record no segments: {m}"
+        );
+
+        // The gate's INPUT must be the real size of hot, not a placeholder.
+        // Everything above here is equally satisfied by hot_bytes == 0, which is
+        // what a swallowed stat error used to record: the gate would then block
+        // every seal forever and the hot window would grow without bound, with
+        // this test still green. Pin the recorded value against the file.
+        let hots = walk_find(&cache_dir, &|n| n == "hot.parquet");
+        assert_eq!(hots.len(), 1, "one hot file for the single resolution");
+        let on_disk = std::fs::metadata(&hots[0]).unwrap().len();
+        assert!(
+            on_disk > 0,
+            "hot.parquet is never empty; it holds four days"
+        );
+        assert_eq!(
+            m["hot_bytes"].as_u64(),
+            Some(on_disk),
+            "manifest must record the hot file's actual size: {m}"
+        );
+        assert!(
+            on_disk < crate::rollup_cache::SEAL_TARGET_BYTES,
+            "the premise of this test is that hot is under the seal target"
         );
     }
 

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -5619,6 +5619,97 @@ mod tests {
         }
     }
 
+    /// A seal whose frozen span turns out to hold no buckets must advance the
+    /// watermark without leaving anything behind.
+    ///
+    /// The span `[sealed_hi, wm)` is chosen from the watermark alone, before
+    /// anything knows whether it contains data, so the seal writes a candidate
+    /// Parquet and only then learns it produced zero rows. This is routine, not
+    /// exotic: on a first build `sealed_hi` is `None` and `wm` is the newest
+    /// bucket, so a source whose data all sits in that newest bucket freezes an
+    /// empty span every time.
+    ///
+    /// Three things have to happen together, and each fails differently:
+    ///  - the candidate file is deleted, or it is an orphan -- unnamed by any
+    ///    manifest, so no later build will ever clean it up;
+    ///  - `next_seq` does not advance, so sequence numbers track real segments;
+    ///  - `sealed_hi` DOES advance to `wm`, or the same empty span is re-frozen
+    ///    and re-discarded on every subsequent build.
+    #[tokio::test]
+    async fn a_seal_that_freezes_no_rows_records_no_segment_and_leaves_no_file() {
+        let _ = env_logger::try_init();
+        let persistence = tinyfs::MemoryPersistence::default();
+        let fs = tinyfs::FS::new(persistence.clone()).await.unwrap();
+        {
+            let root = fs.root().await.unwrap();
+            _ = root.create_dir_path("/ingest").await.unwrap();
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+
+        // A single day, so the newest bucket IS the only bucket. With zero
+        // lateness the watermark lands on it, and the frozen span below it --
+        // everything before day 1 -- is empty.
+        append_day_series(&fs, "/ingest/weather.csv", 1).await;
+        let rows = daily_max(
+            &reduce_ctx(&persistence, &cache_dir),
+            lateness_config(Some("0s")),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "the one day still reads back, got {:?}",
+            rows
+        );
+
+        let manifests = walk_find(&cache_dir, &|n| n == "manifest.json");
+        assert_eq!(manifests.len(), 1, "one manifest for the single resolution");
+        let m: crate::rollup_cache::SegmentManifest =
+            serde_json::from_slice(&std::fs::read(&manifests[0]).unwrap()).unwrap();
+
+        assert!(
+            m.sealed_hi_secs.is_some(),
+            "the watermark must advance past the empty span, or every later \
+             build re-freezes and re-discards it"
+        );
+        assert!(
+            m.segments.is_empty(),
+            "an empty span must not be recorded as a segment: {:?}",
+            m.segments
+        );
+        assert_eq!(
+            m.next_seq, 0,
+            "a discarded candidate must not consume a sequence number"
+        );
+        let segs = walk_find(&cache_dir, &|n| {
+            n.starts_with("seg-") && n.ends_with(".parquet")
+        });
+        assert!(
+            segs.is_empty(),
+            "the zero-row candidate was left on disk as an orphan; no manifest \
+             names it, so nothing will ever delete it: {segs:?}"
+        );
+
+        // The layout stays usable: a later append seals normally on top of the
+        // watermark the empty seal advanced.
+        append_day_series(&fs, "/ingest/weather.csv", 2).await;
+        let rows = daily_max(
+            &reduce_ctx(&persistence, &cache_dir),
+            lateness_config(Some("0s")),
+        )
+        .await
+        .unwrap();
+        let approx = |a: f64, b: f64| (a - b).abs() < 1e-9;
+        assert_eq!(rows.len(), 2, "both days, got {:?}", rows);
+        assert!(
+            approx(rows[0], 143.5) && approx(rows[1], 243.5),
+            "values wrong after sealing on top of an empty span: {:?}",
+            rows
+        );
+    }
+
     /// Compaction bounds the number of live segment files, and the merged segments
     /// answer exactly what the originals did.
     ///

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -508,10 +508,10 @@ impl TemporalReduceSqlFile {
             return Ok(None);
         }
 
-        // Partials are stored once at the finest resolution and re-binned to
-        // this file's resolution at merge time, so coarser resolutions never
-        // rescan raw history. The finest-partial namespace is therefore shared
-        // across all resolutions of the same site.
+        // The finest resolution aggregates the sources directly; every coarser
+        // resolution folds the next-finer resolution's segments, so no level
+        // rescans raw history more than once. The cache namespace is therefore
+        // shared across all resolutions of the same site.
         let resolution_durations = parse_nesting_resolutions(&self.config.resolutions)?;
         let Some(finest_interval) = resolution_durations.first().copied() else {
             return Ok(None);
@@ -525,18 +525,9 @@ impl TemporalReduceSqlFile {
             &self.pattern_url,
         ));
 
-        // Key the partials directory by the parent site partition, which is
-        // shared by every resolution file of this site, so all resolutions read
-        // and write the same finest-resolution partials.
+        // Key the cache by the parent site partition, which is shared by every
+        // resolution file of this site, so all resolutions share one namespace.
         let site_node_id = id.part_id().to_node_id();
-        let glob_dir = crate::rollup_cache::glob_dir(&cache_dir, &cfg_hash, &site_node_id);
-        let partials = crate::rollup_cache::partials_dir(&cache_dir, &cfg_hash, &site_node_id);
-        // Accumulated across source nodes: the partials of every source node's
-        // LIVE versions, named explicitly. Reading this instead of listing
-        // `glob_dir` is what keeps a version-collapse leftover out of the
-        // merge, where it would be summed a second time (testsuite 733).
-        let mut live_partials =
-            crate::version_cache::CachedSet::empty_in(partials.path().to_path_buf());
 
         let fs = self.context.context.filesystem();
         let mut provider_api =
@@ -544,6 +535,14 @@ impl TemporalReduceSqlFile {
         if let Ok(root) = self.context.root().await {
             provider_api = provider_api.with_root(root);
         }
+
+        // Collect every source node's LIVE versions, plus the content identity
+        // of the set: blake3 -> event-time range. That map is the freshness key
+        // (design §5.3); nothing here is keyed by a version number or filename.
+        let mut source_nodes: Vec<(tinyfs::NodeID, Vec<tinyfs::FileVersionInfo>)> =
+            Vec::with_capacity(source_files.len());
+        let mut now: std::collections::BTreeMap<String, crate::rollup_cache::SourceRange> =
+            std::collections::BTreeMap::new();
 
         for node_path in &source_files {
             let file_url_str = node_file_url(scheme, node_path);
@@ -554,100 +553,41 @@ impl TemporalReduceSqlFile {
                 .await
                 .map_other()?;
 
-            // Per-version partials only sum correctly when each source version
-            // contributes a DISJOINT row set, because the read-side merge is a
-            // GROUP BY time_bucket over every version's partial. FilePhysicalSeries
-            // and TablePhysicalSeries store append-only deltas (concatenated on
-            // read), so distinct versions never share a row; their partials merge
-            // in any order and late / out-of-order data is summed into the correct
-            // bucket exactly like a single-pass GROUP BY. Ordering is irrelevant.
+            // The rollup sums every live version of a source. Series entry types
+            // (FilePhysicalSeries, TablePhysicalSeries) store append-only deltas
+            // that are concatenated on read, so their versions are disjoint and
+            // summing them is exactly a single-pass GROUP BY over the whole
+            // series. A non-series file stores a full RE-SNAPSHOT per version,
+            // so two live versions share rows and summing them double-counts.
             //
-            // Non-series sources (FilePhysicalVersion) store a full re-snapshot per
-            // version, so successive versions OVERLAP and merging their partials
-            // would double-count. For those we keep the sequentiality frontier: a
-            // version whose earliest bucket precedes the frontier is an overlapping
-            // re-snapshot and is a hard error recovered with --rebuild, never a
-            // silent double-count.
-            let disjoint_versions = matches!(
+            // This used to be defended by a per-source "sequentiality frontier":
+            // scan each new version's bucket span, persist the high-water mark,
+            // and fail if a later version reached below it. That is a
+            // data-dependent test for a condition fixed by the entry type -- and
+            // for a re-snapshot it fires on the second version regardless, since
+            // every snapshot re-covers all of history. Testing the structure
+            // says the same thing without the scan, the sidecar file, or the
+            // chance of a stale frontier disagreeing with the data.
+            let is_series = matches!(
                 node_path.id().entry_type(),
                 EntryType::FilePhysicalSeries | EntryType::TablePhysicalSeries
             );
-
-            let live =
-                crate::version_cache::LiveVersions::from_persistence(source_node_id, versions);
-            // Reconcile before writing: this both reports which live versions
-            // still need a partial and DELETES the partials of versions that a
-            // collapse superseded. A cache that only ever added is how those
-            // leftovers survived to be double-counted.
-            let reconciled = partials.reconcile(&live).map_other()?;
-            if !reconciled.removed.is_empty() {
-                log::info!(
-                    "temporal-reduce rollup: source node {} dropped {} partial(s) whose \
-                     versions are no longer live (version collapse); any sealed run built \
-                     on them will be rebuilt from the live partials",
-                    source_node_id,
-                    reconciled.removed.len()
-                );
-            }
-            let mut uncached = reconciled.missing;
-            uncached.sort_by_key(|v| v.version);
-            let mut frontier =
-                crate::rollup_cache::read_frontier(&glob_dir, &source_node_id).map_other()?;
-            for version in &uncached {
-                let parquet_path = crate::format_cache::cache_version_path(
-                    &cache_dir,
-                    scheme,
-                    &source_node_id,
-                    version,
-                );
-                // Disjoint (series) sources skip the frontier entirely; only
-                // overlapping sources pay the per-version span scan and guard.
-                let span = if disjoint_versions {
-                    None
-                } else {
-                    self.version_bucket_span(finest_interval, &parquet_path)
-                        .await?
-                };
-                if let Some((lo, _hi)) = span
-                    && let Some(f) = frontier
-                    && lo < f
-                {
-                    return Err(tinyfs::Error::Other(format!(
-                        "temporal-reduce rollup: source node {} version {} backfills \
-                         already-sealed buckets (earliest bucket {} precedes frontier \
-                         {}); an overlapping non-series input breaks incremental partial \
-                         summation. Re-run the export with --rebuild to recompute the \
-                         rollup cache from scratch.",
-                        source_node_id, version.version, lo, f
-                    )));
-                }
-                self.write_version_partial(
-                    &pieces,
-                    finest_interval,
-                    &glob_dir,
-                    &source_node_id,
-                    version,
-                    &parquet_path,
-                )
-                .await?;
-                // Advance and persist the frontier only after the partial is
-                // durably written, so a later violation in this loop cannot
-                // strand an unrecorded sealed bucket: on retry the persisted
-                // frontier still reflects every version already cached.
-                if let Some((_lo, hi)) = span {
-                    let advanced = frontier.map_or(hi, |f| f.max(hi));
-                    if frontier != Some(advanced) {
-                        frontier = Some(advanced);
-                        crate::rollup_cache::write_frontier(&glob_dir, &source_node_id, advanced)
-                            .map_other()?;
-                    }
-                }
+            if !is_series && versions.len() > 1 {
+                return Err(tinyfs::Error::Other(format!(
+                    "temporal-reduce rollup: source '{}' is a non-series file with \
+                     {} live versions. Each version is a full re-snapshot, so they \
+                     overlap and cannot be aggregated together without \
+                     double-counting. Use a series entry type for incrementally \
+                     appended data, or reduce a single-version source.",
+                    node_path.path().display(),
+                    versions.len()
+                )));
             }
 
-            // Collected after the writes above, so newly written partials are
-            // included. Node scoped: a sibling source node's partials in this
-            // shared directory belong to its own live set, not this one's.
-            live_partials.extend(partials.cached_set(&live, |_| true));
+            for v in &versions {
+                let _ = now.insert(source_version_key(&source_node_id, v), source_range(v));
+            }
+            source_nodes.push((source_node_id, versions));
         }
 
         let ctx = &context.datafusion_session;
@@ -673,13 +613,7 @@ impl TemporalReduceSqlFile {
             .chars()
             .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
             .collect();
-        let partials_table = format!("__rollup_partials_{}_{}", cfg_hash, sanitized_id);
-        if !ctx.table_exist(partials_table.as_str()).unwrap_or(false) {
-            let provider = live_partials.table_provider().await.map_other()?;
-            _ = ctx
-                .register_table(partials_table.as_str(), provider)
-                .map_other()?;
-        }
+        let source_table = format!("__rollup_source_{}_{}", cfg_hash, sanitized_id);
 
         let ts = filled.time_column.clone();
 
@@ -689,11 +623,10 @@ impl TemporalReduceSqlFile {
         // per-build cost is bounded to ~allowed_lateness instead of all history.
         //
         // Resolutions form a nesting chain (finest .. coarsest). The finest
-        // resolution folds the shared finest partials directly; every coarser
-        // resolution is built by folding the *next-finer resolution's* runs +
-        // hot (exponentially less input than rescanning the finest partials),
-        // which is exact because the stored partials are associative and the
-        // intervals nest. We build the chain finest-first up to this file's
+        // resolution aggregates the SOURCE directly; every coarser resolution is
+        // built by folding the *next-finer resolution's* runs + hot
+        // (exponentially less input than rescanning the source), which is exact
+        // because the stored partials are associative and the intervals nest. We build the chain finest-first up to this file's
         // resolution, so a consumer of any resolution transparently materializes
         // the finer levels it depends on. Each level reuses its cache when
         // unchanged, so this is cheap after the first cold build.
@@ -718,15 +651,18 @@ impl TemporalReduceSqlFile {
         for (idx, level) in levels.iter().copied().enumerate() {
             let res_dir = crate::rollup_cache::sealed_res_dir(&merged_dir, level.as_secs());
             let built = if idx == 0 {
-                // Finest resolution: fold the shared finest partials.
-                self.build_level_from_partials(
+                // Finest resolution: aggregate the sources directly.
+                self.build_level_from_source(
                     ctx,
                     &pieces,
                     &ts,
                     level,
                     &res_dir,
-                    &partials_table,
-                    &glob_dir,
+                    &cache_dir,
+                    scheme,
+                    &source_nodes,
+                    &now,
+                    &source_table,
                     policy,
                 )
                 .await?
@@ -821,135 +757,6 @@ impl TemporalReduceSqlFile {
         )?;
 
         Ok(Some(table_provider))
-    }
-
-    /// Compute the finest-interval `time_bucket` span [min, max] of one cached
-    /// source version, in the timestamp unit cast to `i64`. Returns `None` when
-    /// the version contributes no non-null timestamps, in which case it neither
-    /// advances nor is checked against the sequentiality frontier. The unit is
-    /// consistent across all versions of one source node, so comparing these
-    /// spans against a per-node frontier is well defined.
-    async fn version_bucket_span(
-        &self,
-        finest_interval: Duration,
-        parquet_path: &std::path::Path,
-    ) -> TinyFSResult<Option<(i64, i64)>> {
-        let ctx = datafusion::prelude::SessionContext::new();
-        let table = "__src_version";
-        ctx.register_parquet(
-            table,
-            parquet_path.to_string_lossy().as_ref(),
-            datafusion::prelude::ParquetReadOptions::default(),
-        )
-        .await
-        .map_other_context(format!(
-            "register cached parquet '{}'",
-            parquet_path.display()
-        ))?;
-
-        let interval = duration_to_sql_interval(finest_interval);
-        let bin = date_bin_expr(&interval, &self.config.time_column);
-        let ts = &self.config.time_column;
-        let span_sql = format!(
-            "SELECT CAST(MIN({bin}) AS BIGINT) AS lo, CAST(MAX({bin}) AS BIGINT) AS hi \
-             FROM {table} WHERE {ts} IS NOT NULL"
-        );
-        let batches = ctx
-            .sql(&span_sql)
-            .await
-            .map_other_context("rollup span SQL planning failed")?
-            .collect()
-            .await
-            .map_other_context("rollup span SQL execution failed")?;
-
-        for batch in &batches {
-            if batch.num_rows() == 0 {
-                continue;
-            }
-            let lo = batch
-                .column(0)
-                .as_any()
-                .downcast_ref::<arrow::array::Int64Array>();
-            let hi = batch
-                .column(1)
-                .as_any()
-                .downcast_ref::<arrow::array::Int64Array>();
-            if let (Some(lo), Some(hi)) = (lo, hi) {
-                use arrow::array::Array;
-                if lo.is_null(0) || hi.is_null(0) {
-                    return Ok(None);
-                }
-                return Ok(Some((lo.value(0), hi.value(0))));
-            }
-        }
-        Ok(None)
-    }
-
-    /// Compute the earliest output-interval bucket touched by a set of freshly
-    /// written partial files. Returns `(native_lo, secs_lo)` where `native_lo`
-    /// is `CAST(date_bin(out, time_bucket) AS BIGINT)` in the timestamp's native
-    /// unit, used as the internal splice point, and `secs_lo` is the same bucket
-    /// as epoch seconds via `EXTRACT(EPOCH FROM ...)`, published in the export
-    /// hint so the export layer can compare against Hive partition path times
-    /// without knowing the timestamp's storage unit.
-    ///
-    /// Returns `None` only when none of the partials contribute a non-null
-    /// bucket. This lower bound (`dirty_lo`) is the splice point for the
-    /// merged-output cache: every output bucket strictly before it is unchanged
-    /// because no new partial falls into it, so it is reused from the cache.
-    async fn min_output_bucket(
-        &self,
-        partial_paths: &[std::path::PathBuf],
-        output_interval: Duration,
-    ) -> TinyFSResult<Option<(i64, i64)>> {
-        let interval = duration_to_sql_interval(output_interval);
-        let bin = date_bin_expr(&interval, "time_bucket");
-        let mut global: Option<(i64, i64)> = None;
-        for path in partial_paths {
-            let ctx = datafusion::prelude::SessionContext::new();
-            let table = "__new_partial";
-            ctx.register_parquet(
-                table,
-                path.to_string_lossy().as_ref(),
-                datafusion::prelude::ParquetReadOptions::default(),
-            )
-            .await
-            .map_other_context(format!("register new partial '{}'", path.display()))?;
-            let sql = format!(
-                "SELECT CAST(MIN({bin}) AS BIGINT) AS lo, \
-                        CAST(MIN(EXTRACT(EPOCH FROM {bin})) AS BIGINT) AS lo_secs \
-                 FROM {table}"
-            );
-            let batches = ctx
-                .sql(&sql)
-                .await
-                .map_other_context("min-output-bucket SQL planning failed")?
-                .collect()
-                .await
-                .map_other_context("min-output-bucket SQL execution failed")?;
-            for batch in &batches {
-                if batch.num_rows() == 0 {
-                    continue;
-                }
-                let lo = batch
-                    .column(0)
-                    .as_any()
-                    .downcast_ref::<arrow::array::Int64Array>();
-                let lo_secs = batch
-                    .column(1)
-                    .as_any()
-                    .downcast_ref::<arrow::array::Int64Array>();
-                if let (Some(lo), Some(lo_secs)) = (lo, lo_secs) {
-                    use arrow::array::Array;
-                    if !lo.is_null(0) && !lo_secs.is_null(0) {
-                        let v = (lo.value(0), lo_secs.value(0));
-                        global =
-                            Some(global.map_or(v, |g: (i64, i64)| if v.0 < g.0 { v } else { g }));
-                    }
-                }
-            }
-        }
-        Ok(global)
     }
 
     /// Newest output-bucket start (epoch seconds) over `table`, re-binning its
@@ -1178,21 +985,32 @@ impl TemporalReduceSqlFile {
         Ok(superseded)
     }
 
-    /// Build the finest resolution level by folding the shared finest partials.
-    /// Freshness is keyed on the partial member set (`covered`): unchanged →
-    /// Reuse; an append-only superset → Incremental (advance watermark, seal,
-    /// recompute hot); any other shape → Rebuild. A backfill older than the
-    /// sealed watermark is a hard error (§5).
+    /// Build the finest resolution level by aggregating the SOURCE directly.
+    ///
+    /// Freshness is keyed on source CONTENT: `sources` maps the blake3 of each
+    /// live source version to the event-time range it covers. Unchanged means
+    /// Reuse; any difference means Incremental over the dirty range; no
+    /// compatible manifest means Rebuild.
+    ///
+    /// There is no per-version partial cache. The cached source Parquets are
+    /// aggregated through a view, pruned to the versions whose recorded
+    /// `max_event_time` reaches the range being rebuilt. That prune is what the
+    /// partials were really buying -- "do not rescan old versions" -- and it
+    /// comes from data tlogfs already records, without a second file population
+    /// and without a cache keyed by a version number.
     #[allow(clippy::too_many_arguments)]
-    async fn build_level_from_partials(
+    async fn build_level_from_source(
         &self,
         ctx: &datafusion::prelude::SessionContext,
         pieces: &AggSqlPieces,
         ts: &str,
         output_interval: Duration,
         res_dir: &std::path::Path,
-        partials_table: &str,
-        glob_dir: &std::path::Path,
+        cache_dir: &std::path::Path,
+        scheme: &str,
+        source_nodes: &[(tinyfs::NodeID, Vec<tinyfs::FileVersionInfo>)],
+        now: &std::collections::BTreeMap<String, crate::rollup_cache::SourceRange>,
+        source_table: &str,
         policy: SealPolicy,
     ) -> TinyFSResult<LevelBuild> {
         let manifest = match crate::rollup_cache::read_sealed_manifest(res_dir).map_other()? {
@@ -1209,36 +1027,27 @@ impl TemporalReduceSqlFile {
             None => None,
         };
 
-        let current_members = crate::rollup_cache::list_glob_members(glob_dir).map_other()?;
-        let current_names: std::collections::BTreeSet<String> = current_members
-            .iter()
-            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
-            .collect();
-
         enum Plan {
             Reuse,
-            Incremental { dirty_lo_secs: Option<i64> },
+            /// Rebuild every output bucket at or after this event time (epoch
+            /// microseconds). `None` means the whole axis.
+            Incremental {
+                dirty_lo_us: Option<i64>,
+            },
             Rebuild,
         }
+
         let plan = match &manifest {
-            Some(m) if m.covered == current_names => Plan::Reuse,
-            Some(m) if m.covered.is_subset(&current_names) => {
-                let new_members: Vec<std::path::PathBuf> = current_members
-                    .iter()
-                    .filter(|p| {
-                        p.file_name()
-                            .map(|n| !m.covered.contains(n.to_string_lossy().as_ref()))
-                            .unwrap_or(false)
-                    })
-                    .cloned()
-                    .collect();
-                let dirty_lo_secs = self
-                    .min_output_bucket(&new_members, output_interval)
-                    .await?
-                    .map(|(_native, secs)| secs);
-                Plan::Incremental { dirty_lo_secs }
-            }
-            _ => Plan::Rebuild,
+            Some(m) if m.sources == *now => Plan::Reuse,
+            Some(m) => Plan::Incremental {
+                // The dirty range is driven by the SYMMETRIC difference, not
+                // just by additions. A digest that vanished matters as much as
+                // one that appeared: it means a version was collapsed away or
+                // deleted, and the buckets it contributed to must be recomputed
+                // from whatever now covers them.
+                dirty_lo_us: dirty_lo_us(&m.sources, now),
+            },
+            None => Plan::Rebuild,
         };
 
         if let Plan::Reuse = plan {
@@ -1256,25 +1065,23 @@ impl TemporalReduceSqlFile {
         }
 
         let rebuilt = matches!(plan, Plan::Rebuild);
-        let (mut m, changed_since) = match plan {
-            Plan::Incremental { dirty_lo_secs } => {
-                let m = manifest.expect("incremental implies a manifest");
-                // Hard-fail on data older than the sealed watermark: it would
-                // reopen an immutable bucket beyond allowed_lateness.
-                if let (Some(sealed_hi), Some(dl)) = (m.sealed_hi_secs, dirty_lo_secs)
-                    && dl < sealed_hi
-                {
-                    return Err(tinyfs::Error::Other(format!(
-                        "temporal-reduce rollup: source data backfills an \
-                         already-sealed bucket (earliest new output bucket {}s \
-                         precedes the sealed watermark {}s; allowed_lateness = \
-                         {}s). Data older than the watermark cannot reopen a \
-                         sealed run. Re-run the export with --rebuild to \
-                         recompute the rollup cache from scratch.",
-                        dl, sealed_hi, policy.lateness_secs
-                    )));
-                }
-                (m, dirty_lo_secs)
+        let (mut m, mut unsealed, changed_since) = match plan {
+            Plan::Incremental { dirty_lo_us } => {
+                let mut m = manifest.expect("incremental implies a manifest");
+                let dirty_lo_secs = dirty_lo_us.map(floor_us_to_secs);
+                // Late data is ordinary work now, not a --rebuild error. Buckets
+                // at or after the dirty point must be recomputed; those below
+                // sealed_hi live in immutable segments, so the segments covering
+                // them are UNSEALED -- dropped from the manifest and folded back
+                // into the hot window, which the seal path below recomputes from
+                // source and re-seals.
+                //
+                // This works only because segments are keyed by the bucket range
+                // they cover, so "which segments hold this instant" is a lookup.
+                // Under the old version-keyed layout there was no way to find
+                // them again, which is exactly why it had to error instead.
+                let unsealed = unseal_from(&mut m, dirty_lo_secs, res_dir)?;
+                (m, unsealed, dirty_lo_secs)
             }
             _ => {
                 crate::rollup_cache::wipe_sealed_res_dir(res_dir).map_other()?;
@@ -1284,32 +1091,76 @@ impl TemporalReduceSqlFile {
                         allowed_lateness_secs: policy.lateness_secs,
                         ..Default::default()
                     },
+                    Vec::new(),
                     None,
                 )
             }
         };
 
-        let superseded = self
-            .seal_and_recompute(
+        // Everything the build must be able to see: the hot window
+        // [sealed_hi, inf) plus the dirty range. Pruning below this is what
+        // keeps an incremental build off the whole history; pruning ABOVE it
+        // would silently drop contributing rows, so take the lower of the two.
+        let read_lo_us = match (m.sealed_hi_secs, changed_since) {
+            (Some(sealed_hi), Some(dirty_lo)) => Some(secs_to_us(sealed_hi.min(dirty_lo))),
+            // No watermark means every bucket is hot: read everything.
+            (None, _) => None,
+            (Some(sealed_hi), None) => Some(secs_to_us(sealed_hi)),
+        };
+
+        // Aggregate the sources into partial columns on the fly. This view is
+        // what `seal_and_recompute` folds, so it plays exactly the role the
+        // partials directory used to -- as a query, not as a file population.
+        let source_set = bounded_source_set(cache_dir, scheme, source_nodes, read_lo_us);
+        let provider = source_set.table_provider().await.map_other()?;
+        let available: std::collections::HashSet<String> = provider
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        if ctx.table_exist(source_table).unwrap_or(false) {
+            _ = ctx.deregister_table(source_table).map_other()?;
+        }
+        _ = ctx.register_table(source_table, provider).map_other()?;
+
+        let partials_view = format!("{}_partials", source_table);
+        let partial_sql = pieces.partial_sql(output_interval, ts, source_table, &available);
+        let build = async {
+            _ = ctx
+                .sql(&format!(
+                    "CREATE OR REPLACE VIEW {partials_view} AS {partial_sql}"
+                ))
+                .await
+                .map_other_context("rollup source partial view")?;
+            self.seal_and_recompute(
                 ctx,
                 pieces,
                 ts,
                 output_interval,
                 res_dir,
-                partials_table,
+                &partials_view,
                 "time_bucket",
                 &mut m,
                 policy,
             )
-            .await?;
-        m.covered = current_names;
+            .await
+        }
+        .await;
+        _ = ctx
+            .sql(&format!("DROP VIEW IF EXISTS {partials_view}"))
+            .await;
+        let superseded = build?;
+
+        m.sources = now.clone();
         m.source_digest = None;
 
         let digest = crate::rollup_cache::write_sealed_manifest(res_dir, &m)
             .await
             .map_other()?;
         // Only now that the manifest naming the merged runs is durable.
-        crate::rollup_cache::remove_superseded(&superseded).await;
+        unsealed.extend(superseded);
+        crate::rollup_cache::remove_superseded(&unsealed).await;
         let provider = crate::rollup_cache::listing_table_for_res_dir(res_dir, &m, ts)
             .await
             .map_other()?;
@@ -1413,7 +1264,7 @@ impl TemporalReduceSqlFile {
                 policy,
             )
             .await?;
-        m.covered = std::collections::BTreeSet::new();
+        m.sources.clear();
         m.source_digest = Some(finer_digest.to_string());
 
         let digest = crate::rollup_cache::write_sealed_manifest(res_dir, &m)
@@ -1465,57 +1316,6 @@ impl TemporalReduceSqlFile {
             .await
             .map_other()?;
         Ok((digest, rows.load(std::sync::atomic::Ordering::Relaxed)))
-    }
-
-    async fn write_version_partial(
-        &self,
-        pieces: &AggSqlPieces,
-        finest_interval: Duration,
-        glob_dir: &std::path::Path,
-        source_node_id: &tinyfs::NodeID,
-        version: &tinyfs::FileVersionInfo,
-        parquet_path: &std::path::Path,
-    ) -> TinyFSResult<()> {
-        let ctx = datafusion::prelude::SessionContext::new();
-        let table = "__src_version";
-        ctx.register_parquet(
-            table,
-            parquet_path.to_string_lossy().as_ref(),
-            datafusion::prelude::ParquetReadOptions::default(),
-        )
-        .await
-        .map_other_context(format!(
-            "register cached parquet '{}'",
-            parquet_path.display()
-        ))?;
-
-        let available: std::collections::HashSet<String> = ctx
-            .table(table)
-            .await
-            .map_other_context("read cached version schema")?
-            .schema()
-            .fields()
-            .iter()
-            .map(|f| f.name().clone())
-            .collect();
-
-        let partial_sql =
-            pieces.partial_sql(finest_interval, &self.config.time_column, table, &available);
-        let stream = ctx
-            .sql(&partial_sql)
-            .await
-            .map_other_context("rollup partial SQL planning failed")?
-            .execute_stream()
-            .await
-            .map_other_context("rollup partial SQL execution failed")?;
-
-        let schema = stream.schema();
-        let mapped = stream.map(|r| r.map_err(|e| crate::error::Error::Arrow(e.to_string())));
-        _ = crate::rollup_cache::partials_dir_at(glob_dir)
-            .write_sidecar(source_node_id, version, schema, Box::pin(mapped))
-            .await
-            .map_other()?;
-        Ok(())
     }
 
     /// Resolve this partition's `pattern_url` to concrete source file
@@ -2764,6 +2564,166 @@ register_dynamic_factory!(
     validate: validate_temporal_reduce_config
 );
 
+/// Content identity of one live source version: its blake3, qualified by node so
+/// two nodes with byte-identical versions stay distinct entries.
+///
+/// A version with no recorded blake3 falls back to node+version, which is
+/// unstable across a collapse and so degrades to "looks changed" -- a rebuild,
+/// never a stale reuse.
+fn source_version_key(node_id: &tinyfs::NodeID, v: &tinyfs::FileVersionInfo) -> String {
+    match &v.blake3 {
+        Some(h) => format!("{}:{}", node_id, h),
+        None => format!("{}:v{}", node_id, v.version),
+    }
+}
+
+/// Event-time range covered by one source version (epoch microseconds, `max`
+/// inclusive), from the bounds tlogfs records on a series version.
+///
+/// A version without recorded bounds gets the whole axis. That is not a special
+/// case to test for later: it makes any dirty range containing it unbounded, so
+/// the build falls back to reading everything -- correct, merely not pruned.
+fn source_range(v: &tinyfs::FileVersionInfo) -> crate::rollup_cache::SourceRange {
+    let md = v.extended_metadata.as_ref();
+    let get = |k: &str| {
+        md.and_then(|m| m.get(k))
+            .and_then(|s| s.parse::<i64>().ok())
+    };
+    match (get("min_event_time"), get("max_event_time")) {
+        (Some(min_us), Some(max_us)) => crate::rollup_cache::SourceRange { min_us, max_us },
+        _ => crate::rollup_cache::SourceRange::UNKNOWN,
+    }
+}
+
+/// Oldest event time (epoch µs) touched by the difference between the cached
+/// source set and the current one, or `None` if the difference reaches the
+/// beginning of time (or a version with no recorded range).
+///
+/// The SYMMETRIC difference matters: a digest that disappeared invalidates the
+/// buckets it fed just as much as a new one does.
+fn dirty_lo_us(
+    before: &std::collections::BTreeMap<String, crate::rollup_cache::SourceRange>,
+    after: &std::collections::BTreeMap<String, crate::rollup_cache::SourceRange>,
+) -> Option<i64> {
+    let mut lo: Option<i64> = None;
+    let mut note = |r: &crate::rollup_cache::SourceRange| {
+        lo = Some(match lo {
+            Some(cur) => cur.min(r.min_us),
+            None => r.min_us,
+        });
+    };
+    for (k, r) in after {
+        if before.get(k) != Some(r) {
+            note(r);
+        }
+    }
+    for (k, r) in before {
+        if !after.contains_key(k) {
+            note(r);
+        }
+    }
+    match lo {
+        Some(v) if v == i64::MIN => None,
+        other => other,
+    }
+}
+
+/// Fold every sealed segment that covers a bucket at or after `dirty_lo_secs`
+/// back into the hot window, returning their files (to delete once the manifest
+/// that no longer names them is durable).
+///
+/// This is how late data is handled. A backfill below the watermark used to be a
+/// hard error demanding `--rebuild`, because segments were keyed by which source
+/// versions produced them and there was no way to ask "which segments hold this
+/// instant". Segments are keyed by bucket range now, so that question is a
+/// lookup: drop the ones that answer it, lower `sealed_hi` to the oldest drop,
+/// and the ordinary seal path recomputes those buckets from source and re-seals
+/// them. No merge-in-place, no separate late-data path.
+///
+/// `dirty_lo_secs = None` means the dirty range reaches the beginning of time, so
+/// everything unseals -- which is a rebuild, expressed in the same terms.
+fn unseal_from(
+    m: &mut crate::rollup_cache::SealedManifest,
+    dirty_lo_secs: Option<i64>,
+    res_dir: &std::path::Path,
+) -> TinyFSResult<Vec<std::path::PathBuf>> {
+    // Nothing sealed reaches the dirty range: no unsealing to do.
+    let Some(sealed_hi) = m.sealed_hi_secs else {
+        return Ok(Vec::new());
+    };
+    if dirty_lo_secs.is_some_and(|lo| sealed_hi <= lo) {
+        return Ok(Vec::new());
+    }
+
+    // A segment covers [lo, hi); it is dirty iff it holds any bucket >= dirty_lo.
+    let dirty = |r: &crate::rollup_cache::SealedRun| match dirty_lo_secs {
+        Some(lo) => r.hi_secs > lo,
+        None => true,
+    };
+    let (dropped, kept): (Vec<_>, Vec<_>) = std::mem::take(&mut m.runs)
+        .into_iter()
+        .partition(|r| dirty(r));
+    m.runs = kept;
+
+    // The new watermark is the dirty point, lowered further to the bottom edge
+    // of any segment straddling it -- a segment is dropped whole, so everything
+    // it covered is hot again. A `None` bottom edge reached the beginning of
+    // time, so nothing stays sealed.
+    //
+    // This is computed from the dirty point rather than from the dropped
+    // segments alone, because the watermark can legitimately have advanced over
+    // a span that produced no segment file: sealing an empty range (a gap in the
+    // data) records the watermark and writes nothing. Deriving the new watermark
+    // only from dropped files would leave it above the dirty point with no
+    // segment covering the difference, silently losing those buckets.
+    let mut new_hi: Option<i64> = dirty_lo_secs;
+    let mut open_ended = dirty_lo_secs.is_none();
+    for r in &dropped {
+        match r.lo_secs {
+            Some(lo) => new_hi = Some(new_hi.map_or(lo, |cur: i64| cur.min(lo))),
+            None => open_ended = true,
+        }
+    }
+    m.sealed_hi_secs = if open_ended { None } else { new_hi };
+
+    // Those bytes are hot again, so account for them: the seal gate reads
+    // `hot_bytes` to decide whether freezing is worthwhile, and the next build
+    // rewrites exactly this much.
+    m.hot_bytes = m
+        .hot_bytes
+        .saturating_add(dropped.iter().map(|r| r.bytes).sum());
+
+    Ok(dropped
+        .iter()
+        .map(|r| crate::rollup_cache::run_path(res_dir, &r.name))
+        .collect())
+}
+
+/// The cached source Parquets to aggregate, pruned to versions that can reach
+/// `read_lo_us` (epoch µs). `None` reads every live version.
+fn bounded_source_set(
+    cache_dir: &std::path::Path,
+    scheme: &str,
+    source_nodes: &[(tinyfs::NodeID, Vec<tinyfs::FileVersionInfo>)],
+    read_lo_us: Option<i64>,
+) -> crate::version_cache::CachedSet {
+    let bounds = read_lo_us.map_or(tinyfs::SeriesReadBounds::NONE, |lo| {
+        tinyfs::SeriesReadBounds::from_event_time_lo(lo)
+    });
+    crate::format_cache::glob_cached_set_bounded(cache_dir, scheme, source_nodes, &bounds)
+}
+
+/// Epoch microseconds -> epoch seconds, rounding DOWN (toward -inf, so it holds
+/// for pre-epoch times too). Every µs->s conversion here widens the range it
+/// bounds, so a rounding error can only cause extra work, never dropped data.
+fn floor_us_to_secs(us: i64) -> i64 {
+    us.div_euclid(1_000_000)
+}
+
+fn secs_to_us(secs: i64) -> i64 {
+    secs.saturating_mul(1_000_000)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3792,8 +3752,17 @@ mod tests {
             rows
         }
 
-        fn count_rollup_partials(cache_dir: &std::path::Path) -> usize {
-            let mut count = 0;
+        /// Every cache file with its content digest, under `filter`ed dirs.
+        ///
+        /// Incrementality is asserted on this rather than on a file COUNT: a
+        /// count cannot tell reuse apart from recompute-and-overwrite, which is
+        /// exactly the failure worth catching now that the cache is a fixed
+        /// handful of files instead of one per source version.
+        fn cache_fingerprint(
+            cache_dir: &std::path::Path,
+            keep: &dyn Fn(&std::path::Path) -> bool,
+        ) -> Vec<(String, String)> {
+            let mut out = Vec::new();
             let mut stack = vec![cache_dir.to_path_buf()];
             while let Some(dir) = stack.pop() {
                 let Ok(entries) = std::fs::read_dir(&dir) else {
@@ -3803,18 +3772,17 @@ mod tests {
                     let path = entry.path();
                     if path.is_dir() {
                         stack.push(path);
-                    } else if path.extension().is_some_and(|e| e == "parquet")
-                        && path
-                            .parent()
-                            .and_then(|p| p.file_name())
-                            .and_then(|n| n.to_str())
-                            .is_some_and(|n| n.starts_with("rollup_"))
-                    {
-                        count += 1;
+                    } else if keep(&path) {
+                        let bytes = std::fs::read(&path).unwrap();
+                        out.push((
+                            path.strip_prefix(cache_dir).unwrap().display().to_string(),
+                            blake3::hash(&bytes).to_hex().to_string(),
+                        ));
                     }
                 }
             }
-            count
+            out.sort();
+            out
         }
 
         let tmp = tempfile::tempdir().unwrap();
@@ -3840,20 +3808,31 @@ mod tests {
         assert_eq!(tmin0, 20.5, "day0 min temp");
         assert_eq!(tmax0, 43.5, "day0 max temp");
 
-        // One partial per source file after the first read.
-        let partials_after_first = count_rollup_partials(&cache_dir);
-        assert_eq!(partials_after_first, 2, "one partial per source file");
+        // The cache names the content of both source files, and holds only the
+        // merged levels -- no per-source-version file population.
+        let all = |_: &std::path::Path| true;
+        let after_first = cache_fingerprint(&cache_dir, &all);
+        let manifests = walk_find(&cache_dir, &|n| n == "manifest.json");
+        assert_eq!(
+            manifests.len(),
+            1,
+            "one manifest, for the single resolution"
+        );
+        let m = crate::rollup_cache::read_sealed_manifest(manifests[0].parent().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.sources.len(), 2, "one source entry per source file");
 
         // A second read over an unchanged source, with a fresh session but the
-        // same cache directory, must reuse the cached partials: identical output
-        // and no newly-written partials.
+        // same cache directory, must REUSE: identical output, and not one cache
+        // byte rewritten.
         let cache_ctx2 = make_ctx(Some(cache_dir.clone()));
         let rollup_rows2 = collect_daily(&fs, &cache_ctx2, config()).await;
         assert_eq!(rollup_rows2, rollup_rows, "incremental read matches");
         assert_eq!(
-            count_rollup_partials(&cache_dir),
-            partials_after_first,
-            "second read must not recompute any partials"
+            cache_fingerprint(&cache_dir, &all),
+            after_first,
+            "second read over unchanged sources must not rewrite the cache"
         );
     }
 
@@ -3983,8 +3962,17 @@ mod tests {
             rows
         }
 
-        fn count_rollup_partials(cache_dir: &std::path::Path) -> usize {
-            let mut count = 0;
+        /// Every cache file with its content digest, under `filter`ed dirs.
+        ///
+        /// Incrementality is asserted on this rather than on a file COUNT: a
+        /// count cannot tell reuse apart from recompute-and-overwrite, which is
+        /// exactly the failure worth catching now that the cache is a fixed
+        /// handful of files instead of one per source version.
+        fn cache_fingerprint(
+            cache_dir: &std::path::Path,
+            keep: &dyn Fn(&std::path::Path) -> bool,
+        ) -> Vec<(String, String)> {
+            let mut out = Vec::new();
             let mut stack = vec![cache_dir.to_path_buf()];
             while let Some(dir) = stack.pop() {
                 let Ok(entries) = std::fs::read_dir(&dir) else {
@@ -3994,18 +3982,17 @@ mod tests {
                     let path = entry.path();
                     if path.is_dir() {
                         stack.push(path);
-                    } else if path.extension().is_some_and(|e| e == "parquet")
-                        && path
-                            .parent()
-                            .and_then(|p| p.file_name())
-                            .and_then(|n| n.to_str())
-                            .is_some_and(|n| n.starts_with("rollup_"))
-                    {
-                        count += 1;
+                    } else if keep(&path) {
+                        let bytes = std::fs::read(&path).unwrap();
+                        out.push((
+                            path.strip_prefix(cache_dir).unwrap().display().to_string(),
+                            blake3::hash(&bytes).to_hex().to_string(),
+                        ));
                     }
                 }
             }
-            count
+            out.sort();
+            out
         }
 
         let tmp = tempfile::tempdir().unwrap();
@@ -4014,20 +4001,23 @@ mod tests {
 
         // Read all three resolutions from the cascading rollup path.
         let hourly = collect_resolution(&cache_ctx, config(), "res=1h.series", "r_1h").await;
-        let partials_after_first_res = count_rollup_partials(&cache_dir);
+        // The finest level (res3600) is the only one that touches raw source.
+        let finest = |p: &std::path::Path| p.to_string_lossy().contains("res3600");
+        let finest_after_1h = cache_fingerprint(&cache_dir, &finest);
+        assert!(
+            !finest_after_1h.is_empty(),
+            "the finest resolution must be materialized"
+        );
         let six_hourly = collect_resolution(&cache_ctx, config(), "res=6h.series", "r_6h").await;
         let daily = collect_resolution(&cache_ctx, config(), "res=1d.series", "r_1d").await;
 
-        // Raw is scanned only once: the finest partials (one per source file)
-        // are shared, so reading coarser resolutions adds no new partials.
+        // Raw is scanned once. The coarser resolutions fold the finest level's
+        // output, so they must leave it byte-identical -- if a coarser read
+        // rewrote it, the cascade would be rescanning source per resolution.
         assert_eq!(
-            partials_after_first_res, 2,
-            "one finest partial per source file"
-        );
-        assert_eq!(
-            count_rollup_partials(&cache_dir),
-            2,
-            "coarser resolutions must reuse the shared finest partials"
+            cache_fingerprint(&cache_dir, &finest),
+            finest_after_1h,
+            "coarser resolutions must reuse the finest level untouched"
         );
 
         // Each cascaded resolution matches its single-pass output.
@@ -4112,8 +4102,9 @@ mod tests {
         let hots = walk_find(&cache_dir, &|n| n == "hot.parquet");
         assert_eq!(hots.len(), 3, "each level recomputes its own hot window");
 
-        // The finest level folds raw partials (source_digest == None); each
-        // coarser level records the finer manifest digest it folded.
+        // The finest level aggregates the sources (source_digest == None, and
+        // `sources` names their content); each coarser level records the finer
+        // manifest digest it folded instead.
         for m_path in &manifests {
             let res_dir = m_path.parent().unwrap();
             let secs: u64 = res_dir
@@ -4128,11 +4119,11 @@ mod tests {
             if secs == 3600 {
                 assert!(
                     m.source_digest.is_none(),
-                    "finest level folds shared partials, not a finer level"
+                    "finest level aggregates sources, not a finer level"
                 );
                 assert!(
-                    !m.covered.is_empty(),
-                    "finest level tracks its partial member set"
+                    !m.sources.is_empty(),
+                    "finest level tracks the content of its live source versions"
                 );
             } else {
                 assert!(
@@ -4141,6 +4132,124 @@ mod tests {
                 );
             }
         }
+    }
+
+    fn range(min_us: i64, max_us: i64) -> crate::rollup_cache::SourceRange {
+        crate::rollup_cache::SourceRange { min_us, max_us }
+    }
+
+    fn source_map(
+        entries: &[(&str, crate::rollup_cache::SourceRange)],
+    ) -> std::collections::BTreeMap<String, crate::rollup_cache::SourceRange> {
+        entries
+            .iter()
+            .map(|(k, r)| ((*k).to_string(), *r))
+            .collect()
+    }
+
+    /// The dirty point is driven by the SYMMETRIC difference of the source sets.
+    /// A version that DISAPPEARED -- collapsed away or deleted -- invalidates the
+    /// buckets it fed just as surely as a new one does, so keying only on
+    /// additions would serve output still containing its rows.
+    #[test]
+    fn test_dirty_lo_us_covers_both_directions() {
+        let a = range(1_000, 2_000);
+        let b = range(5_000, 6_000);
+        let c = range(9_000, 9_500);
+
+        let before = source_map(&[("a", a), ("b", b)]);
+
+        assert_eq!(
+            dirty_lo_us(&before, &before),
+            None,
+            "unchanged: no dirty range"
+        );
+
+        // Pure append: only the new version's span is dirty.
+        let appended = source_map(&[("a", a), ("b", b), ("c", c)]);
+        assert_eq!(dirty_lo_us(&before, &appended), Some(9_000));
+
+        // Removal: the vanished version's span is dirty even though nothing
+        // was added.
+        let removed = source_map(&[("a", a)]);
+        assert_eq!(dirty_lo_us(&before, &removed), Some(5_000));
+
+        // A collapse -- several versions replaced by one merged version with the
+        // same content -- is dirty over the whole span it replaces, and no
+        // further back.
+        let collapsed = source_map(&[("merged", range(1_000, 6_000))]);
+        assert_eq!(dirty_lo_us(&before, &collapsed), Some(1_000));
+
+        // A version with no recorded range makes the dirty range unbounded, so
+        // the build reads everything rather than pruning something it cannot
+        // prove is unaffected.
+        let unknown = source_map(&[
+            ("a", a),
+            ("b", b),
+            ("c", crate::rollup_cache::SourceRange::UNKNOWN),
+        ]);
+        assert_eq!(dirty_lo_us(&before, &unknown), None);
+    }
+
+    /// Late data unseals: segments covering the dirty point are dropped and the
+    /// watermark falls back to the bottom of the oldest one dropped, so the
+    /// ordinary seal path recomputes those buckets from source.
+    #[test]
+    fn test_unseal_from_drops_segments_covering_the_dirty_point() {
+        let seg = |name: &str, lo: Option<i64>, hi: i64| crate::rollup_cache::SealedRun {
+            name: name.to_string(),
+            lo_secs: lo,
+            hi_secs: hi,
+            digest: "d".to_string(),
+            bytes: 100,
+        };
+        let base = crate::rollup_cache::SealedManifest {
+            format: crate::rollup_cache::SEALED_FORMAT.to_string(),
+            sealed_hi_secs: Some(300),
+            runs: vec![
+                seg("run-0", None, 100),
+                seg("run-1", Some(100), 200),
+                seg("run-2", Some(200), 300),
+            ],
+            hot_bytes: 7,
+            ..Default::default()
+        };
+        let dir = std::path::Path::new("/tmp/unused");
+
+        // Dirty above the watermark: nothing sealed is affected.
+        let mut m = base.clone();
+        assert!(unseal_from(&mut m, Some(400), dir).unwrap().is_empty());
+        assert_eq!(m.runs.len(), 3);
+        assert_eq!(m.sealed_hi_secs, Some(300));
+
+        // Dirty inside the middle segment: it and everything after it are
+        // dropped, and the watermark falls to that segment's bottom -- not to
+        // the dirty point, because a segment is dropped whole.
+        let mut m = base.clone();
+        let dropped = unseal_from(&mut m, Some(150), dir).unwrap();
+        assert_eq!(dropped.len(), 2, "run-1 and run-2");
+        assert_eq!(m.runs.len(), 1);
+        assert_eq!(m.sealed_hi_secs, Some(100));
+        assert_eq!(m.hot_bytes, 207, "unsealed bytes are hot again");
+
+        // An unbounded dirty range unseals everything.
+        let mut m = base.clone();
+        let dropped = unseal_from(&mut m, None, dir).unwrap();
+        assert_eq!(dropped.len(), 3);
+        assert!(m.runs.is_empty());
+        assert_eq!(m.sealed_hi_secs, None);
+
+        // A watermark advanced over an empty span records no segment file. The
+        // watermark must still fall back to the dirty point, or the buckets
+        // between them would be neither sealed nor recomputed -- silently lost.
+        let mut m = crate::rollup_cache::SealedManifest {
+            sealed_hi_secs: Some(500),
+            runs: vec![seg("run-0", None, 100)],
+            ..Default::default()
+        };
+        let dropped = unseal_from(&mut m, Some(300), dir).unwrap();
+        assert!(dropped.is_empty(), "no segment covers [300, 500)");
+        assert_eq!(m.sealed_hi_secs, Some(300));
     }
 
     /// Phase 3: non-nesting resolution sets are rejected so cascaded rollups can
@@ -4157,13 +4266,18 @@ mod tests {
         assert_eq!(ok.first().copied(), Some(Duration::from_secs(3600)));
     }
 
-    /// Phase 4: a non-sequential source version, one that backfills buckets
-    /// already sealed by an earlier version, is a hard error on the incremental
-    /// path rather than a silent double-count. A single source file is written
-    /// twice: the first version holds only day 2, the second is a full rewrite
-    /// that prepends day 1, regressing the input min-ts below the frontier.
+    /// A non-series source with more than one live version is a hard error
+    /// rather than a silent double-count: each version is a full re-snapshot, so
+    /// summing them counts the overlapping rows twice. A single CSV is written
+    /// twice; the second version is a full rewrite that also prepends a day.
+    ///
+    /// This used to be phrased as a *sequentiality* check -- scan each version's
+    /// bucket span and fail if it reached below a persisted frontier -- which
+    /// tested the data for a property fixed by the entry type, and needed a
+    /// sidecar file to remember. The structural test reports the same case, and
+    /// reports it before reading a single row.
     #[tokio::test]
-    async fn test_rollup_rejects_non_sequential_version() {
+    async fn test_rollup_rejects_multi_version_non_series_source() {
         let _ = env_logger::try_init();
 
         let persistence = tinyfs::MemoryPersistence::default();
@@ -4244,11 +4358,11 @@ mod tests {
             .as_table_provider(file_id, &provider_context)
             .await;
 
-        let err = result.expect_err("non-sequential version must be a hard error");
+        let err = result.expect_err("overlapping re-snapshots must be a hard error");
         let msg = err.to_string();
         assert!(
-            msg.contains("backfills") && msg.contains("--rebuild"),
-            "error must explain the violation and suggest --rebuild, got: {}",
+            msg.contains("non-series") && msg.contains("double-counting"),
+            "error must name the overlap and why it is refused, got: {}",
             msg
         );
     }
@@ -4256,9 +4370,9 @@ mod tests {
     /// A FilePhysicalSeries source appends disjoint deltas, so a later version
     /// carrying EARLIER timestamps (late / out-of-order data, e.g. a collector
     /// flushing a buffered sample after a newer one) must merge correctly rather
-    /// than tripping the sequentiality frontier. The frontier guard only applies
-    /// to overlapping non-series sources; for series the per-version partials are
-    /// disjoint and the GROUP BY time_bucket merge is order-independent.
+    /// than being refused. The overlap guard applies only to non-series sources;
+    /// series versions are disjoint deltas and the GROUP BY time_bucket merge is
+    /// order-independent.
     #[tokio::test]
     async fn test_rollup_series_tolerates_late_data() {
         let _ = env_logger::try_init();
@@ -4394,11 +4508,13 @@ mod tests {
         );
     }
 
-    /// Merged-output cache incremental splice: after a first build seeds the
-    /// cache, a later build that appends a NEWER version splices the cached
-    /// prefix with a freshly merged suffix. A build that BACKFILLS a version
-    /// older than the sealed watermark (beyond allowed_lateness) is a hard error
-    /// suggesting --rebuild, since it would reopen an immutable sealed run.
+    /// Merged-output cache across the three shapes of a rebuild: seed, APPEND a
+    /// newer version, and BACKFILL one older than everything already built.
+    ///
+    /// The backfill is the point. It was a hard error suggesting `--rebuild`
+    /// until segments were keyed by the bucket range they cover; now the
+    /// segments holding the backfilled buckets are unsealed and recomputed, and
+    /// the output is simply correct.
     #[tokio::test]
     async fn test_merged_cache_incremental_splice_append_and_backfill() {
         let _ = env_logger::try_init();
@@ -4555,47 +4671,38 @@ mod tests {
             hint1.digest, hint2.digest,
             "append changes the merged digest"
         );
-        let day3_secs = 2 * 86400; // 1970-01-03T00:00:00Z
-        assert_eq!(
-            hint2.changed_since,
-            Some(day3_secs),
-            "append splice watermark should be day 3 in epoch seconds"
+        // `changed_since` is derived from the event-time range tlogfs records on
+        // each source version. MemoryPersistence records none, so every version
+        // reports an unknown range and the dirty range is the whole axis -- the
+        // export rewrites everything. Correct, merely unoptimized; `dirty_lo_us`
+        // is unit-tested directly on known ranges. What matters here is that the
+        // unknown case degrades to MORE work, never to stale output.
+        assert!(
+            hint2.changed_since.is_none(),
+            "sources with no recorded event range must widen the dirty range, \
+             not narrow it: {:?}",
+            hint2.changed_since
         );
 
-        // Build 3 (BACKFILL beyond the lateness window): add day 1 (earliest).
-        // With the default allowed_lateness of 1 day, day 2 has already been
-        // sealed (watermark = day2), so day-1 data would reopen an immutable
-        // sealed bucket. The new contract is a hard error suggesting --rebuild,
-        // not a silent unbounded backfill.
+        // Build 3 (BACKFILL): add day 1, older than everything already built and
+        // potentially below the sealed watermark. This used to be a hard error
+        // demanding --rebuild, because segments were keyed by the source versions
+        // that produced them and there was no way to find which held day 1.
+        // Segments are keyed by bucket range now, so the affected ones are simply
+        // unsealed and recomputed.
         {
             let root = fs.root().await.unwrap();
             append_day(&root, "/ingest/weather.csv", 1).await;
         }
-        let provider_context = make_ctx(Some(cache_dir.clone()));
-        let context = test_context(&provider_context, FileID::root());
-        let temporal_dir = TemporalReduceDirectory::new(config(), context).unwrap();
-        let temporal_handle = temporal_dir.create_handle();
-        let weather_node = temporal_handle.get("weather").await.unwrap().unwrap();
-        let NodeType::Directory(weather_dir) = &weather_node.node_type else {
-            panic!("expected directory");
-        };
-        let daily_node = weather_dir.get("res=1d.series").await.unwrap().unwrap();
-        let file_id = daily_node.id;
-        let NodeType::File(file_handle) = &daily_node.node_type else {
-            panic!("expected file node");
-        };
-        let file_arc = file_handle.get_file().await;
-        let file_guard = file_arc.lock().await;
-        let queryable = file_guard.as_queryable().expect("queryable");
-        let err = queryable
-            .as_table_provider(file_id, &provider_context)
-            .await
-            .expect_err("backfill beyond allowed_lateness must hard-fail");
-        let msg = err.to_string();
+        let (rows3, hint3) = collect_daily(&make_ctx(Some(cache_dir.clone())), config()).await;
+        assert_eq!(rows3.len(), 3, "backfill adds a bucket, got {:?}", rows3);
         assert!(
-            msg.contains("sealed") && msg.contains("--rebuild"),
-            "backfill error should mention the sealed watermark and --rebuild: {msg}"
+            approx(rows3[0].0, 132.0) && approx(rows3[1].0, 232.0) && approx(rows3[2].0, 332.0),
+            "backfill values wrong (a double-count would inflate these): {:?}",
+            rows3
         );
+        let hint3 = hint3.expect("build 3 publishes an export hint");
+        assert_ne!(hint2.digest, hint3.digest, "backfill changes the digest");
     }
 
     /// Regression: partials are shared by every resolution, so when a later
@@ -5382,13 +5489,18 @@ mod tests {
             .await
             .unwrap();
         }
+        // At least one sealed run plus the hot file, i.e. two separately-ordered
+        // inputs -- which is what the k-way merge has to reconcile. Only one run
+        // survives here: MemoryPersistence records no event-time bounds, so every
+        // source version reports an unknown range, every build's dirty range is
+        // the whole axis, and the sealed segments are unsealed and re-sealed as
+        // one. Under tlogfs the bounds are recorded and segments accumulate.
         let runs = walk_find(&cache_dir, &|n| {
             n.starts_with("run-") && n.ends_with(".parquet")
         });
         assert!(
-            runs.len() >= 2,
-            "test needs multiple sealed runs to exercise the merge, got {}",
-            runs.len()
+            !runs.is_empty(),
+            "test needs a sealed run plus hot to exercise the merge, got none"
         );
 
         // Acquire the reduced table provider (built during the last rollup).

--- a/crates/provider/src/factory/temporal_reduce.rs
+++ b/crates/provider/src/factory/temporal_reduce.rs
@@ -287,6 +287,21 @@ impl LevelChange {
             LevelChange::Nothing | LevelChange::Everything => None,
         }
     }
+
+    /// The lower -- i.e. more inclusive -- of two dirty ranges.
+    ///
+    /// [`LevelChange::Everything`] absorbs anything, [`LevelChange::Nothing`] is
+    /// the identity, and two bounded ranges keep the earlier point. Used where a
+    /// level has more than one independent reason to believe its sealed history
+    /// is stale and must honour all of them at once.
+    fn min(self, other: LevelChange) -> LevelChange {
+        match (self, other) {
+            (LevelChange::Everything, _) | (_, LevelChange::Everything) => LevelChange::Everything,
+            (LevelChange::Nothing, o) => o,
+            (s, LevelChange::Nothing) => s,
+            (LevelChange::Since(a), LevelChange::Since(b)) => LevelChange::Since(a.min(b)),
+        }
+    }
 }
 
 pub struct TemporalReduceSqlFile {
@@ -737,6 +752,7 @@ impl TemporalReduceSqlFile {
                         &finer_digest,
                         finer_rebuilt,
                         finer_changed,
+                        &now,
                         policy,
                     )
                     .await;
@@ -777,13 +793,18 @@ impl TemporalReduceSqlFile {
             .register_table(read_name.as_str(), table_provider)
             .map_other()?;
         let recon_sql = pieces.reconstruct_sql(&ts, &read_name);
-        let recon_plan = ctx
-            .sql(&recon_sql)
-            .await
-            .map_other_context("rollup reconstruction planning failed")?
-            .logical_plan()
-            .clone();
-        let _ = ctx.deregister_table(read_name.as_str()).map_other()?;
+        // Deregister before propagating: read_name is deterministic in
+        // cfg_hash/node/resolution, so leaving it behind on the shared session
+        // turns one transient planning failure into a permanent duplicate-name
+        // error for this resolution.
+        let recon_plan = {
+            let out = ctx
+                .sql(&recon_sql)
+                .await
+                .map_other_context("rollup reconstruction planning failed");
+            let _ = ctx.deregister_table(read_name.as_str()).map_other()?;
+            out?.logical_plan().clone()
+        };
         let table_provider: Arc<dyn datafusion::catalog::TableProvider> = Arc::new(
             datafusion::catalog::view::ViewTable::new(recon_plan, Some(recon_sql)),
         );
@@ -1273,6 +1294,12 @@ impl TemporalReduceSqlFile {
     /// watermark holding pre-backfill values forever. This level therefore
     /// unseals from the same point, or unseals entirely when the finer level's
     /// dirty range was unbounded.
+    ///
+    /// `finer_changed` alone is not sufficient, however: it reports only what
+    /// moved in THIS call, and a sibling output file's earlier build may already
+    /// have consumed the finer level's change. This level therefore ALSO
+    /// compares `now` against the source set it last folded and unseals from
+    /// whichever of the two points is lower.
     #[allow(clippy::too_many_arguments)]
     async fn build_level_from_finer(
         &self,
@@ -1285,6 +1312,7 @@ impl TemporalReduceSqlFile {
         finer_digest: &str,
         finer_rebuilt: bool,
         finer_changed: LevelChange,
+        now: &std::collections::BTreeMap<String, crate::rollup_cache::SourceRange>,
         policy: SealPolicy,
     ) -> TinyFSResult<LevelBuild> {
         let manifest =
@@ -1326,21 +1354,59 @@ impl TemporalReduceSqlFile {
         let can_advance = !finer_rebuilt && manifest.is_some();
         let (mut m, mut unsealed, changed, rebuilt) = if can_advance {
             let mut m = manifest.expect("can_advance implies a manifest");
+            // This level has TWO independent reasons to distrust its sealed
+            // history, and must honour the lower of them.
+            //
+            // (1) `finer_changed`: what the finer level moved in THIS call.
+            //
+            // (2) The source content this level last folded versus what is live
+            //     now. This is not implied by (1). Each output file
+            //     (`res=1h.series`, `res=1d.series`) is a separate build over
+            //     the same cache, and the finer level's change is consumed by
+            //     whichever build runs first: by the time the coarse file is
+            //     built, the finest level legitimately reports `Nothing` -- it
+            //     is unchanged since a moment ago -- while THIS level has never
+            //     folded the backfill. The same gap opens whenever a previous
+            //     build failed between the finer level's manifest write and
+            //     this one's.
+            //
+            //     Keying only on (1) would advance in place, recompute only the
+            //     hot window `[sealed_hi, inf)`, and then record the new finer
+            //     digest -- marking itself fresh forever while every sealed
+            //     bucket below the watermark keeps its pre-backfill value.
+            //
+            // Computing (2) from the same symmetric difference the finest level
+            // uses is what makes each level's freshness self-sufficient: it does
+            // not depend on which files are built, in what order, or on how many
+            // finer-level changes have been consumed since this level last ran.
+            let source_changed = if m.sources == *now {
+                LevelChange::Nothing
+            } else {
+                match dirty_lo_us(&m.sources, now) {
+                    Some(us) => LevelChange::Since(floor_secs_to_bucket(
+                        floor_us_to_secs(us),
+                        output_interval,
+                    )),
+                    // An unbounded dirty range is the whole axis, not "nothing".
+                    None => LevelChange::Everything,
+                }
+            };
+            // Align to OUR (coarser) bucket: a watermark must be a bucket
+            // boundary or the bucket straddling it belongs to neither the
+            // sealed nor the hot side. See `floor_secs_to_bucket`.
+            let dirty = match finer_changed {
+                LevelChange::Since(lo) => {
+                    LevelChange::Since(floor_secs_to_bucket(lo, output_interval))
+                }
+                other => other,
+            }
+            .min(source_changed);
             // Late data at the finest level lowered ITS watermark; ours must
             // follow, or our segments keep their pre-backfill values forever.
-            // Align to our own (coarser) bucket so the watermark stays a bucket
-            // boundary -- see `floor_secs_to_bucket`.
-            let unsealed = match finer_changed {
+            let unsealed = match dirty {
                 // Nothing below our watermark moved, so our segments stand.
                 LevelChange::Nothing => Vec::new(),
-                // Align to OUR (coarser) bucket: a watermark must be a bucket
-                // boundary or the bucket straddling it belongs to neither the
-                // sealed nor the hot side. See `floor_secs_to_bucket`.
-                LevelChange::Since(lo) => unseal_from(
-                    &mut m,
-                    Some(floor_secs_to_bucket(lo, output_interval)),
-                    res_dir,
-                )?,
+                LevelChange::Since(lo) => unseal_from(&mut m, Some(lo), res_dir)?,
                 // Unbounded: unseal everything.
                 LevelChange::Everything => unseal_from(&mut m, None, res_dir)?,
             };
@@ -1378,7 +1444,7 @@ impl TemporalReduceSqlFile {
                 policy,
             )
             .await?;
-        m.sources.clear();
+        m.sources = now.clone();
         m.source_digest = Some(finer_digest.to_string());
 
         let digest = crate::rollup_cache::write_segment_manifest(res_dir, &m)
@@ -5606,6 +5672,152 @@ mod tests {
             "within-window backfill values wrong: {:?}",
             rows
         );
+    }
+
+    /// Regression: a coarse level must unseal on a backfill even when the finer
+    /// level's change was already consumed by a SIBLING output file's build.
+    ///
+    /// Each output file is a separate build over the shared cache, and
+    /// `res=1h.series` is read before `res=1d.series` here. The 1h build
+    /// unseals and absorbs the backfill; the 1d build that follows therefore
+    /// sees the 1h level report `Nothing` -- it genuinely did not move in that
+    /// call -- while the 1d level has never folded the backfilled day.
+    ///
+    /// Keying the 1d level's unsealing on the finer level's in-call change alone
+    /// made it advance in place, recompute only its hot window, and record the
+    /// new finer digest, marking itself fresh forever with the backfilled day
+    /// missing from its sealed history. It now also compares the live source set
+    /// against the one it last folded, so the staleness is visible to it
+    /// directly.
+    #[tokio::test]
+    async fn test_coarse_unseals_backfill_consumed_by_sibling_build() {
+        let _ = env_logger::try_init();
+        let persistence = tinyfs::MemoryPersistence::default();
+        let fs = tinyfs::FS::new(persistence.clone()).await.unwrap();
+        {
+            let root = fs.root().await.unwrap();
+            _ = root.create_dir_path("/ingest").await.unwrap();
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+
+        // Both resolutions, so the 1d level is built by folding the 1h level.
+        // Zero lateness plus a zero seal target puts everything below the
+        // newest bucket into sealed segments, which is where the defect hides:
+        // a hot-window recompute alone cannot repair a sealed bucket.
+        let config = || TemporalReduceConfig {
+            resolutions: vec!["1h".to_string(), "1d".to_string()],
+            ..lateness_config(Some("0s"))
+        };
+
+        async fn sums(
+            provider_context: &crate::ProviderContext,
+            config: TemporalReduceConfig,
+            res_file: &str,
+        ) -> Vec<f64> {
+            let context = test_context(provider_context, FileID::root());
+            let temporal_dir = TemporalReduceDirectory::new(config, context).unwrap();
+            let temporal_handle = temporal_dir.create_handle();
+            let weather_node = temporal_handle.get("weather").await.unwrap().unwrap();
+            let NodeType::Directory(weather_dir) = &weather_node.node_type else {
+                panic!("expected directory");
+            };
+            let node = weather_dir.get(res_file).await.unwrap().unwrap();
+            let file_id = node.id;
+            let NodeType::File(file_handle) = &node.node_type else {
+                panic!("expected file node");
+            };
+            let file_arc = file_handle.get_file().await;
+            let file_guard = file_arc.lock().await;
+            let queryable = file_guard.as_queryable().expect("queryable");
+            let table_provider = queryable
+                .as_table_provider(file_id, provider_context)
+                .await
+                .expect("table provider");
+            drop(file_guard);
+            let ctx = &provider_context.datafusion_session;
+            let table = format!("t_{}", res_file.replace(['=', '.'], "_"));
+            _ = ctx.register_table(&table, table_provider).unwrap();
+            let batches = ctx
+                .sql(&format!(
+                    "SELECT \"temperature.sum\" FROM {} ORDER BY timestamp",
+                    table
+                ))
+                .await
+                .unwrap()
+                .collect()
+                .await
+                .unwrap();
+            let mut rows = Vec::new();
+            for b in &batches {
+                let col = b
+                    .column_by_name("temperature.sum")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .unwrap()
+                    .clone();
+                for i in 0..b.num_rows() {
+                    rows.push(col.value(i));
+                }
+            }
+            _ = ctx.deregister_table(&table).unwrap();
+            rows
+        }
+
+        // Seed both levels with days 3..=5, so the 1d level accumulates sealed
+        // segments well above the day the backfill will land in.
+        for day in 3..=5u32 {
+            append_day_series(&fs, "/ingest/weather.csv", day).await;
+        }
+        let seeded = sums(
+            &reduce_ctx(&persistence, &cache_dir),
+            config(),
+            "res=1d.series",
+        )
+        .await;
+        assert_eq!(seeded.len(), 3, "days 3..=5 seeded, got {:?}", seeded);
+        let _ = sums(
+            &reduce_ctx(&persistence, &cache_dir),
+            config(),
+            "res=1h.series",
+        )
+        .await;
+
+        // Backfill day 1: older than every sealed bucket in either level.
+        append_day_series(&fs, "/ingest/weather.csv", 1).await;
+
+        // The FINEST resolution is read first and consumes the change.
+        let ctx = reduce_ctx(&persistence, &cache_dir);
+        let hourly = sums(&ctx, config(), "res=1h.series").await;
+        assert_eq!(
+            hourly.len(),
+            24 * 4,
+            "four days of hourly buckets after the backfill, got {}",
+            hourly.len()
+        );
+
+        // The COARSE resolution is read second, in the same session. Its finer
+        // level now reports no change, but it has never folded day 1.
+        let daily = sums(&ctx, config(), "res=1d.series").await;
+        assert_eq!(
+            daily.len(),
+            4,
+            "coarse level dropped the backfilled day, which its sealed segments \
+             cannot repair by recomputing the hot window alone: {:?}",
+            daily
+        );
+        let approx = |a: f64, b: f64| (a - b).abs() < 1e-6;
+        for (i, day) in [1u32, 3, 4, 5].iter().copied().enumerate() {
+            assert!(
+                approx(daily[i], expected_day_sum(day)),
+                "coarse day {} sum wrong (a double-count inflates, a lost \
+                 segment deflates): got {}, want {}",
+                day,
+                daily[i],
+                expected_day_sum(day)
+            );
+        }
     }
 
     /// Changing `allowed_lateness` invalidates the sealed layout: the manifest

--- a/crates/provider/src/format_cache.rs
+++ b/crates/provider/src/format_cache.rs
@@ -61,6 +61,14 @@ pub fn cache_version_path(
 }
 
 /// Check which of a node's live versions are missing from the cache.
+///
+/// Adds only; never deletes. Use it when `versions` may be a SUBSET of the
+/// node's live versions -- notably the dynamic-file path, which synthesizes a
+/// single version from metadata because such nodes have no persistence records.
+/// Reconciling against a subset would delete the sidecars of every version not
+/// in it. Callers holding the full live set should use
+/// [`reconcile_cached_versions`] instead, so the cache stays a projection of
+/// what is live rather than growing forever.
 #[must_use]
 pub fn find_uncached_versions(
     cache_dir: &Path,
@@ -70,6 +78,42 @@ pub fn find_uncached_versions(
 ) -> Vec<FileVersionInfo> {
     let live = LiveVersions::from_persistence(*node_id, versions.to_vec());
     node_sidecars(cache_dir, scheme, node_id).missing(&live)
+}
+
+/// Make a node's cache directory a projection of its live versions: delete the
+/// sidecars of versions that are no longer live, and report which live versions
+/// still need writing.
+///
+/// This is the collection step the format cache never had. Every other property
+/// in this module's header held -- per-version files are immutable, so there was
+/// nothing to INVALIDATE -- but nothing ever removed them, so the directory grew
+/// by one Parquet for every version ever written and was never bounded. Version
+/// collapse makes that worse than mere disk cost: it replaces a run of versions
+/// with one merged version carrying the same content, so the superseded
+/// sidecars are duplicates of data the merged one already holds.
+///
+/// Reads are what keep it bounded, because reads are what happen. Deleting is
+/// safe: a sidecar is derived data, regenerable from the source version.
+///
+/// `versions` MUST be the node's complete live set, as returned by
+/// `list_file_versions`. Passing a subset deletes the rest.
+pub fn reconcile_cached_versions(
+    cache_dir: &Path,
+    scheme: &str,
+    node_id: &tinyfs::NodeID,
+    versions: &[FileVersionInfo],
+) -> Result<Vec<FileVersionInfo>> {
+    let live = LiveVersions::from_persistence(*node_id, versions.to_vec());
+    let rec = node_sidecars(cache_dir, scheme, node_id).reconcile(&live)?;
+    if !rec.removed.is_empty() {
+        log::debug!(
+            "[SWEEP] format cache: removed {} superseded sidecar(s) for {}_{}",
+            rec.removed.len(),
+            scheme,
+            node_id
+        );
+    }
+    Ok(rec.missing)
 }
 
 /// Write a single version's format output to cache as Parquet.
@@ -229,6 +273,73 @@ mod tests {
 
     fn test_node_id() -> tinyfs::NodeID {
         tinyfs::NodeID::new(uuid7::uuid7().to_string())
+    }
+
+    /// Reconciling retires the sidecars of versions that are no longer live and
+    /// reports nothing missing when every live version is already cached.
+    ///
+    /// This is the collection step the format cache lacked entirely: its files
+    /// are immutable, so there was never anything to invalidate, but nothing
+    /// removed them either and the directory grew by one Parquet per version
+    /// ever written. Collapse is what makes that a correctness concern and not
+    /// just disk: it replaces versions 1..3 with a single merged version, and
+    /// the superseded sidecars hold the very rows the merged one now carries.
+    #[tokio::test]
+    async fn reconcile_retires_sidecars_a_collapse_superseded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path();
+        let node_id = test_node_id();
+        let schema = test_schema();
+
+        let before = vec![
+            test_version(1, "h1"),
+            test_version(2, "h2"),
+            test_version(3, "h3"),
+        ];
+        for v in &before {
+            let batch = test_batch(&schema, &[v.version as i64], &["x"]);
+            let stream: crate::version_cache::BatchStream =
+                Box::pin(futures::stream::once(async move { Ok(batch) }));
+            let _ = cache_write_version(cache_dir, "csv", &node_id, v, schema.clone(), stream)
+                .await
+                .unwrap();
+        }
+        let dir = cache_node_dir(cache_dir, "csv", &node_id);
+        let count = |d: &Path| std::fs::read_dir(d).unwrap().count();
+        assert_eq!(count(&dir), 3, "three versions cached");
+
+        // A collapse merges 1..3 into one new, higher-numbered version with the
+        // same content. `list_file_versions` would now return only version 4.
+        let after = vec![test_version(4, "merged")];
+        let missing = reconcile_cached_versions(cache_dir, "csv", &node_id, &after).unwrap();
+
+        assert_eq!(
+            missing.len(),
+            1,
+            "the merged version is not cached yet, so it must be reported missing"
+        );
+        assert_eq!(missing[0].version, 4);
+        assert_eq!(
+            count(&dir),
+            0,
+            "all three superseded sidecars must be gone; a cache that only adds \
+             is how they survived to be double-counted"
+        );
+
+        // Cache the merged version, then reconcile again: steady state is a
+        // no-op, neither deleting a live sidecar nor reporting it missing.
+        let batch = test_batch(&schema, &[4], &["x"]);
+        let stream: crate::version_cache::BatchStream =
+            Box::pin(futures::stream::once(async move { Ok(batch) }));
+        let _ = cache_write_version(cache_dir, "csv", &node_id, &after[0], schema, stream)
+            .await
+            .unwrap();
+        let missing = reconcile_cached_versions(cache_dir, "csv", &node_id, &after).unwrap();
+        assert!(
+            missing.is_empty(),
+            "live cached version must not be missing"
+        );
+        assert_eq!(count(&dir), 1, "live sidecar must survive reconciliation");
     }
 
     #[test]

--- a/crates/provider/src/format_cache.rs
+++ b/crates/provider/src/format_cache.rs
@@ -139,7 +139,7 @@ pub async fn cache_write_version(
 /// without event-time bounds return `None` (and are always retained by an
 /// event-time bound -- a missing bound must never drop data).
 #[must_use]
-fn version_max_event_time(v: &FileVersionInfo) -> Option<i64> {
+pub fn version_max_event_time(v: &FileVersionInfo) -> Option<i64> {
     v.extended_metadata
         .as_ref()?
         .get("max_event_time")?
@@ -204,13 +204,34 @@ pub fn glob_cached_set(
     scheme: &str,
     nodes: &[(tinyfs::NodeID, Vec<FileVersionInfo>)],
 ) -> crate::version_cache::CachedSet {
+    glob_cached_set_bounded(cache_dir, scheme, nodes, &tinyfs::SeriesReadBounds::NONE)
+}
+
+/// [`glob_cached_set`], pruned by a per-version event-time bound.
+///
+/// The multi-node analogue of [`listing_table_from_cache_bounded`], and the
+/// reason the rollup needs no per-version partial cache: an incremental rebuild
+/// of recent buckets scans only the source versions that can reach them, which
+/// is the same "skip old inputs" property the partials directory provided, from
+/// metadata tlogfs already records.
+#[must_use]
+pub fn glob_cached_set_bounded(
+    cache_dir: &Path,
+    scheme: &str,
+    nodes: &[(tinyfs::NodeID, Vec<FileVersionInfo>)],
+    bounds: &tinyfs::SeriesReadBounds,
+) -> crate::version_cache::CachedSet {
     // Falls back to the cache root only for schema recovery when no member is
     // cached yet, which is the same "no data to describe" case the glob
     // directory reported as an error.
     let mut set = crate::version_cache::CachedSet::empty_in(cache_dir.to_path_buf());
     for (node_id, versions) in nodes {
         let live = LiveVersions::from_persistence(*node_id, versions.clone());
-        set.extend(node_sidecars(cache_dir, scheme, node_id).cached_set(&live, |_| true));
+        set.extend(
+            node_sidecars(cache_dir, scheme, node_id).cached_set(&live, |v| {
+                bounds.retains(version_max_event_time(v), v.version as i64)
+            }),
+        );
     }
     set
 }

--- a/crates/provider/src/format_cache.rs
+++ b/crates/provider/src/format_cache.rs
@@ -17,10 +17,6 @@
 
 use arrow::datatypes::SchemaRef;
 use datafusion::catalog::TableProvider;
-use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
-};
 use datafusion::execution::context::SessionContext;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -138,109 +134,41 @@ pub async fn listing_table_from_cache_bounded(
         .await
 }
 
-/// Directory for a glob-scoped unified cache (all files matching a pattern).
+/// The cached Parquets of the live versions of EVERY node matched by a glob,
+/// as one explicit [`CachedSet`].
 ///
-/// Returns `{cache_dir}/{scheme}_glob_{pattern_hash}/`
+/// Replaces a symlink farm. The former mechanism built
+/// `{cache_dir}/{scheme}_glob_{hash}/` full of symlinks to per-node cache files
+/// and then pointed a `ListingTable` at the DIRECTORY. That worked only while
+/// three separate conventions all held: the caller wiped the directory first,
+/// the versions handed in were live, and nothing else wrote there. Two call
+/// sites performed that ritual by hand, and the wipe-then-repopulate step raced
+/// any concurrent reader of the same pattern, which takes no lock.
+///
+/// Naming the files makes the guarantee structural instead of ritual, and it is
+/// the same mechanism the rollup uses to accumulate several source nodes into
+/// one scan. Schema evolution is preserved: [`CachedSet::table_provider`] merges
+/// schemas across exactly these files, so a column that appears only in some
+/// members is present and NULL-filled elsewhere (the UNION-ALL-BY-NAME property
+/// the glob directory existed to provide).
+///
+/// Each `versions` slice must be that node's LIVE versions, as returned by
+/// `list_file_versions`, which already hides collapse-superseded ones.
 #[must_use]
-pub fn cache_glob_dir(cache_dir: &Path, scheme: &str, pattern_hash: &str) -> PathBuf {
-    cache_dir.join(format!("{}_glob_{}", scheme, pattern_hash))
-}
-
-/// Compute a deterministic hash for a glob pattern string.
-#[must_use]
-pub fn pattern_hash(pattern: &str) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    pattern.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
-}
-
-/// Ensure symlinks exist in the glob directory for all cached versions of a node.
-///
-/// Creates symlinks from `{glob_dir}/{node_id}_v{version}_{blake3}.parquet`
-/// to the per-node cache directory files.
-///
-/// Returns the number of new symlinks created.
-pub fn ensure_glob_symlinks(
+pub fn glob_cached_set(
     cache_dir: &Path,
     scheme: &str,
-    node_id: &tinyfs::NodeID,
-    versions: &[FileVersionInfo],
-    glob_dir: &Path,
-) -> Result<usize> {
-    let mut created = 0;
-    for version in versions {
-        let source = cache_version_path(cache_dir, scheme, node_id, version);
-        if !source.exists() {
-            continue; // Skip versions not yet cached
-        }
-
-        let key = match version.blake3.as_deref() {
-            Some(hash) => hash.to_string(),
-            None => node_id.to_short_string(),
-        };
-        let link_name = glob_dir.join(format!("{}_v{}_{}.parquet", node_id, version.version, key));
-
-        if !link_name.exists() {
-            #[cfg(unix)]
-            {
-                std::os::unix::fs::symlink(&source, &link_name).map_err(crate::error::Error::Io)?;
-            }
-            #[cfg(not(unix))]
-            {
-                // On non-Unix, fall back to hard link or copy
-                std::fs::hard_link(&source, &link_name)
-                    .or_else(|_| std::fs::copy(&source, &link_name).map(|_| ()))
-                    .map_err(crate::error::Error::Io)?;
-            }
-            created += 1;
-        }
+    nodes: &[(tinyfs::NodeID, Vec<FileVersionInfo>)],
+) -> crate::version_cache::CachedSet {
+    // Falls back to the cache root only for schema recovery when no member is
+    // cached yet, which is the same "no data to describe" case the glob
+    // directory reported as an error.
+    let mut set = crate::version_cache::CachedSet::empty_in(cache_dir.to_path_buf());
+    for (node_id, versions) in nodes {
+        let live = LiveVersions::from_persistence(*node_id, versions.clone());
+        set.extend(node_sidecars(cache_dir, scheme, node_id).cached_set(&live, |_| true));
     }
-    Ok(created)
-}
-
-/// Clean a glob directory by removing all existing symlinks, then recreating it.
-///
-/// This is used before populating with fresh symlinks each query to ensure
-/// deleted versions or changed file sets are not stale.
-pub fn reset_glob_dir(glob_dir: &Path) -> Result<()> {
-    if glob_dir.exists() {
-        std::fs::remove_dir_all(glob_dir).map_err(crate::error::Error::Io)?;
-    }
-    std::fs::create_dir_all(glob_dir).map_err(crate::error::Error::Io)?;
-    Ok(())
-}
-
-/// Build a `ListingTable` over a glob directory containing symlinks to
-/// per-node cached Parquet files from multiple source files.
-///
-/// This replaces the UNION ALL BY NAME pattern: instead of N separate
-/// MemTables unioned via SQL, a single ListingTable scans all files
-/// in the glob directory. Schema evolution (different columns per file)
-/// is handled by `ListingTable`'s schema adapter.
-pub async fn listing_table_from_glob_cache(
-    glob_dir: &Path,
-    _ctx: &SessionContext,
-) -> Result<Arc<dyn TableProvider>> {
-    let dir_url = format!("file://{}/", glob_dir.display());
-
-    let table_url = ListingTableUrl::parse(&dir_url)?;
-    let listing_options =
-        ListingOptions::new(Arc::new(ParquetFormat::default())).with_file_extension(".parquet");
-
-    // Merge schemas from ALL parquet files in the glob directory.
-    // DataFusion's infer_schema only samples a subset of files, which loses
-    // columns that appear in later files (e.g., sensors added over time).
-    // This is the glob-cache equivalent of UNION ALL BY NAME's schema merge.
-    let merged_schema = crate::version_cache::merge_parquet_schemas_in_dir(glob_dir).await?;
-
-    let config = ListingTableConfig::new(table_url)
-        .with_listing_options(listing_options)
-        .with_schema(merged_schema);
-
-    let table = ListingTable::try_new(config)?;
-    Ok(Arc::new(table))
+    set
 }
 
 #[cfg(test)]
@@ -587,87 +515,8 @@ mod tests {
         assert_eq!(c, 1);
     }
 
-    #[test]
-    fn test_pattern_hash_deterministic() {
-        let h1 = pattern_hash("/sensors/**/*.json");
-        let h2 = pattern_hash("/sensors/**/*.json");
-        assert_eq!(h1, h2);
-        assert_eq!(h1.len(), 16); // 16 hex chars
-
-        // Different pattern => different hash
-        let h3 = pattern_hash("/other/**/*.csv");
-        assert_ne!(h1, h3);
-    }
-
-    #[test]
-    fn test_cache_glob_dir() {
-        let dir = cache_glob_dir(Path::new("/tmp/cache"), "oteljson", "abc123");
-        assert_eq!(dir, Path::new("/tmp/cache/oteljson_glob_abc123"));
-    }
-
-    #[test]
-    fn test_reset_glob_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let glob_dir = tmp.path().join("test_glob");
-
-        // Create dir with a file in it
-        std::fs::create_dir_all(&glob_dir).unwrap();
-        std::fs::write(glob_dir.join("old.parquet"), b"old data").unwrap();
-        assert!(glob_dir.join("old.parquet").exists());
-
-        // Reset should remove old contents
-        reset_glob_dir(&glob_dir).unwrap();
-        assert!(glob_dir.exists());
-        assert!(!glob_dir.join("old.parquet").exists());
-    }
-
     #[tokio::test]
-    async fn test_ensure_glob_symlinks() {
-        let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path();
-        let node_id = test_node_id();
-        let versions = vec![test_version(1, "aaa"), test_version(2, "bbb")];
-
-        let schema = test_schema();
-
-        // Write both versions to per-node cache
-        for v in &versions {
-            let batch = test_batch(&schema, &[1000], &["x"]);
-            let stream: Pin<
-                Box<
-                    dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send,
-                >,
-            > = Box::pin(futures::stream::once({
-                let batch = batch;
-                async move { Ok(batch) }
-            }));
-            let _ = cache_write_version(cache_dir, "oteljson", &node_id, v, schema.clone(), stream)
-                .await
-                .unwrap();
-        }
-
-        // Create glob dir and build symlinks
-        let glob_dir = tmp.path().join("glob_test");
-        std::fs::create_dir_all(&glob_dir).unwrap();
-        let created =
-            ensure_glob_symlinks(cache_dir, "oteljson", &node_id, &versions, &glob_dir).unwrap();
-        assert_eq!(created, 2);
-
-        // Verify symlinks exist
-        let entries: Vec<_> = std::fs::read_dir(&glob_dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .collect();
-        assert_eq!(entries.len(), 2);
-
-        // Calling again should create 0 new symlinks (idempotent)
-        let created2 =
-            ensure_glob_symlinks(cache_dir, "oteljson", &node_id, &versions, &glob_dir).unwrap();
-        assert_eq!(created2, 0);
-    }
-
-    #[tokio::test]
-    async fn test_listing_table_from_glob_cache() {
+    async fn glob_cached_set_scans_every_matched_node() {
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = tmp.path();
 
@@ -697,29 +546,11 @@ mod tests {
                 .unwrap();
         }
 
-        // Create glob dir, symlink both nodes' versions in
-        let glob_dir = tmp.path().join("my_glob");
-        std::fs::create_dir_all(&glob_dir).unwrap();
-        let _ = ensure_glob_symlinks(
-            cache_dir,
-            "csv",
-            &node1,
-            std::slice::from_ref(&v1),
-            &glob_dir,
-        )
-        .unwrap();
-        let _ = ensure_glob_symlinks(
-            cache_dir,
-            "csv",
-            &node2,
-            std::slice::from_ref(&v2),
-            &glob_dir,
-        )
-        .unwrap();
-
-        // Build listing table over glob dir
+        // One explicit scan over both nodes' live versions.
+        let nodes = vec![(node1, vec![v1.clone()]), (node2, vec![v2.clone()])];
         let ctx = SessionContext::new();
-        let table = listing_table_from_glob_cache(&glob_dir, &ctx)
+        let table = glob_cached_set(cache_dir, "csv", &nodes)
+            .table_provider()
             .await
             .unwrap();
 
@@ -739,12 +570,12 @@ mod tests {
         assert_eq!(cnt, 2); // One row from each node
     }
 
-    /// Verify that listing_table_from_glob_cache merges schemas across files
+    /// Verify that the glob scan merges schemas across files
     /// with different columns (UNION ALL BY NAME semantics).  This catches the
     /// bug where schema inference from a single file drops columns that only
     /// exist in later files (e.g., sensors added over time).
     #[tokio::test]
-    async fn test_listing_table_glob_cache_schema_merge() {
+    async fn glob_cached_set_merges_schemas_across_members() {
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = tmp.path();
 
@@ -805,29 +636,11 @@ mod tests {
             .await
             .unwrap();
 
-        // Create glob dir with symlinks to both nodes
-        let glob_dir = tmp.path().join("merge_glob");
-        std::fs::create_dir_all(&glob_dir).unwrap();
-        let _ = ensure_glob_symlinks(
-            cache_dir,
-            "csv",
-            &node1,
-            std::slice::from_ref(&v1),
-            &glob_dir,
-        )
-        .unwrap();
-        let _ = ensure_glob_symlinks(
-            cache_dir,
-            "csv",
-            &node2,
-            std::slice::from_ref(&v2),
-            &glob_dir,
-        )
-        .unwrap();
-
-        // Build listing table -- should have merged schema with all 3 columns
+        // Merged schema must carry all 3 columns across the two members.
+        let nodes = vec![(node1, vec![v1.clone()]), (node2, vec![v2.clone()])];
         let ctx = SessionContext::new();
-        let table = listing_table_from_glob_cache(&glob_dir, &ctx)
+        let table = glob_cached_set(cache_dir, "csv", &nodes)
+            .table_provider()
             .await
             .unwrap();
 

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -15,6 +15,7 @@ pub mod format_cache;
 mod format_registry;
 mod provider_api;
 pub mod rollup_cache;
+pub mod size_tier;
 mod sql_transform;
 mod table_creation;
 mod table_provider_options;

--- a/crates/provider/src/provider_api.rs
+++ b/crates/provider/src/provider_api.rs
@@ -596,9 +596,11 @@ impl Provider {
             )));
         }
 
-        // Find uncached versions
+        // Reconcile, not merely check: `versions` is this node's complete live
+        // set, so this is the one place that can also retire the sidecars of
+        // versions a collapse superseded. Without it the cache only ever grew.
         let uncached =
-            crate::format_cache::find_uncached_versions(cache_dir, scheme, &node_id, &versions);
+            crate::format_cache::reconcile_cached_versions(cache_dir, scheme, &node_id, &versions)?;
 
         if uncached.is_empty() {
             log::debug!(

--- a/crates/provider/src/provider_api.rs
+++ b/crates/provider/src/provider_api.rs
@@ -703,26 +703,21 @@ impl Provider {
                 return self.create_table_provider(&file_url_str, ctx).await;
             }
 
-            // Multi-file: cache each, symlink into glob dir, ListingTable
-            let pat_hash = crate::format_cache::pattern_hash(url_str);
-            let glob_dir = crate::format_cache::cache_glob_dir(cache_dir, scheme, &pat_hash);
-            crate::format_cache::reset_glob_dir(&glob_dir)?;
-
+            // Multi-file: cache each, then scan every live version explicitly.
+            let mut nodes = Vec::with_capacity(matches.len());
             for (node_path, _) in &matches {
                 let file_url_str = format!("{}://{}", scheme, node_path.path().display());
                 let file_url = Url::parse(&file_url_str)?;
 
-                let (node_id, versions) = self
-                    .ensure_url_cached(&file_url, format_provider.as_ref(), cache_dir)
-                    .await?;
-
-                let _ = crate::format_cache::ensure_glob_symlinks(
-                    cache_dir, scheme, &node_id, &versions, &glob_dir,
-                )?;
+                nodes.push(
+                    self.ensure_url_cached(&file_url, format_provider.as_ref(), cache_dir)
+                        .await?,
+                );
             }
 
-            let provider =
-                crate::format_cache::listing_table_from_glob_cache(&glob_dir, ctx).await?;
+            let provider = crate::format_cache::glob_cached_set(cache_dir, scheme, &nodes)
+                .table_provider()
+                .await?;
 
             log::debug!(
                 "[OK] Glob cache ListingTable for {} files (pattern '{}')",

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -200,6 +200,13 @@ pub const SEAL_TARGET_BYTES: u64 = 1024 * 1024;
 /// `max` is INCLUSIVE: it is the largest event time present, not a half-open
 /// end. Ranges elsewhere in this module are half-open, so the distinction is
 /// called out here rather than assumed.
+///
+/// Only `min_us` drives the dirty range -- unsealing is governed by a single
+/// watermark, so there is nothing an upper bound could exclude. `max_us` earns
+/// its place in the comparison: a version whose bounds were absent and are
+/// later recorded (an ingest fix, or a tlogfs upgrade backfilling them) keeps
+/// its blake3 but changes its range, and that must read as changed so the
+/// pessimistic full-axis range it had is replaced by the real one.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceRange {
     pub min_us: i64,
@@ -254,7 +261,7 @@ pub const SEALED_FORMAT: &str = "segments-v3";
 
 /// Manifest describing the segment cache for one output resolution. Its
 /// serialized bytes are the export-hint digest, so it must serialize
-/// deterministically (fixed field order; `covered` is an ordered set).
+/// deterministically (fixed field order; `sources` is an ordered map).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SegmentManifest {
     /// On-disk file format (see [`SEALED_FORMAT`]). Absent in legacy manifests,

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -2,32 +2,41 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Rollup partial-aggregate cache -- per-version Parquet cache of decomposable
-//! temporal-reduce partials.
+//! Rollup aggregate cache -- on-disk storage for `temporal-reduce` levels.
 //!
 //! `temporal-reduce` downsamples a source series into per-resolution
-//! aggregations.  Without caching, every read recomputes a full
+//! aggregations. Without caching, every read recomputes a full
 //! `GROUP BY date_bin` over the entire source history, so per-build cost grows
 //! without bound as the pond ages.
 //!
-//! This module caches the decomposable partials (`Sum`, `Count`, `Min`, `Max`,
-//! ...) for each individual input version as a Parquet file on disk under
-//! `{POND}/cache/`.  At read time a `ListingTable` is built over the cached
-//! partials and a cheap cross-version merge (`GROUP BY time_bucket`)
-//! reconstructs the final aggregation.
+//! Each output resolution is stored as a small set of files under
+//! `{POND}/cache/`: immutable *segments* covering closed bucket ranges, plus one
+//! recomputed `hot.parquet` for the open window above the watermark. They hold
+//! decomposable partials (`Sum`, `Count`, `Min`, `Max`, ...), so a read is a
+//! cheap `GROUP BY time_bucket` merge and the output columns are reconstructed
+//! at read time. A `manifest.json` names the members and the range each covers.
 //!
 //! This is the aggregation-tier analogue of [`crate::format_cache`], which
-//! caches the *parsed leaves*.  Together they make both the parse and the
+//! caches the *parsed leaves*. Together they make both the parse and the
 //! aggregation incremental.
 //!
-//! Key properties (identical discipline to the format cache):
-//! - Per-version caching: each input version is independently immutable
-//!   (blake3 hash), so there is nothing to invalidate.  One new ingest version
-//!   produces exactly one new partial.
-//! - Incremental: only uncached versions are computed; cached versions are free.
-//! - Throwaway: `rm -rf {POND}/cache/` is always safe.
-//! - Config-namespaced: a different aggregation set / time column / resolution
-//!   list yields a fresh `cfg_hash` namespace rather than mixing semantics.
+//! Key properties:
+//! - **Keyed by time range, not by source version.** The manifest records which
+//!   bucket range each segment covers and which source CONTENT (blake3) the
+//!   level reflects. Version numbers are not stable -- a tlogfs collapse
+//!   rewrites N versions into one merged version with a new, higher number and
+//!   identical content -- so keying on them made unchanged data look changed.
+//! - **File count tracks data, not build frequency.** Sealing is gated on
+//!   accumulated bytes ([`SEAL_TARGET_BYTES`]) and segments are compacted by the
+//!   same size-tiered policy tlogfs uses ([`crate::size_tier`]), so a pond
+//!   rebuilt every minute does not grow a file every minute.
+//! - **Self-correcting.** Late data unseals the segments covering it and lets
+//!   the ordinary seal path recompute them; nothing here is a dead end
+//!   requiring `--rebuild`.
+//! - **Throwaway.** `rm -rf {POND}/cache/` is always safe.
+//! - **Config-namespaced.** A different aggregation set / time column /
+//!   resolution list yields a fresh `cfg_hash` namespace rather than mixing
+//!   semantics.
 
 use datafusion::catalog::TableProvider;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
@@ -35,7 +44,7 @@ use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -43,11 +52,11 @@ use std::sync::Arc;
 type Result<T> = std::result::Result<T, crate::error::Error>;
 
 /// Compute a stable namespace hash over the parts of a temporal-reduce config
-/// that change the *meaning* of the cached partials: the aggregation set, the
+/// that change the *meaning* of the cached aggregates: the aggregation set, the
 /// time column, and the resolution list.
 ///
 /// A config change yields a fresh namespace rather than mixing incompatible
-/// partials into one directory.  Changing config invalidates semantics, not
+/// aggregates into one directory.  Changing config invalidates semantics, not
 /// content, so a new namespace is the correct response; the old one is reaped
 /// by normal cache pruning.
 ///
@@ -64,60 +73,26 @@ pub fn cfg_hash(canonical: &str) -> String {
     format!("{:016x}", hasher.finish())
 }
 
-/// Directory holding a node's cached rollup partials for one config namespace.
+/// Where an older binary kept a node's per-source-version partials:
+/// `{cache_dir}/rollup_{cfg_hash}_{node_id}/`.
 ///
-/// Returns `{cache_dir}/rollup_{cfg_hash}_{node_id}/`.
+/// Nothing writes here. It exists only so [`drop_node_namespace`] and
+/// [`drop_all`] still clear a directory left behind by a pond built before the
+/// rollup aggregated its sources directly.
 #[must_use]
-pub fn cache_node_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID) -> PathBuf {
+fn legacy_partials_node_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID) -> PathBuf {
     cache_dir.join(format!("rollup_{}_{}", cfg_hash, node_id))
 }
 
-// A rollup glob dir is a `SidecarNaming::NodeScoped` [`crate::version_cache::SidecarDir`]:
-// one partial file per (source node, input version). The source pattern can
-// match many rotated input files, each its own node with its own versions, so
-// the directory is shared and reconciliation there must be node scoped. The
-// naming, writing, reconciling and reading of those partials lives in
-// `version_cache`; this module keeps only what is genuinely rollup specific
-// (the sequentiality frontier, sealed runs, and namespace drops).
-
-/// Directory holding all per-source-version partials for one temporal-reduce
-/// node and config namespace: `{cache_dir}/rollup_{cfg_hash}_{tr_node_id}/`.
-#[must_use]
-pub fn glob_dir(cache_dir: &Path, cfg_hash: &str, tr_node_id: &tinyfs::NodeID) -> PathBuf {
-    cache_node_dir(cache_dir, cfg_hash, tr_node_id)
-}
-
-/// Wrap an already-resolved partials directory path as a sidecar dir.
-#[must_use]
-pub fn partials_dir_at(glob_dir: &Path) -> crate::version_cache::SidecarDir {
-    crate::version_cache::SidecarDir::new(
-        glob_dir.to_path_buf(),
-        crate::version_cache::SidecarNaming::NodeScoped,
-    )
-}
-
-/// The partials directory of one temporal-reduce node, as a sidecar dir.
-#[must_use]
-pub fn partials_dir(
-    cache_dir: &Path,
-    cfg_hash: &str,
-    tr_node_id: &tinyfs::NodeID,
-) -> crate::version_cache::SidecarDir {
-    crate::version_cache::SidecarDir::new(
-        glob_dir(cache_dir, cfg_hash, tr_node_id),
-        crate::version_cache::SidecarNaming::NodeScoped,
-    )
-}
-
-/// Drop a node's entire rollup-cache namespace for one config, forcing all
-/// partials to be recomputed on next read.  Used by the `--rebuild` recovery
-/// path.  Idempotent: a missing directory is not an error.
+/// Drop a node's entire rollup-cache namespace for one config, forcing the
+/// rollup to be recomputed from source on next read. Used by the `--rebuild`
+/// recovery path. Idempotent: a missing directory is not an error.
 pub fn drop_node_namespace(
     cache_dir: &Path,
     cfg_hash: &str,
     node_id: &tinyfs::NodeID,
 ) -> Result<()> {
-    let dir = cache_node_dir(cache_dir, cfg_hash, node_id);
+    let dir = legacy_partials_node_dir(cache_dir, cfg_hash, node_id);
     if dir.exists() {
         std::fs::remove_dir_all(&dir).map_err(crate::error::Error::Io)?;
     }
@@ -128,8 +103,8 @@ pub fn drop_node_namespace(
     Ok(())
 }
 
-/// Drop every rollup-cache namespace under `cache_dir`, forcing all partials
-/// for all temporal-reduce nodes to be recomputed on next read.  This is the
+/// Drop every rollup-cache namespace under `cache_dir`, forcing every
+/// temporal-reduce level to be recomputed from source on next read.  This is the
 /// global `--rebuild` recovery primitive.  The format cache and any other cache
 /// content are left untouched.  Idempotent: a missing `cache_dir` is not an
 /// error.
@@ -154,70 +129,16 @@ pub fn drop_all(cache_dir: &Path) -> Result<usize> {
     Ok(dropped)
 }
 
-/// Path of a source node's sequentiality-frontier sidecar within the glob dir:
-/// `{glob_dir}/{source_node}.frontier`.  The file holds the maximum sealed
-/// `time_bucket` value (in the finest-interval timestamp unit) observed across
-/// every cached version of that source node.
-#[must_use]
-pub fn frontier_path(glob_dir: &Path, source_node_id: &tinyfs::NodeID) -> PathBuf {
-    glob_dir.join(format!("{}.frontier", source_node_id))
-}
-
-/// Read a source node's persisted sequentiality frontier.
-///
-/// Returns `Ok(None)` only when the frontier file is genuinely absent, which is
-/// the self-heal path for a fresh or `--rebuild`-cleared cache. A file that is
-/// present but unparseable is a corrupt control artifact and is a hard error:
-/// silently treating it as absent would disable the double-count guard for
-/// overlapping non-series sources, allowing a re-snapshot to be summed twice.
-pub fn read_frontier(glob_dir: &Path, source_node_id: &tinyfs::NodeID) -> Result<Option<i64>> {
-    let path = frontier_path(glob_dir, source_node_id);
-    let contents = match std::fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(crate::error::Error::Io(e)),
-    };
-    contents.trim().parse::<i64>().map(Some).map_err(|e| {
-        crate::error::Error::CacheCorrupt(format!(
-            "frontier file '{}' is present but unparseable ({}); the rollup cache \
-             is corrupt. Re-run the export with --rebuild to recompute it from scratch.",
-            path.display(),
-            e
-        ))
-    })
-}
-
-/// Persist a source node's frontier (atomic write via `.tmp` then rename).
-pub fn write_frontier(
-    glob_dir: &Path,
-    source_node_id: &tinyfs::NodeID,
-    frontier: i64,
-) -> Result<()> {
-    std::fs::create_dir_all(glob_dir).map_err(crate::error::Error::Io)?;
-    let final_path = frontier_path(glob_dir, source_node_id);
-    let tmp_path = final_path.with_extension("frontier.tmp");
-    std::fs::write(&tmp_path, frontier.to_string()).map_err(crate::error::Error::Io)?;
-    std::fs::rename(&tmp_path, &final_path).map_err(crate::error::Error::Io)?;
-    Ok(())
-}
-
-// --- Merged-output cache: per-resolution materialized merge result -----------
+// --- Merged-output cache: per-resolution materialized aggregation ------------
 //
-// The partial cache above makes the partial COMPUTATION incremental, but the
-// cross-version merge (`GROUP BY date_bin` over every cached partial) still runs
-// in full on every build. This merged-output cache materializes the merged
-// buckets to one Parquet file per output resolution, so a rebuild recomputes
-// only the suffix of buckets touched by newly-added source versions and reuses
-// the sealed prefix unchanged.
+// Materializes each output resolution's merged buckets on disk, so a rebuild
+// recomputes only the buckets a change can reach and reuses the rest.
 //
-// It lives in a directory SEPARATE from the partials glob dir so the partials
-// `ListingTable` (which unions every `.parquet` under the glob dir) never
-// mistakes a merged-output file for a partial.
-//
-// Integrity: a blake3 digest of the Parquet bytes is written to a sidecar. On
-// read the digest is re-verified. An absent or incompletely published file
-// self-heals via a full remerge; a present file whose bytes do not match the
-// digest is a hard error rather than silently serving tampered aggregates.
+// Integrity: a blake3 digest of each Parquet's bytes is recorded in the
+// manifest. On read the digest is re-verified. An absent or incompletely
+// published file self-heals via a full remerge; a present file whose bytes do
+// not match the digest is a hard error rather than silently serving tampered
+// aggregates.
 
 /// Directory holding the merged-output cache for one temporal-reduce node and
 /// config namespace: `{cache_dir}/merged_{cfg_hash}_{node_id}/`.
@@ -226,45 +147,32 @@ pub fn merged_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID) ->
     cache_dir.join(format!("merged_{}_{}", cfg_hash, node_id))
 }
 
-/// List the per-source-version partial member files (`*.parquet`) currently
-/// present in a glob dir. These are the partials merged into every resolution's
-/// output; the returned paths are sorted for deterministic diffing.
-pub fn list_glob_members(glob_dir: &Path) -> Result<Vec<PathBuf>> {
-    let mut out = Vec::new();
-    let rd = match std::fs::read_dir(glob_dir) {
-        Ok(rd) => rd,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
-        Err(e) => return Err(crate::error::Error::Io(e)),
-    };
-    for entry in rd {
-        let path = entry.map_err(crate::error::Error::Io)?.path();
-        if path.extension().is_some_and(|ext| ext == "parquet") {
-            out.push(path);
-        }
-    }
-    out.sort();
-    Ok(out)
-}
-
-// --- Sealed-runs merged cache (Phase 2: watermark + immutable runs) ----------
+// --- Segments: watermark + immutable sealed runs ------------------------------
 //
-// Phase 1's merged cache is a single mutable Parquet whose sealed prefix is
-// rewritten on every build (O(history) I/O). Phase 2 replaces it with a
-// directory of immutable, append-only *sealed run* files plus one recomputed
-// *hot* file, separated by a watermark derived from `allowed_lateness`:
+// Each resolution is a directory of immutable *sealed run* files plus one
+// recomputed *hot* file, separated by a watermark derived from
+// `allowed_lateness`:
 //
 //   {merged_dir}/res{secs}/
 //       run-00000000.parquet   immutable sealed run (buckets [lo, hi))
 //       run-00000001.parquet   ...
 //       hot.parquet            every bucket at or above sealed_hi, recomputed
 //                              each build
-//       manifest.json          watermark + run ranges + coverage + digests
+//       manifest.json          watermark + run ranges + source content + digests
 //
 // Buckets below sealed_hi are frozen once and never rescanned, so per-build cost
-// is bounded to the hot window. That window holds the allowed-lateness tail plus
-// whatever has frozen since the last seal, which SEAL_TARGET_BYTES bounds. The read provider is a
-// `ListingTable` over the whole res dir (runs ⧺ hot); consumers apply their own
-// `ORDER BY`.
+// is bounded to the hot window: the allowed-lateness tail plus whatever has
+// frozen since the last seal, which SEAL_TARGET_BYTES bounds. The alternative --
+// one mutable Parquet whose sealed prefix is rewritten every build -- costs
+// O(history) I/O per build.
+//
+// Because a run is identified by the bucket range it covers, late data below the
+// watermark is answerable: the runs holding those buckets are found by lookup,
+// dropped, and recomputed by the ordinary seal path.
+//
+// The read provider names the manifest's members explicitly; it never lists the
+// directory, so a superseded file left behind by an interrupted compaction
+// cannot be double-counted. Consumers apply their own `ORDER BY`.
 
 /// Minimum accumulated size, in bytes, before frozen buckets are sealed into a
 /// run file.
@@ -280,6 +188,37 @@ pub fn list_glob_members(glob_dir: &Path) -> Result<Vec<PathBuf>> {
 /// collapsing hundreds of builds into one run. Compaction is the right tool for
 /// making files genuinely large; this only has to stop the bleeding.
 pub const SEAL_TARGET_BYTES: u64 = 1024 * 1024;
+
+/// The event-time span covered by one source version, in epoch MICROSECONDS.
+///
+/// Microseconds because that is the unit tlogfs records on `OplogEntry` and
+/// surfaces as `min_event_time` / `max_event_time`, so for series sources this
+/// is free -- no scan. Output-bucket ranges elsewhere in this module are epoch
+/// SECONDS; conversion between the two must round outward (floor a lower bound,
+/// ceil an upper one) so a rounding step can never exclude a contributing row.
+///
+/// `max` is INCLUSIVE: it is the largest event time present, not a half-open
+/// end. Ranges elsewhere in this module are half-open, so the distinction is
+/// called out here rather than assumed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceRange {
+    pub min_us: i64,
+    pub max_us: i64,
+}
+
+impl SourceRange {
+    /// A version whose event-time bounds were never recorded, covering the whole
+    /// axis.
+    ///
+    /// Not a special case to test for downstream: any dirty range containing it
+    /// becomes unbounded, so the build reads everything -- pessimistic, still
+    /// correct. Non-series sources land here, which is why the pruning benefit
+    /// is confined to series data, where the bounds are recorded for free.
+    pub const UNKNOWN: Self = Self {
+        min_us: i64::MIN,
+        max_us: i64::MAX,
+    };
+}
 
 /// Maximum number of sealed runs to leave live in one resolution before
 /// compaction merges regardless of size class.
@@ -305,12 +244,13 @@ pub struct SealedRun {
 
 /// On-disk format of the sealed run + hot files. Bumped when their column
 /// layout or the manifest's build semantics change so an older cache is
-/// discarded and rebuilt rather than misread. `partials-v2` stores the
+/// discarded and rebuilt rather than misread. `segments-v3` stores the
 /// *mergeable partials* (sum/count/min/max) with output columns reconstructed at
-/// read time (design §3 / Phase 3 step 1) AND may derive a coarser resolution by
-/// folding the next-finer resolution's runs (`source_digest`; Phase 3 step 2);
-/// legacy caches deserialize with an empty `format` and are wiped + rebuilt.
-pub const SEALED_FORMAT: &str = "partials-v3";
+/// read time, keys the finest resolution on source CONTENT (`sources`) rather
+/// than on per-version partial filenames, and may derive a coarser resolution by
+/// folding the next-finer resolution's runs (`source_digest`). Older caches
+/// carry a different (or empty) `format` and are wiped + rebuilt.
+pub const SEALED_FORMAT: &str = "segments-v3";
 
 /// Manifest describing the sealed-runs cache for one output resolution. Its
 /// serialized bytes are the export-hint digest, so it must serialize
@@ -343,16 +283,27 @@ pub struct SealedManifest {
     /// it without writing anything to find out.
     #[serde(default)]
     pub hot_bytes: u64,
-    /// Partial member file names this cache reflects (freshness key; identical
-    /// role to the Phase 1 coverage sidecar). Used only by the finest resolution,
-    /// which folds the shared finest partials directly; empty for coarser
-    /// resolutions, which key freshness on `source_digest` instead.
-    pub covered: BTreeSet<String>,
+    /// The source content this cache reflects: blake3 of each LIVE source
+    /// version, mapped to the event-time range it covers. Used only by the
+    /// finest resolution, which aggregates the sources directly; empty for
+    /// coarser resolutions, which key freshness on `source_digest` instead.
+    ///
+    /// Keying on CONTENT rather than on storage artifacts is the point. The
+    /// previous key was a set of partial FILENAMES, one per source version, and
+    /// version numbers are not stable: a tlogfs collapse rewrites N versions
+    /// into one merged version with a new, higher number and identical content.
+    /// Every guard this cache used to need -- the sequentiality frontier, the
+    /// series/non-series split, the backfill hard errors -- existed to defend a
+    /// key that changed when the data had not. A blake3 does not.
+    ///
+    /// Bounded: tlogfs collapse bounds the number of live versions, whereas a
+    /// directory holding one file per version ever written was unbounded.
+    pub sources: BTreeMap<String, SourceRange>,
     /// For a coarser resolution built by folding the next-finer resolution's
     /// runs (Phase 3 step 2): the finer resolution's manifest digest this cache
-    /// was folded from. `None` for the finest resolution (which folds the shared
-    /// partials and uses `covered`). A change in the finer digest triggers a
-    /// coarse rebuild/advance.
+    /// was folded from. `None` for the finest resolution (which aggregates the
+    /// sources directly and uses `sources`). A change in the finer digest
+    /// triggers a coarse rebuild/advance.
     #[serde(default)]
     pub source_digest: Option<String>,
 }
@@ -445,8 +396,8 @@ pub async fn remove_superseded(files: &[PathBuf]) {
     }
 }
 
-/// Remove an entire res dir (used when `allowed_lateness` changes or the
-/// coverage shrinks, forcing a rebuild from the retained partials).
+/// Remove an entire res dir, forcing this resolution to be rebuilt from source
+/// (used when `allowed_lateness` or the on-disk format changes).
 pub fn wipe_sealed_res_dir(res_dir: &Path) -> Result<()> {
     match std::fs::remove_dir_all(res_dir) {
         Ok(()) => Ok(()),
@@ -604,73 +555,13 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_node_dir_layout() {
+    fn test_legacy_partials_node_dir_layout() {
         let cache_dir = Path::new("/tmp/pond/cache");
         let node_id = test_node_id();
-        let dir = cache_node_dir(cache_dir, "deadbeef", &node_id);
+        let dir = legacy_partials_node_dir(cache_dir, "deadbeef", &node_id);
         let dir_str = dir.to_str().unwrap();
         assert!(dir_str.starts_with("/tmp/pond/cache/rollup_deadbeef_"));
         assert!(dir_str.contains(&node_id.to_string()));
-    }
-
-    /// Partials of several input versions merge to exactly the single-pass
-    /// GROUP BY result, including a bucket straddling two versions -- and,
-    /// after a version collapse, the superseded versions' partials are gone
-    /// rather than summed a second time.
-    #[tokio::test]
-    async fn test_write_and_list_partials_merge() {
-        use crate::version_cache::LiveVersions;
-
-        let tmp = tempfile::tempdir().unwrap();
-        let node_id = test_node_id();
-        let dir = partials_dir(tmp.path(), "cfg", &node_id);
-        let schema = partials_schema();
-
-        // Version 1: bucket 0 sum=10 count=2 ; bucket 1 sum=5 count=1
-        let v1 = test_version(1, Some("v1hash"));
-        let b1 = partials_batch(&schema, &[0, 1], &[10.0, 5.0], &[2, 1]);
-        let s1: BatchStream = Box::pin(futures::stream::iter(vec![Ok(b1)]));
-        _ = dir
-            .write_sidecar(&node_id, &v1, schema.clone(), s1)
-            .await
-            .unwrap();
-
-        // Version 2: bucket 1 (boundary straddle) sum=7 count=1 ; bucket 2 sum=4 count=1
-        let v2 = test_version(2, Some("v2hash"));
-        let b2 = partials_batch(&schema, &[1, 2], &[7.0, 4.0], &[1, 1]);
-        let s2: BatchStream = Box::pin(futures::stream::iter(vec![Ok(b2)]));
-        _ = dir
-            .write_sidecar(&node_id, &v2, schema.clone(), s2)
-            .await
-            .unwrap();
-
-        // Incrementality: both versions now cached, nothing stale.
-        let live = LiveVersions::from_persistence(node_id, vec![v1.clone(), v2.clone()]);
-        let reconciled = dir.reconcile(&live).unwrap();
-        assert!(reconciled.missing.is_empty());
-        assert!(reconciled.removed.is_empty());
-
-        let merged = merge_partials(&dir.cached_set(&live, |_| true)).await;
-        assert_eq!(merged, vec![(0, 10.0, 2), (1, 12.0, 2), (2, 4.0, 1)]);
-
-        // Now collapse v1+v2 into a single live v3 covering the same rows. The
-        // superseded partials must be removed, not merged on top of v3's --
-        // that addition is the double-count pinned by testsuite 733.
-        let v3 = test_version(3, Some("v3hash"));
-        let live = LiveVersions::from_persistence(node_id, vec![v3.clone()]);
-        let reconciled = dir.reconcile(&live).unwrap();
-        assert_eq!(reconciled.removed.len(), 2);
-        assert_eq!(reconciled.missing.len(), 1);
-
-        let b3 = partials_batch(&schema, &[0, 1, 2], &[10.0, 12.0, 4.0], &[2, 2, 1]);
-        let s3: BatchStream = Box::pin(futures::stream::iter(vec![Ok(b3)]));
-        _ = dir
-            .write_sidecar(&node_id, &v3, schema.clone(), s3)
-            .await
-            .unwrap();
-
-        let merged = merge_partials(&dir.cached_set(&live, |_| true)).await;
-        assert_eq!(merged, vec![(0, 10.0, 2), (1, 12.0, 2), (2, 4.0, 1)]);
     }
 
     /// Fold a cached set the way the read path does, returning
@@ -768,7 +659,7 @@ mod tests {
             }],
             hot_digest: Some(hot_digest),
             hot_bytes: 0,
-            covered: BTreeSet::new(),
+            sources: BTreeMap::new(),
             source_digest: None,
         };
 
@@ -822,17 +713,18 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = tmp.path();
         let node_id = test_node_id();
-        let schema = partials_schema();
-        let v1 = test_version(1, Some("v1hash"));
-        let b1 = partials_batch(&schema, &[0], &[1.0], &[1]);
-        let s1: BatchStream = Box::pin(futures::stream::iter(vec![Ok(b1)]));
-        _ = partials_dir(cache_dir, "cfg", &node_id)
-            .write_sidecar(&node_id, &v1, schema.clone(), s1)
-            .await
-            .unwrap();
-        assert!(cache_node_dir(cache_dir, "cfg", &node_id).exists());
+        // Both namespaces: the live merged cache and the partials directory a
+        // pre-`segments-v3` binary would have left behind. `--rebuild` must
+        // clear both, or the stale one wastes disk forever.
+        let legacy = legacy_partials_node_dir(cache_dir, "cfg", &node_id);
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("v1.parquet"), b"stale").unwrap();
+        let merged = merged_dir(cache_dir, "cfg", &node_id);
+        std::fs::create_dir_all(&merged).unwrap();
+
         drop_node_namespace(cache_dir, "cfg", &node_id).unwrap();
-        assert!(!cache_node_dir(cache_dir, "cfg", &node_id).exists());
+        assert!(!legacy.exists());
+        assert!(!merged.exists());
         // Idempotent.
         drop_node_namespace(cache_dir, "cfg", &node_id).unwrap();
     }

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -256,13 +256,30 @@ pub fn list_glob_members(glob_dir: &Path) -> Result<Vec<PathBuf>> {
 //   {merged_dir}/res{secs}/
 //       run-00000000.parquet   immutable sealed run (buckets [lo, hi))
 //       run-00000001.parquet   ...
-//       hot.parquet            open buckets >= watermark, recomputed each build
+//       hot.parquet            every bucket at or above sealed_hi, recomputed
+//                              each build
 //       manifest.json          watermark + run ranges + coverage + digests
 //
-// Buckets below the watermark are frozen once and never rescanned, so per-build
-// cost is bounded to the hot window (~allowed_lateness). The read provider is a
+// Buckets below sealed_hi are frozen once and never rescanned, so per-build cost
+// is bounded to the hot window. That window holds the allowed-lateness tail plus
+// whatever has frozen since the last seal, which SEAL_TARGET_BYTES bounds. The read provider is a
 // `ListingTable` over the whole res dir (runs ⧺ hot); consumers apply their own
 // `ORDER BY`.
+
+/// Minimum accumulated size, in bytes, before frozen buckets are sealed into a
+/// run file.
+///
+/// Sealing used to trigger on the watermark advancing, which tied the file count
+/// to how often a build ran rather than to how much data existed: a pond rebuilt
+/// every minute grew a run file every minute, each a few kilobytes. Gating on
+/// size decouples the two, so the count tracks data volume.
+///
+/// Deliberately modest. The cost of raising it is that the hot window -- which is
+/// recomputed in full on every build -- carries the unsealed remainder, so the
+/// target bounds per-build work. 1 MiB keeps that recompute trivial while still
+/// collapsing hundreds of builds into one run. Compaction is the right tool for
+/// making files genuinely large; this only has to stop the bleeding.
+pub const SEAL_TARGET_BYTES: u64 = 1024 * 1024;
 
 /// One immutable sealed run file and the half-open output-bucket range it
 /// covers, in epoch seconds. `lo_secs` is `None` for the genesis run (unbounded
@@ -273,6 +290,9 @@ pub struct SealedRun {
     pub lo_secs: Option<i64>,
     pub hi_secs: i64,
     pub digest: String,
+    /// On-disk size of the run file in bytes, recorded when it was written.
+    /// Lets compaction choose merge candidates without stat-ing every run.
+    pub bytes: u64,
 }
 
 /// On-disk format of the sealed run + hot files. Bumped when their column
@@ -282,7 +302,7 @@ pub struct SealedRun {
 /// read time (design §3 / Phase 3 step 1) AND may derive a coarser resolution by
 /// folding the next-finer resolution's runs (`source_digest`; Phase 3 step 2);
 /// legacy caches deserialize with an empty `format` and are wiped + rebuilt.
-pub const SEALED_FORMAT: &str = "partials-v2";
+pub const SEALED_FORMAT: &str = "partials-v3";
 
 /// Manifest describing the sealed-runs cache for one output resolution. Its
 /// serialized bytes are the export-hint digest, so it must serialize
@@ -306,6 +326,15 @@ pub struct SealedManifest {
     pub runs: Vec<SealedRun>,
     /// blake3 digest of `hot.parquet`.
     pub hot_digest: Option<String>,
+    /// On-disk size of `hot.parquet` as of the last build, in bytes.
+    ///
+    /// This is the seal trigger. `hot` spans `[sealed_hi, inf)`, which strictly
+    /// contains the frozen span `[sealed_hi, watermark)` that a seal would
+    /// write, so this is a conservative upper bound on how much a seal would
+    /// produce: below the target, sealing cannot be worthwhile, and we can skip
+    /// it without writing anything to find out.
+    #[serde(default)]
+    pub hot_bytes: u64,
     /// Partial member file names this cache reflects (freshness key; identical
     /// role to the Phase 1 coverage sidecar). Used only by the finest resolution,
     /// which folds the shared finest partials directly; empty for coarser
@@ -690,8 +719,10 @@ mod tests {
                 lo_secs: None,
                 hi_secs: 120,
                 digest: run_digest,
+                bytes: 0,
             }],
             hot_digest: Some(hot_digest),
+            hot_bytes: 0,
             covered: BTreeSet::new(),
             source_digest: None,
         };

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -718,6 +718,160 @@ mod tests {
         assert!(read_segment_manifest(&res_dir).unwrap().is_some());
     }
 
+    /// An absent manifest and an unparseable one mean opposite things, and the
+    /// difference must survive the read: absent is a cold cache (build it), while
+    /// present-but-garbage means something wrote or truncated a file this code
+    /// owns. Collapsing the latter into `Ok(None)` would look like a harmless
+    /// rebuild while quietly discarding a res dir whose segments are still
+    /// referenced -- corruption that repairs itself into data loss.
+    ///
+    /// The check that matters is on `read_verified_segment_manifest`, the
+    /// wrapper the build path actually calls: it converts a hot-file
+    /// disagreement into `Ok(None)` (a legitimate rebuild), so it must NOT do
+    /// the same to a corrupt manifest.
+    #[tokio::test]
+    async fn an_unparseable_manifest_is_corruption_not_a_cold_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let res_dir = tmp.path().to_path_buf();
+        std::fs::create_dir_all(&res_dir).unwrap();
+
+        // Absent: a cold cache, not an error.
+        assert!(
+            read_segment_manifest(&res_dir).unwrap().is_none(),
+            "no manifest yet is a cold cache"
+        );
+
+        // Truncated mid-write, as an interrupted writer would leave it. The
+        // atomic tmp+rename in `write_segment_manifest` is what prevents this,
+        // so reaching it means that guarantee was broken from outside.
+        std::fs::write(res_dir.join("manifest.json"), b"{\"format\":\"partials-v2\",").unwrap();
+
+        let err = read_segment_manifest(&res_dir)
+            .expect_err("a present but unparseable manifest is corruption");
+        assert!(
+            matches!(err, crate::error::Error::CacheCorrupt(_)),
+            "must be CacheCorrupt, not an IO or serde error: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("--rebuild"),
+            "the message must tell the operator how to recover: {err}"
+        );
+
+        let err = read_verified_segment_manifest(&res_dir)
+            .expect_err("the verifying wrapper must not swallow corruption into a rebuild");
+        assert!(matches!(err, crate::error::Error::CacheCorrupt(_)), "{err:?}");
+    }
+
+    /// The mirror of `listing_table_ignores_a_parquet_the_manifest_does_not_name`:
+    /// a file the manifest does not name is ignored, but a file it DOES name and
+    /// that is absent is a hard error. Both rules exist to make the manifest the
+    /// single authority on membership -- an extra file must not be summed, and a
+    /// missing one must not become a silent hole in the series.
+    ///
+    /// Skipping the missing member would be the more dangerous half: the gap
+    /// lands in whatever bucket range that segment held, the manifest still
+    /// agrees with itself, and an unchanged source makes every later build reuse
+    /// it, so the hole is served indefinitely.
+    #[tokio::test]
+    async fn listing_table_rejects_a_manifest_member_missing_from_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let res_dir = tmp.path().join("res60");
+        let schema = partials_schema();
+        let s: BatchStream = Box::pin(futures::stream::iter(vec![Ok(partials_batch(
+            &schema,
+            &[120],
+            &[40.0],
+            &[4],
+        ))]));
+        let hot_digest = write_parquet_atomic(&hot_path(&res_dir), schema.clone(), s)
+            .await
+            .unwrap();
+
+        // The manifest names a segment that was never written (or was deleted
+        // out from under the cache).
+        let manifest = SegmentManifest {
+            format: SEALED_FORMAT.to_string(),
+            allowed_lateness_secs: 0,
+            sealed_hi_secs: Some(120),
+            next_seq: 1,
+            segments: vec![Segment {
+                name: "seg-00000000.parquet".to_string(),
+                lo_secs: None,
+                hi_secs: 120,
+                digest: "0".repeat(64),
+                bytes: 0,
+            }],
+            hot_digest: Some(hot_digest),
+            hot_bytes: 0,
+            sources: BTreeMap::new(),
+            source_digest: None,
+        };
+
+        let err = listing_table_for_res_dir(&res_dir, &manifest, "time_bucket")
+            .await
+            .expect_err("a manifest member missing on disk must not be skipped");
+        assert!(
+            matches!(err, crate::error::Error::CacheCorrupt(_)),
+            "must be CacheCorrupt so the operator sees a corrupt cache rather \
+             than a short read: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("seg-00000000.parquet"),
+            "the message must name the missing member: {err}"
+        );
+    }
+
+    /// The hot file is a mandatory member of every res dir -- it holds the open
+    /// window `[sealed_hi, inf)`, i.e. the most recent data. Reading the sealed
+    /// segments alone would succeed and return a series that simply stops at the
+    /// watermark, which looks like "no recent data" rather than like a fault.
+    #[tokio::test]
+    async fn listing_table_rejects_a_res_dir_with_no_hot_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let res_dir = tmp.path().join("res60");
+        let schema = partials_schema();
+        let seg_name = "seg-00000000.parquet";
+        let s: BatchStream = Box::pin(futures::stream::iter(vec![Ok(partials_batch(
+            &schema,
+            &[0, 60],
+            &[10.0, 20.0],
+            &[1, 2],
+        ))]));
+        let seg_digest = write_parquet_atomic(&segment_path(&res_dir, seg_name), schema.clone(), s)
+            .await
+            .unwrap();
+
+        let manifest = SegmentManifest {
+            format: SEALED_FORMAT.to_string(),
+            allowed_lateness_secs: 0,
+            sealed_hi_secs: Some(120),
+            next_seq: 1,
+            segments: vec![Segment {
+                name: seg_name.to_string(),
+                lo_secs: None,
+                hi_secs: 120,
+                digest: seg_digest,
+                bytes: 0,
+            }],
+            hot_digest: None,
+            hot_bytes: 0,
+            sources: BTreeMap::new(),
+            source_digest: None,
+        };
+
+        let err = listing_table_for_res_dir(&res_dir, &manifest, "time_bucket")
+            .await
+            .expect_err("a res dir without hot must not read as a truncated series");
+        assert!(
+            matches!(err, crate::error::Error::CacheCorrupt(_)),
+            "{err:?}"
+        );
+        assert!(
+            err.to_string().contains("hot"),
+            "the message must identify the missing hot file: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn test_merged_cache_drop_all_removes_merged_dir() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -744,7 +744,11 @@ mod tests {
         // Truncated mid-write, as an interrupted writer would leave it. The
         // atomic tmp+rename in `write_segment_manifest` is what prevents this,
         // so reaching it means that guarantee was broken from outside.
-        std::fs::write(res_dir.join("manifest.json"), b"{\"format\":\"partials-v2\",").unwrap();
+        std::fs::write(
+            res_dir.join("manifest.json"),
+            b"{\"format\":\"partials-v2\",",
+        )
+        .unwrap();
 
         let err = read_segment_manifest(&res_dir)
             .expect_err("a present but unparseable manifest is corruption");
@@ -759,7 +763,10 @@ mod tests {
 
         let err = read_verified_segment_manifest(&res_dir)
             .expect_err("the verifying wrapper must not swallow corruption into a rebuild");
-        assert!(matches!(err, crate::error::Error::CacheCorrupt(_)), "{err:?}");
+        assert!(
+            matches!(err, crate::error::Error::CacheCorrupt(_)),
+            "{err:?}"
+        );
     }
 
     /// The mirror of `listing_table_ignores_a_parquet_the_manifest_does_not_name`:

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -53,7 +53,7 @@ type Result<T> = std::result::Result<T, crate::error::Error>;
 ///
 /// The caller passes a canonical string built from those config fields.  The
 /// hash uses the same `DefaultHasher` convention as
-/// [`crate::format_cache::pattern_hash`]; stability across binaries is not
+/// the former `format_cache::pattern_hash`; stability across binaries is not
 /// required because the cache is throwaway.
 #[must_use]
 pub fn cfg_hash(canonical: &str) -> String {

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -263,9 +263,15 @@ pub struct SegmentManifest {
     #[serde(default)]
     pub hot_bytes: u64,
     /// The source content this cache reflects: blake3 of each LIVE source
-    /// version, mapped to the event-time range it covers. Used only by the
-    /// finest resolution, which aggregates the sources directly; empty for
-    /// coarser resolutions, which key freshness on `source_digest` instead.
+    /// version, mapped to the event-time range it covers.
+    ///
+    /// Recorded by EVERY resolution, not just the finest. The finest uses it to
+    /// decide reuse-vs-incremental directly. A coarser resolution keys reuse on
+    /// `source_digest`, but still needs this to bound how far back to unseal
+    /// when that digest is stale: its finer level's in-call change may already
+    /// have been consumed by an earlier build of a different output file, so
+    /// "the finer level reports no change" does not mean this level is current.
+    /// See `build_level_from_finer`.
     ///
     /// Keying on CONTENT rather than on storage artifacts is the point. The
     /// previous key was a set of partial FILENAMES, one per source version, and

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -29,22 +29,14 @@
 //! - Config-namespaced: a different aggregation set / time column / resolution
 //!   list yields a fresh `cfg_hash` namespace rather than mixing semantics.
 
-use arrow::datatypes::SchemaRef;
-use arrow::record_batch::RecordBatch;
 use datafusion::catalog::TableProvider;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
-use datafusion::parquet::basic::Compression;
-use datafusion::parquet::file::properties::WriterProperties;
-use futures::StreamExt;
-use futures::stream::Stream;
-use parquet::arrow::AsyncArrowWriter;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::sync::Arc;
 
 /// Result type for rollup cache operations.
@@ -234,14 +226,6 @@ pub fn merged_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID) ->
     cache_dir.join(format!("merged_{}_{}", cfg_hash, node_id))
 }
 
-/// Compute the hex blake3 digest of a file's bytes.
-fn file_blake3(path: &Path) -> Result<String> {
-    let mut hasher = blake3::Hasher::new();
-    let mut file = std::fs::File::open(path).map_err(crate::error::Error::Io)?;
-    let _copied = std::io::copy(&mut file, &mut hasher).map_err(crate::error::Error::Io)?;
-    Ok(hasher.finalize().to_hex().to_string())
-}
-
 /// List the per-source-version partial member files (`*.parquet`) currently
 /// present in a glob dir. These are the partials merged into every resolution's
 /// output; the returned paths are sorted for deterministic diffing.
@@ -411,43 +395,6 @@ pub fn wipe_sealed_res_dir(res_dir: &Path) -> Result<()> {
     }
 }
 
-/// Stream a record batch stream to `path` atomically (tmp + rename) and return
-/// the blake3 digest of the written Parquet bytes. Used for both sealed runs and
-/// the hot file; the digest is recorded in the manifest rather than a sidecar.
-pub async fn write_parquet_atomic(
-    path: &Path,
-    schema: SchemaRef,
-    stream: Pin<
-        Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
-    >,
-) -> Result<String> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-    let tmp_path = PathBuf::from(format!("{}.tmp", path.display()));
-    let file = tokio::fs::File::create(&tmp_path).await?;
-    let props = WriterProperties::builder()
-        .set_compression(Compression::ZSTD(parquet::basic::ZstdLevel::default()))
-        .build();
-    let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props))
-        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-    let mut stream = stream;
-    while let Some(batch) = stream.next().await {
-        let batch = batch?;
-        writer
-            .write(&batch)
-            .await
-            .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-    }
-    let _ = writer
-        .close()
-        .await
-        .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
-    let digest = file_blake3(&tmp_path)?;
-    tokio::fs::rename(&tmp_path, path).await?;
-    Ok(digest)
-}
-
 /// Build the read provider for a res dir: a `ListingTable` over exactly the
 /// sealed runs named by `manifest`, plus the hot file. A manifest member
 /// missing on disk is a hard error (corrupt cache), never a silent hole in the
@@ -457,7 +404,7 @@ pub async fn write_parquet_atomic(
 /// are not the same set: a `.parquet` can sit in the directory without being
 /// referenced by the manifest, and every such orphan is a duplicate copy of
 /// some bucket range that a directory-shaped scan sums a second time. Orphans
-/// arise in normal operation, not only after a crash -- [`write_parquet_atomic`]
+/// arise in normal operation, not only after a crash -- [`crate::version_cache::write_parquet_atomic`]
 /// renames a new run into place BEFORE the manifest recording it is written, so
 /// any interruption in that window leaves one behind, and compaction (which must
 /// publish a merged segment before deleting its inputs) widens that window by
@@ -523,8 +470,11 @@ pub async fn listing_table_for_res_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::version_cache::{BatchStream, write_parquet_atomic};
     use arrow::array::{Float64Array, Int64Array};
+    use arrow::datatypes::SchemaRef;
     use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
     use datafusion::execution::context::SessionContext;
     use std::sync::Arc;
     use tinyfs::FileVersionInfo;
@@ -605,9 +555,7 @@ mod tests {
         // Version 1: bucket 0 sum=10 count=2 ; bucket 1 sum=5 count=1
         let v1 = test_version(1, Some("v1hash"));
         let b1 = partials_batch(&schema, &[0, 1], &[10.0, 5.0], &[2, 1]);
-        let s1: Pin<
-            Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
-        > = Box::pin(futures::stream::iter(vec![Ok(b1)]));
+        let s1: BatchStream = Box::pin(futures::stream::iter(vec![Ok(b1)]));
         _ = dir
             .write_sidecar(&node_id, &v1, schema.clone(), s1)
             .await
@@ -616,9 +564,7 @@ mod tests {
         // Version 2: bucket 1 (boundary straddle) sum=7 count=1 ; bucket 2 sum=4 count=1
         let v2 = test_version(2, Some("v2hash"));
         let b2 = partials_batch(&schema, &[1, 2], &[7.0, 4.0], &[1, 1]);
-        let s2: Pin<
-            Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
-        > = Box::pin(futures::stream::iter(vec![Ok(b2)]));
+        let s2: BatchStream = Box::pin(futures::stream::iter(vec![Ok(b2)]));
         _ = dir
             .write_sidecar(&node_id, &v2, schema.clone(), s2)
             .await
@@ -643,9 +589,7 @@ mod tests {
         assert_eq!(reconciled.missing.len(), 1);
 
         let b3 = partials_batch(&schema, &[0, 1, 2], &[10.0, 12.0, 4.0], &[2, 2, 1]);
-        let s3: Pin<
-            Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
-        > = Box::pin(futures::stream::iter(vec![Ok(b3)]));
+        let s3: BatchStream = Box::pin(futures::stream::iter(vec![Ok(b3)]));
         _ = dir
             .write_sidecar(&node_id, &v3, schema.clone(), s3)
             .await
@@ -707,11 +651,7 @@ mod tests {
         let schema = partials_schema();
 
         async fn put(path: &Path, schema: SchemaRef, batch: RecordBatch) -> String {
-            let s: Pin<
-                Box<
-                    dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send,
-                >,
-            > = Box::pin(futures::stream::iter(vec![Ok(batch)]));
+            let s: BatchStream = Box::pin(futures::stream::iter(vec![Ok(batch)]));
             write_parquet_atomic(path, schema, s).await.unwrap()
         }
 
@@ -809,9 +749,7 @@ mod tests {
         let schema = partials_schema();
         let v1 = test_version(1, Some("v1hash"));
         let b1 = partials_batch(&schema, &[0], &[1.0], &[1]);
-        let s1: Pin<
-            Box<dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send>,
-        > = Box::pin(futures::stream::iter(vec![Ok(b1)]));
+        let s1: BatchStream = Box::pin(futures::stream::iter(vec![Ok(b1)]));
         _ = partials_dir(cache_dir, "cfg", &node_id)
             .write_sidecar(&node_id, &v1, schema.clone(), s1)
             .await

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -73,36 +73,6 @@ pub fn cfg_hash(canonical: &str) -> String {
     format!("{:016x}", hasher.finish())
 }
 
-/// Where an older binary kept a node's per-source-version partials:
-/// `{cache_dir}/rollup_{cfg_hash}_{node_id}/`.
-///
-/// Nothing writes here. It exists only so [`drop_node_namespace`] and
-/// [`drop_all`] still clear a directory left behind by a pond built before the
-/// rollup aggregated its sources directly.
-#[must_use]
-fn legacy_partials_node_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID) -> PathBuf {
-    cache_dir.join(format!("rollup_{}_{}", cfg_hash, node_id))
-}
-
-/// Drop a node's entire rollup-cache namespace for one config, forcing the
-/// rollup to be recomputed from source on next read. Used by the `--rebuild`
-/// recovery path. Idempotent: a missing directory is not an error.
-pub fn drop_node_namespace(
-    cache_dir: &Path,
-    cfg_hash: &str,
-    node_id: &tinyfs::NodeID,
-) -> Result<()> {
-    let dir = legacy_partials_node_dir(cache_dir, cfg_hash, node_id);
-    if dir.exists() {
-        std::fs::remove_dir_all(&dir).map_err(crate::error::Error::Io)?;
-    }
-    let mdir = merged_dir(cache_dir, cfg_hash, node_id);
-    if mdir.exists() {
-        std::fs::remove_dir_all(&mdir).map_err(crate::error::Error::Io)?;
-    }
-    Ok(())
-}
-
 /// Drop every rollup-cache namespace under `cache_dir`, forcing every
 /// temporal-reduce level to be recomputed from source on next read.  This is the
 /// global `--rebuild` recovery primitive.  The format cache and any other cache
@@ -120,7 +90,7 @@ pub fn drop_all(cache_dir: &Path) -> Result<usize> {
             && entry
                 .file_name()
                 .to_str()
-                .is_some_and(|n| n.starts_with("rollup_") || n.starts_with("merged_"));
+                .is_some_and(|n| n.starts_with("merged_"));
         if is_rollup {
             std::fs::remove_dir_all(&path).map_err(crate::error::Error::Io)?;
             dropped += 1;
@@ -509,7 +479,6 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use datafusion::execution::context::SessionContext;
     use std::sync::Arc;
-    use tinyfs::FileVersionInfo;
 
     fn partials_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![
@@ -536,17 +505,6 @@ mod tests {
         .unwrap()
     }
 
-    fn test_version(version: u64, blake3: Option<&str>) -> FileVersionInfo {
-        FileVersionInfo {
-            version,
-            timestamp: 0,
-            size: 100,
-            blake3: blake3.map(str::to_string),
-            entry_type: tinyfs::EntryType::FilePhysicalVersion,
-            extended_metadata: None,
-        }
-    }
-
     fn test_node_id() -> tinyfs::NodeID {
         tinyfs::NodeID::new(uuid7::uuid7().to_string())
     }
@@ -559,51 +517,6 @@ mod tests {
         assert_eq!(a, b, "same config must hash identically");
         assert_ne!(a, c, "different resolution list must change the namespace");
         assert_eq!(a.len(), 16);
-    }
-
-    #[test]
-    fn test_legacy_partials_node_dir_layout() {
-        let cache_dir = Path::new("/tmp/pond/cache");
-        let node_id = test_node_id();
-        let dir = legacy_partials_node_dir(cache_dir, "deadbeef", &node_id);
-        let dir_str = dir.to_str().unwrap();
-        assert!(dir_str.starts_with("/tmp/pond/cache/rollup_deadbeef_"));
-        assert!(dir_str.contains(&node_id.to_string()));
-    }
-
-    /// Fold a cached set the way the read path does, returning
-    /// `(time_bucket, sum, count)` rows.
-    async fn merge_partials(set: &crate::version_cache::CachedSet) -> Vec<(i64, f64, i64)> {
-        let ctx = SessionContext::new();
-        let table = set.table_provider().await.unwrap();
-        _ = ctx.register_table("partials", table).unwrap();
-        let df = ctx
-            .sql(
-                "SELECT time_bucket, SUM(\"__p_sum_0\") AS s, SUM(\"__p_count_1\") AS c \
-                 FROM partials GROUP BY time_bucket ORDER BY time_bucket",
-            )
-            .await
-            .unwrap();
-        let batches = df.collect().await.unwrap();
-        let merged = arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
-        let bucket = merged
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        let s = merged
-            .column(1)
-            .as_any()
-            .downcast_ref::<Float64Array>()
-            .unwrap();
-        let c = merged
-            .column(2)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        (0..merged.num_rows())
-            .map(|i| (bucket.value(i), s.value(i), c.value(i)))
-            .collect()
     }
 
     /// A stray Parquet in the res dir must not contribute rows: the manifest,
@@ -713,27 +626,6 @@ mod tests {
             "an unreferenced Parquet in the res dir was scanned; the read must \
              enumerate the manifest, not list the directory"
         );
-    }
-
-    #[tokio::test]
-    async fn test_drop_node_namespace() {
-        let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = tmp.path();
-        let node_id = test_node_id();
-        // Both namespaces: the live merged cache and the partials directory a
-        // pre-`segments-v3` binary would have left behind. `--rebuild` must
-        // clear both, or the stale one wastes disk forever.
-        let legacy = legacy_partials_node_dir(cache_dir, "cfg", &node_id);
-        std::fs::create_dir_all(&legacy).unwrap();
-        std::fs::write(legacy.join("v1.parquet"), b"stale").unwrap();
-        let merged = merged_dir(cache_dir, "cfg", &node_id);
-        std::fs::create_dir_all(&merged).unwrap();
-
-        drop_node_namespace(cache_dir, "cfg", &node_id).unwrap();
-        assert!(!legacy.exists());
-        assert!(!merged.exists());
-        // Idempotent.
-        drop_node_namespace(cache_dir, "cfg", &node_id).unwrap();
     }
 
     #[tokio::test]

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -448,15 +448,27 @@ pub async fn write_parquet_atomic(
     Ok(digest)
 }
 
-/// Build the read provider for a res dir: a `ListingTable` over all sealed runs
-/// plus the hot file. Verifies every manifest run and the hot file are present
-/// on disk first; a missing member is a hard error (corrupt cache), never a
-/// silent hole in the series.
+/// Build the read provider for a res dir: a `ListingTable` over exactly the
+/// sealed runs named by `manifest`, plus the hot file. A manifest member
+/// missing on disk is a hard error (corrupt cache), never a silent hole in the
+/// series.
+///
+/// The scan names its files EXPLICITLY rather than listing `res_dir`. The two
+/// are not the same set: a `.parquet` can sit in the directory without being
+/// referenced by the manifest, and every such orphan is a duplicate copy of
+/// some bucket range that a directory-shaped scan sums a second time. Orphans
+/// arise in normal operation, not only after a crash -- [`write_parquet_atomic`]
+/// renames a new run into place BEFORE the manifest recording it is written, so
+/// any interruption in that window leaves one behind, and compaction (which must
+/// publish a merged segment before deleting its inputs) widens that window by
+/// design. This is the same defect that let a directory-listed format cache
+/// double-count the versions a collapse superseded; the fix is the same one.
 pub async fn listing_table_for_res_dir(
     res_dir: &Path,
     manifest: &SealedManifest,
     ts_column: &str,
 ) -> Result<Arc<dyn TableProvider>> {
+    let mut files: Vec<PathBuf> = Vec::with_capacity(manifest.runs.len() + 1);
     for run in &manifest.runs {
         let p = run_path(res_dir, &run.name);
         if !p.exists() {
@@ -466,6 +478,7 @@ pub async fn listing_table_for_res_dir(
                 p.display()
             )));
         }
+        files.push(p);
     }
     let hot = hot_path(res_dir);
     if !hot.exists() {
@@ -475,8 +488,16 @@ pub async fn listing_table_for_res_dir(
             hot.display()
         )));
     }
-    let dir_url = format!("file://{}/", res_dir.display());
-    let table_url = ListingTableUrl::parse(&dir_url)?;
+    files.push(hot);
+
+    // Schema from the same explicit member list, so an orphan cannot contribute
+    // a column either. `files` always holds at least the hot file, so the
+    // empty-list directory fallback inside `merge_parquet_schemas` is unreachable.
+    let merged_schema = crate::version_cache::merge_parquet_schemas(&files, res_dir).await?;
+    let mut paths = Vec::with_capacity(files.len());
+    for p in &files {
+        paths.push(ListingTableUrl::parse(format!("file://{}", p.display()))?);
+    }
     // Every run and the hot file is written by a query ending in
     // `ORDER BY time_bucket`, so each file is individually sorted ascending on
     // the timestamp column, and the runs' bucket ranges are disjoint. Declaring
@@ -492,8 +513,7 @@ pub async fn listing_table_for_res_dir(
         .with_file_sort_order(vec![vec![
             datafusion::prelude::col(ts_column).sort(true, false),
         ]]);
-    let merged_schema = crate::version_cache::merge_parquet_schemas_in_dir(res_dir).await?;
-    let config = ListingTableConfig::new(table_url)
+    let config = ListingTableConfig::new_with_multi_paths(paths)
         .with_listing_options(listing_options)
         .with_schema(merged_schema);
     let table = ListingTable::try_new(config)?;
@@ -668,6 +688,117 @@ mod tests {
         (0..merged.num_rows())
             .map(|i| (bucket.value(i), s.value(i), c.value(i)))
             .collect()
+    }
+
+    /// A stray Parquet in the res dir must not contribute rows: the manifest,
+    /// not the directory listing, defines what the scan reads.
+    ///
+    /// Orphans are ordinary, not exotic. `write_parquet_atomic` renames a run
+    /// into place before the manifest naming it is written, so an interruption
+    /// in that window leaves one; compaction must publish a merged segment
+    /// before deleting the inputs it replaces, so it holds that window open on
+    /// purpose. A directory-shaped scan sums such a file a second time, which is
+    /// exactly how a directory-listed format cache double-counted the versions a
+    /// collapse superseded.
+    #[tokio::test]
+    async fn listing_table_ignores_a_parquet_the_manifest_does_not_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let res_dir = tmp.path().join("res60");
+        let schema = partials_schema();
+
+        async fn put(path: &Path, schema: SchemaRef, batch: RecordBatch) -> String {
+            let s: Pin<
+                Box<
+                    dyn Stream<Item = std::result::Result<RecordBatch, crate::error::Error>> + Send,
+                >,
+            > = Box::pin(futures::stream::iter(vec![Ok(batch)]));
+            write_parquet_atomic(path, schema, s).await.unwrap()
+        }
+
+        // One sealed run covering buckets [0, 120) and the open hot file.
+        let run_name = "run-00000000.parquet";
+        let run_digest = put(
+            &run_path(&res_dir, run_name),
+            schema.clone(),
+            partials_batch(&schema, &[0, 60], &[10.0, 20.0], &[1, 2]),
+        )
+        .await;
+        let hot_digest = put(
+            &hot_path(&res_dir),
+            schema.clone(),
+            partials_batch(&schema, &[120], &[40.0], &[4]),
+        )
+        .await;
+
+        // The orphan: a duplicate of the sealed run under a name the manifest
+        // never records, as an interrupted seal or an in-flight compaction
+        // would leave behind.
+        _ = put(
+            &run_path(&res_dir, "run-00000001.parquet"),
+            schema.clone(),
+            partials_batch(&schema, &[0, 60], &[10.0, 20.0], &[1, 2]),
+        )
+        .await;
+
+        let manifest = SealedManifest {
+            format: SEALED_FORMAT.to_string(),
+            allowed_lateness_secs: 0,
+            sealed_hi_secs: Some(120),
+            next_seq: 1,
+            runs: vec![SealedRun {
+                name: run_name.to_string(),
+                lo_secs: None,
+                hi_secs: 120,
+                digest: run_digest,
+            }],
+            hot_digest: Some(hot_digest),
+            covered: BTreeSet::new(),
+            source_digest: None,
+        };
+
+        let provider = listing_table_for_res_dir(&res_dir, &manifest, "time_bucket")
+            .await
+            .unwrap();
+        let ctx = SessionContext::new();
+        _ = ctx.register_table("merged", provider).unwrap();
+        let batches = ctx
+            .sql(
+                "SELECT time_bucket, SUM(\"__p_sum_0\") AS s, SUM(\"__p_count_1\") AS c \
+                 FROM merged GROUP BY time_bucket ORDER BY time_bucket",
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let merged = arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
+        let bucket = merged
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let s = merged
+            .column(1)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        let c = merged
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let got: Vec<(i64, f64, i64)> = (0..merged.num_rows())
+            .map(|i| (bucket.value(i), s.value(i), c.value(i)))
+            .collect();
+
+        // Assert the SUMS, not an average: the orphan doubles sum and count
+        // together, so avg is invariant under this bug and would pass either way.
+        assert_eq!(
+            got,
+            vec![(0, 10.0, 1), (60, 20.0, 2), (120, 40.0, 4)],
+            "an unreferenced Parquet in the res dir was scanned; the read must \
+             enumerate the manifest, not list the directory"
+        );
     }
 
     #[tokio::test]

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -281,6 +281,14 @@ pub fn list_glob_members(glob_dir: &Path) -> Result<Vec<PathBuf>> {
 /// making files genuinely large; this only has to stop the bleeding.
 pub const SEAL_TARGET_BYTES: u64 = 1024 * 1024;
 
+/// Maximum number of sealed runs to leave live in one resolution before
+/// compaction merges regardless of size class.
+///
+/// This bounds read fan-out: every query opens every live run plus hot, so the
+/// count is what a reader pays. Size-tiered merging keeps the number near
+/// `log(data)` on its own; this is the backstop for ragged inputs.
+pub const MAX_LIVE_RUNS: usize = 50;
+
 /// One immutable sealed run file and the half-open output-bucket range it
 /// covers, in epoch seconds. `lo_secs` is `None` for the genesis run (unbounded
 /// below); `hi_secs` is exclusive.
@@ -414,6 +422,29 @@ pub async fn write_sealed_manifest(res_dir: &Path, manifest: &SealedManifest) ->
     Ok(digest)
 }
 
+/// Delete run files that compaction superseded.
+///
+/// MUST be called only after the manifest naming their replacement has been
+/// durably written. Publishing the merged run first and deleting its inputs
+/// second means a crash in between leaves orphans rather than a hole, and
+/// orphans are harmless precisely because reads enumerate the manifest instead
+/// of listing the directory. Doing it the other way round would lose data.
+///
+/// Failures are logged and ignored: a leftover file costs disk, not
+/// correctness, and the next compaction is free to try again.
+pub async fn remove_superseded(files: &[PathBuf]) {
+    for f in files {
+        if let Err(e) = tokio::fs::remove_file(f).await
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            log::warn!(
+                "rollup compaction: could not remove superseded run {}: {e}",
+                f.display()
+            );
+        }
+    }
+}
+
 /// Remove an entire res dir (used when `allowed_lateness` changes or the
 /// coverage shrinks, forcing a rebuild from the retained partials).
 pub fn wipe_sealed_res_dir(res_dir: &Path) -> Result<()> {
@@ -466,12 +497,26 @@ pub async fn listing_table_for_res_dir(
     }
     files.push(hot);
 
+    listing_table_for_files(&files, res_dir, ts_column).await
+}
+
+/// Build a `ListingTable` over exactly `files`, in the order given.
+///
+/// The explicit list is the point: a directory-shaped table would also pick up
+/// orphans, which is the defect [`listing_table_for_res_dir`] exists to avoid.
+/// Compaction needs the same guarantee over a subset -- it reads only the runs
+/// it is merging -- so both go through here.
+pub async fn listing_table_for_files(
+    files: &[PathBuf],
+    fallback_dir: &Path,
+    ts_column: &str,
+) -> Result<Arc<dyn TableProvider>> {
     // Schema from the same explicit member list, so an orphan cannot contribute
     // a column either. `files` always holds at least the hot file, so the
     // empty-list directory fallback inside `merge_parquet_schemas` is unreachable.
-    let merged_schema = crate::version_cache::merge_parquet_schemas(&files, res_dir).await?;
+    let merged_schema = crate::version_cache::merge_parquet_schemas(files, fallback_dir).await?;
     let mut paths = Vec::with_capacity(files.len());
-    for p in &files {
+    for p in files {
         paths.push(ListingTableUrl::parse(format!("file://{}", p.display()))?);
     }
     // Every run and the hot file is written by a query ending in

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -147,18 +147,18 @@ pub fn merged_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID) ->
     cache_dir.join(format!("merged_{}_{}", cfg_hash, node_id))
 }
 
-// --- Segments: watermark + immutable sealed runs ------------------------------
+// --- Segments: watermark + immutable segments ------------------------------
 //
-// Each resolution is a directory of immutable *sealed run* files plus one
+// Each resolution is a directory of immutable *segment* files plus one
 // recomputed *hot* file, separated by a watermark derived from
 // `allowed_lateness`:
 //
 //   {merged_dir}/res{secs}/
-//       run-00000000.parquet   immutable sealed run (buckets [lo, hi))
-//       run-00000001.parquet   ...
+//       seg-00000000.parquet   immutable segment (buckets [lo, hi))
+//       seg-00000001.parquet   ...
 //       hot.parquet            every bucket at or above sealed_hi, recomputed
 //                              each build
-//       manifest.json          watermark + run ranges + source content + digests
+//       manifest.json          watermark + segment ranges + source content + digests
 //
 // Buckets below sealed_hi are frozen once and never rescanned, so per-build cost
 // is bounded to the hot window: the allowed-lateness tail plus whatever has
@@ -166,8 +166,8 @@ pub fn merged_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID) ->
 // one mutable Parquet whose sealed prefix is rewritten every build -- costs
 // O(history) I/O per build.
 //
-// Because a run is identified by the bucket range it covers, late data below the
-// watermark is answerable: the runs holding those buckets are found by lookup,
+// Because a segment is identified by the bucket range it covers, late data below the
+// watermark is answerable: the segments holding those buckets are found by lookup,
 // dropped, and recomputed by the ordinary seal path.
 //
 // The read provider names the manifest's members explicitly; it never lists the
@@ -175,17 +175,17 @@ pub fn merged_dir(cache_dir: &Path, cfg_hash: &str, node_id: &tinyfs::NodeID) ->
 // cannot be double-counted. Consumers apply their own `ORDER BY`.
 
 /// Minimum accumulated size, in bytes, before frozen buckets are sealed into a
-/// run file.
+/// segment file.
 ///
 /// Sealing used to trigger on the watermark advancing, which tied the file count
 /// to how often a build ran rather than to how much data existed: a pond rebuilt
-/// every minute grew a run file every minute, each a few kilobytes. Gating on
+/// every minute grew a segment file every minute, each a few kilobytes. Gating on
 /// size decouples the two, so the count tracks data volume.
 ///
 /// Deliberately modest. The cost of raising it is that the hot window -- which is
 /// recomputed in full on every build -- carries the unsealed remainder, so the
 /// target bounds per-build work. 1 MiB keeps that recompute trivial while still
-/// collapsing hundreds of builds into one run. Compaction is the right tool for
+/// collapsing hundreds of builds into one segment. Compaction is the right tool for
 /// making files genuinely large; this only has to stop the bleeding.
 pub const SEAL_TARGET_BYTES: u64 = 1024 * 1024;
 
@@ -220,43 +220,43 @@ impl SourceRange {
     };
 }
 
-/// Maximum number of sealed runs to leave live in one resolution before
+/// Maximum number of segments to leave live in one resolution before
 /// compaction merges regardless of size class.
 ///
-/// This bounds read fan-out: every query opens every live run plus hot, so the
+/// This bounds read fan-out: every query opens every live segment plus hot, so the
 /// count is what a reader pays. Size-tiered merging keeps the number near
 /// `log(data)` on its own; this is the backstop for ragged inputs.
-pub const MAX_LIVE_RUNS: usize = 50;
+pub const MAX_LIVE_SEGMENTS: usize = 50;
 
-/// One immutable sealed run file and the half-open output-bucket range it
-/// covers, in epoch seconds. `lo_secs` is `None` for the genesis run (unbounded
+/// One immutable segment file and the half-open output-bucket range it
+/// covers, in epoch seconds. `lo_secs` is `None` for the genesis segment (unbounded
 /// below); `hi_secs` is exclusive.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SealedRun {
+pub struct Segment {
     pub name: String,
     pub lo_secs: Option<i64>,
     pub hi_secs: i64,
     pub digest: String,
-    /// On-disk size of the run file in bytes, recorded when it was written.
-    /// Lets compaction choose merge candidates without stat-ing every run.
+    /// On-disk size of the segment file in bytes, recorded when it was written.
+    /// Lets compaction choose merge candidates without stat-ing every segment.
     pub bytes: u64,
 }
 
-/// On-disk format of the sealed run + hot files. Bumped when their column
+/// On-disk format of the segment + hot files. Bumped when their column
 /// layout or the manifest's build semantics change so an older cache is
 /// discarded and rebuilt rather than misread. `segments-v3` stores the
 /// *mergeable partials* (sum/count/min/max) with output columns reconstructed at
 /// read time, keys the finest resolution on source CONTENT (`sources`) rather
 /// than on per-version partial filenames, and may derive a coarser resolution by
-/// folding the next-finer resolution's runs (`source_digest`). Older caches
+/// folding the next-finer resolution's segments (`source_digest`). Older caches
 /// carry a different (or empty) `format` and are wiped + rebuilt.
 pub const SEALED_FORMAT: &str = "segments-v3";
 
-/// Manifest describing the sealed-runs cache for one output resolution. Its
+/// Manifest describing the segment cache for one output resolution. Its
 /// serialized bytes are the export-hint digest, so it must serialize
 /// deterministically (fixed field order; `covered` is an ordered set).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct SealedManifest {
+pub struct SegmentManifest {
     /// On-disk file format (see [`SEALED_FORMAT`]). Absent in legacy manifests,
     /// which deserialize to `""` and are treated as a format mismatch (rebuild).
     #[serde(default)]
@@ -265,13 +265,13 @@ pub struct SealedManifest {
     /// a different value discards and rebuilds the res dir.
     pub allowed_lateness_secs: i64,
     /// Exclusive upper bound (epoch seconds) of the sealed region: every output
-    /// bucket with start `< sealed_hi_secs` lives in some run. `None` before any
+    /// bucket with start `< sealed_hi_secs` lives in some segment. `None` before any
     /// bucket has been sealed.
     pub sealed_hi_secs: Option<i64>,
-    /// Next sealed-run sequence number for file naming.
+    /// Next segment sequence number for file naming.
     pub next_seq: u64,
-    /// Sealed run files in ascending bucket order.
-    pub runs: Vec<SealedRun>,
+    /// Sealed segment files in ascending bucket order.
+    pub segments: Vec<Segment>,
     /// blake3 digest of `hot.parquet`.
     pub hot_digest: Option<String>,
     /// On-disk size of `hot.parquet` as of the last build, in bytes.
@@ -300,7 +300,7 @@ pub struct SealedManifest {
     /// directory holding one file per version ever written was unbounded.
     pub sources: BTreeMap<String, SourceRange>,
     /// For a coarser resolution built by folding the next-finer resolution's
-    /// runs (Phase 3 step 2): the finer resolution's manifest digest this cache
+    /// segments (Phase 3 step 2): the finer resolution's manifest digest this cache
     /// was folded from. `None` for the finest resolution (which aggregates the
     /// sources directly and uses `sources`). A change in the finer digest
     /// triggers a coarse rebuild/advance.
@@ -308,13 +308,13 @@ pub struct SealedManifest {
     pub source_digest: Option<String>,
 }
 
-/// Per-resolution sealed-runs directory: `{merged_dir}/res{interval_secs}/`.
+/// Per-resolution segment directory: `{merged_dir}/res{interval_secs}/`.
 #[must_use]
-pub fn sealed_res_dir(merged_dir: &Path, interval_secs: u64) -> PathBuf {
+pub fn segment_res_dir(merged_dir: &Path, interval_secs: u64) -> PathBuf {
     merged_dir.join(format!("res{}", interval_secs))
 }
 
-fn sealed_manifest_path(res_dir: &Path) -> PathBuf {
+fn segment_manifest_path(res_dir: &Path) -> PathBuf {
     res_dir.join("manifest.json")
 }
 
@@ -324,17 +324,17 @@ pub fn hot_path(res_dir: &Path) -> PathBuf {
     res_dir.join("hot.parquet")
 }
 
-/// Path of a sealed run file by name in a res dir.
+/// Path of a segment file by name in a res dir.
 #[must_use]
-pub fn run_path(res_dir: &Path, name: &str) -> PathBuf {
+pub fn segment_path(res_dir: &Path, name: &str) -> PathBuf {
     res_dir.join(name)
 }
 
-/// Read the sealed-runs manifest. `Ok(None)` when absent (fresh cache). A
+/// Read the segment manifest. `Ok(None)` when absent (fresh cache). A
 /// present-but-unparseable manifest is a hard error rather than a silent
 /// rebuild, matching the frontier/merged-cache corruption discipline.
-pub fn read_sealed_manifest(res_dir: &Path) -> Result<Option<SealedManifest>> {
-    let path = sealed_manifest_path(res_dir);
+pub fn read_segment_manifest(res_dir: &Path) -> Result<Option<SegmentManifest>> {
+    let path = segment_manifest_path(res_dir);
     let bytes = match std::fs::read(&path) {
         Ok(b) => b,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -342,7 +342,7 @@ pub fn read_sealed_manifest(res_dir: &Path) -> Result<Option<SealedManifest>> {
     };
     serde_json::from_slice(&bytes).map(Some).map_err(|e| {
         crate::error::Error::CacheCorrupt(format!(
-            "sealed-runs manifest '{}' is present but unparseable ({}); the rollup \
+            "segment manifest '{}' is present but unparseable ({}); the rollup \
              cache is corrupt. Re-run the export with --rebuild to recompute it.",
             path.display(),
             e
@@ -352,31 +352,31 @@ pub fn read_sealed_manifest(res_dir: &Path) -> Result<Option<SealedManifest>> {
 
 /// Compute the export-hint digest of a manifest without writing it (used on the
 /// reuse path, where the res dir is served unchanged).
-pub fn sealed_manifest_digest(manifest: &SealedManifest) -> Result<String> {
+pub fn segment_manifest_digest(manifest: &SegmentManifest) -> Result<String> {
     let bytes = serde_json::to_vec_pretty(manifest)
         .map_err(|e| crate::error::Error::Arrow(format!("serialize sealed manifest: {}", e)))?;
     Ok(blake3::hash(&bytes).to_hex().to_string())
 }
 
-/// Persist the sealed-runs manifest atomically (tmp + rename) and return the
+/// Persist the segment manifest atomically (tmp + rename) and return the
 /// blake3 digest of its serialized bytes, which callers use as the export-hint
 /// digest for the whole resolution.
-pub async fn write_sealed_manifest(res_dir: &Path, manifest: &SealedManifest) -> Result<String> {
+pub async fn write_segment_manifest(res_dir: &Path, manifest: &SegmentManifest) -> Result<String> {
     tokio::fs::create_dir_all(res_dir).await?;
     let bytes = serde_json::to_vec_pretty(manifest)
         .map_err(|e| crate::error::Error::Arrow(format!("serialize sealed manifest: {}", e)))?;
     let digest = blake3::hash(&bytes).to_hex().to_string();
-    let path = sealed_manifest_path(res_dir);
+    let path = segment_manifest_path(res_dir);
     let tmp = PathBuf::from(format!("{}.tmp", path.display()));
     tokio::fs::write(&tmp, &bytes).await?;
     tokio::fs::rename(&tmp, &path).await?;
     Ok(digest)
 }
 
-/// Delete run files that compaction superseded.
+/// Delete segment files that compaction superseded.
 ///
 /// MUST be called only after the manifest naming their replacement has been
-/// durably written. Publishing the merged run first and deleting its inputs
+/// durably written. Publishing the merged segment first and deleting its inputs
 /// second means a crash in between leaves orphans rather than a hole, and
 /// orphans are harmless precisely because reads enumerate the manifest instead
 /// of listing the directory. Doing it the other way round would lose data.
@@ -389,7 +389,7 @@ pub async fn remove_superseded(files: &[PathBuf]) {
             && e.kind() != std::io::ErrorKind::NotFound
         {
             log::warn!(
-                "rollup compaction: could not remove superseded run {}: {e}",
+                "rollup compaction: could not remove superseded segment {}: {e}",
                 f.display()
             );
         }
@@ -398,7 +398,7 @@ pub async fn remove_superseded(files: &[PathBuf]) {
 
 /// Remove an entire res dir, forcing this resolution to be rebuilt from source
 /// (used when `allowed_lateness` or the on-disk format changes).
-pub fn wipe_sealed_res_dir(res_dir: &Path) -> Result<()> {
+pub fn wipe_segment_res_dir(res_dir: &Path) -> Result<()> {
     match std::fs::remove_dir_all(res_dir) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -407,7 +407,7 @@ pub fn wipe_sealed_res_dir(res_dir: &Path) -> Result<()> {
 }
 
 /// Build the read provider for a res dir: a `ListingTable` over exactly the
-/// sealed runs named by `manifest`, plus the hot file. A manifest member
+/// segments named by `manifest`, plus the hot file. A manifest member
 /// missing on disk is a hard error (corrupt cache), never a silent hole in the
 /// series.
 ///
@@ -416,22 +416,22 @@ pub fn wipe_sealed_res_dir(res_dir: &Path) -> Result<()> {
 /// referenced by the manifest, and every such orphan is a duplicate copy of
 /// some bucket range that a directory-shaped scan sums a second time. Orphans
 /// arise in normal operation, not only after a crash -- [`crate::version_cache::write_parquet_atomic`]
-/// renames a new run into place BEFORE the manifest recording it is written, so
+/// renames a new segment into place BEFORE the manifest recording it is written, so
 /// any interruption in that window leaves one behind, and compaction (which must
 /// publish a merged segment before deleting its inputs) widens that window by
 /// design. This is the same defect that let a directory-listed format cache
 /// double-count the versions a collapse superseded; the fix is the same one.
 pub async fn listing_table_for_res_dir(
     res_dir: &Path,
-    manifest: &SealedManifest,
+    manifest: &SegmentManifest,
     ts_column: &str,
 ) -> Result<Arc<dyn TableProvider>> {
-    let mut files: Vec<PathBuf> = Vec::with_capacity(manifest.runs.len() + 1);
-    for run in &manifest.runs {
-        let p = run_path(res_dir, &run.name);
+    let mut files: Vec<PathBuf> = Vec::with_capacity(manifest.segments.len() + 1);
+    for seg in &manifest.segments {
+        let p = segment_path(res_dir, &seg.name);
         if !p.exists() {
             return Err(crate::error::Error::CacheCorrupt(format!(
-                "sealed run '{}' recorded in the manifest is missing on disk; the \
+                "segment '{}' recorded in the manifest is missing on disk; the \
                  rollup cache is corrupt. Re-run the export with --rebuild.",
                 p.display()
             )));
@@ -441,7 +441,7 @@ pub async fn listing_table_for_res_dir(
     let hot = hot_path(res_dir);
     if !hot.exists() {
         return Err(crate::error::Error::CacheCorrupt(format!(
-            "sealed-runs hot file '{}' is missing; the rollup cache is corrupt. \
+            "hot file '{}' is missing; the rollup cache is corrupt. \
              Re-run the export with --rebuild.",
             hot.display()
         )));
@@ -455,7 +455,7 @@ pub async fn listing_table_for_res_dir(
 ///
 /// The explicit list is the point: a directory-shaped table would also pick up
 /// orphans, which is the defect [`listing_table_for_res_dir`] exists to avoid.
-/// Compaction needs the same guarantee over a subset -- it reads only the runs
+/// Compaction needs the same guarantee over a subset -- it reads only the segments
 /// it is merging -- so both go through here.
 pub async fn listing_table_for_files(
     files: &[PathBuf],
@@ -470,12 +470,12 @@ pub async fn listing_table_for_files(
     for p in files {
         paths.push(ListingTableUrl::parse(format!("file://{}", p.display()))?);
     }
-    // Every run and the hot file is written by a query ending in
+    // Every segment and the hot file is written by a query ending in
     // `ORDER BY time_bucket`, so each file is individually sorted ascending on
-    // the timestamp column, and the runs' bucket ranges are disjoint. Declaring
+    // the timestamp column, and the segments' bucket ranges are disjoint. Declaring
     // that file-level ordering lets the physical planner satisfy a consumer's
     // `ORDER BY {ts}` with a streaming `SortPreservingMergeExec` (k-way merge of
-    // the already-sorted runs + hot) instead of a `SortExec` that buffers the
+    // the already-sorted segments + hot) instead of a `SortExec` that buffers the
     // whole reduced series in memory -- the O(1)-memory read path from the design
     // §3. Parquet statistics (collected by default) give the planner the per-file
     // min/max it needs to order the file groups.
@@ -602,7 +602,7 @@ mod tests {
     /// A stray Parquet in the res dir must not contribute rows: the manifest,
     /// not the directory listing, defines what the scan reads.
     ///
-    /// Orphans are ordinary, not exotic. `write_parquet_atomic` renames a run
+    /// Orphans are ordinary, not exotic. `write_parquet_atomic` renames a segment
     /// into place before the manifest naming it is written, so an interruption
     /// in that window leaves one; compaction must publish a merged segment
     /// before deleting the inputs it replaces, so it holds that window open on
@@ -620,10 +620,10 @@ mod tests {
             write_parquet_atomic(path, schema, s).await.unwrap()
         }
 
-        // One sealed run covering buckets [0, 120) and the open hot file.
-        let run_name = "run-00000000.parquet";
-        let run_digest = put(
-            &run_path(&res_dir, run_name),
+        // One segment covering buckets [0, 120) and the open hot file.
+        let seg_name = "seg-00000000.parquet";
+        let seg_digest = put(
+            &segment_path(&res_dir, seg_name),
             schema.clone(),
             partials_batch(&schema, &[0, 60], &[10.0, 20.0], &[1, 2]),
         )
@@ -635,26 +635,26 @@ mod tests {
         )
         .await;
 
-        // The orphan: a duplicate of the sealed run under a name the manifest
+        // The orphan: a duplicate of the segment under a name the manifest
         // never records, as an interrupted seal or an in-flight compaction
         // would leave behind.
         _ = put(
-            &run_path(&res_dir, "run-00000001.parquet"),
+            &segment_path(&res_dir, "seg-00000001.parquet"),
             schema.clone(),
             partials_batch(&schema, &[0, 60], &[10.0, 20.0], &[1, 2]),
         )
         .await;
 
-        let manifest = SealedManifest {
+        let manifest = SegmentManifest {
             format: SEALED_FORMAT.to_string(),
             allowed_lateness_secs: 0,
             sealed_hi_secs: Some(120),
             next_seq: 1,
-            runs: vec![SealedRun {
-                name: run_name.to_string(),
+            segments: vec![Segment {
+                name: seg_name.to_string(),
                 lo_secs: None,
                 hi_secs: 120,
-                digest: run_digest,
+                digest: seg_digest,
                 bytes: 0,
             }],
             hot_digest: Some(hot_digest),
@@ -733,14 +733,14 @@ mod tests {
     async fn test_merged_cache_drop_all_removes_merged_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let node_id = test_node_id();
-        // Materialize a sealed-runs res dir so drop_all has a merged_* dir to
+        // Materialize a segment res dir so drop_all has a merged_* dir to
         // remove.
-        let res_dir = sealed_res_dir(&merged_dir(tmp.path(), "cfg", &node_id), 60);
-        let manifest = SealedManifest {
+        let res_dir = segment_res_dir(&merged_dir(tmp.path(), "cfg", &node_id), 60);
+        let manifest = SegmentManifest {
             allowed_lateness_secs: 86400,
             ..Default::default()
         };
-        let _ = write_sealed_manifest(&res_dir, &manifest).await.unwrap();
+        let _ = write_segment_manifest(&res_dir, &manifest).await.unwrap();
         assert!(res_dir.exists());
         let dropped = drop_all(tmp.path()).unwrap();
         assert!(dropped >= 1);

--- a/crates/provider/src/rollup_cache.rs
+++ b/crates/provider/src/rollup_cache.rs
@@ -105,10 +105,12 @@ pub fn drop_all(cache_dir: &Path) -> Result<usize> {
 // recomputes only the buckets a change can reach and reuses the rest.
 //
 // Integrity: a blake3 digest of each Parquet's bytes is recorded in the
-// manifest. On read the digest is re-verified. An absent or incompletely
-// published file self-heals via a full remerge; a present file whose bytes do
-// not match the digest is a hard error rather than silently serving tampered
-// aggregates.
+// manifest. A file the manifest names but that is absent is a hard error --
+// segments are published before the manifest that names them, so a missing one
+// means the directory was damaged, not that a build was interrupted. The hot
+// file is the exception: it is mutated in place, so its digest is re-verified
+// against the manifest on every build and a disagreement rebuilds the
+// resolution rather than serving a gap. See `read_verified_segment_manifest`.
 
 /// Directory holding the merged-output cache for one temporal-reduce node and
 /// config namespace: `{cache_dir}/merged_{cfg_hash}_{node_id}/`.
@@ -325,6 +327,52 @@ pub fn read_segment_manifest(res_dir: &Path) -> Result<Option<SegmentManifest>> 
             e
         ))
     })
+}
+
+/// [`read_segment_manifest`], discarding a manifest that disagrees with the hot
+/// file on disk.
+///
+/// `hot.parquet` is the one file in the layout that is MUTATED IN PLACE: each
+/// build renames a freshly merged hot over the previous one, and only then
+/// writes the manifest recording the watermark that hot was built for. A crash
+/// in that window leaves a hot holding only `bucket >= new_wm` alongside a
+/// manifest still claiming `sealed_hi = old_wm`, so the buckets between them
+/// live in no member of the cache. Nothing else detects this: the read path
+/// checks only that the named files EXIST, and if the sources are unchanged the
+/// next build reuses the manifest and serves the hole indefinitely.
+///
+/// Treating the disagreement as "no usable manifest" makes it self-healing --
+/// the caller rebuilds the resolution from source -- at the cost of one blake3
+/// of hot per build, which is bounded by the seal target and is rewritten by
+/// that same build anyway.
+///
+/// Segments need no such check: they are immutable, published under a fresh
+/// name BEFORE the manifest that names them, and deleted only after it is
+/// durable, so a crash can only orphan a file that no manifest references.
+pub fn read_verified_segment_manifest(res_dir: &Path) -> Result<Option<SegmentManifest>> {
+    let Some(m) = read_segment_manifest(res_dir)? else {
+        return Ok(None);
+    };
+    let hot = hot_path(res_dir);
+    match (&m.hot_digest, hot.exists()) {
+        (Some(recorded), true) => {
+            let actual = crate::version_cache::file_blake3(&hot)?;
+            if &actual == recorded {
+                Ok(Some(m))
+            } else {
+                log::warn!(
+                    "[ROLLUP] hot file '{}' does not match the digest recorded in \
+                     the manifest; rebuilding this resolution (a build was \
+                     interrupted between publishing hot and its manifest)",
+                    hot.display()
+                );
+                Ok(None)
+            }
+        }
+        // No hot yet, or a manifest that predates the digest: nothing to check
+        // against, and the caller's existence checks still apply.
+        _ => Ok(Some(m)),
+    }
 }
 
 /// Compute the export-hint digest of a manifest without writing it (used on the
@@ -626,6 +674,42 @@ mod tests {
             "an unreferenced Parquet in the res dir was scanned; the read must \
              enumerate the manifest, not list the directory"
         );
+    }
+
+    /// The hot file is mutated in place BEFORE the manifest recording the
+    /// watermark it was built for. A crash in that window leaves the two
+    /// disagreeing and the buckets between the old and new watermarks in no
+    /// member of the cache -- served forever, because an unchanged source makes
+    /// the next build reuse. The manifest must therefore be rejected when hot
+    /// does not match the digest it recorded.
+    #[tokio::test]
+    async fn a_hot_file_that_disagrees_with_its_manifest_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let res_dir = tmp.path().to_path_buf();
+        std::fs::create_dir_all(&res_dir).unwrap();
+        std::fs::write(hot_path(&res_dir), b"hot bytes").unwrap();
+        let digest = crate::version_cache::file_blake3(&hot_path(&res_dir)).unwrap();
+
+        let m = SegmentManifest {
+            format: SEALED_FORMAT.to_string(),
+            hot_digest: Some(digest),
+            ..Default::default()
+        };
+        _ = write_segment_manifest(&res_dir, &m).await.unwrap();
+
+        assert!(
+            read_verified_segment_manifest(&res_dir).unwrap().is_some(),
+            "a matching hot file keeps the manifest usable"
+        );
+
+        // Simulate the crash: hot advanced, the manifest did not.
+        std::fs::write(hot_path(&res_dir), b"a newer hot, published first").unwrap();
+        assert!(
+            read_verified_segment_manifest(&res_dir).unwrap().is_none(),
+            "a hot file that does not match its manifest must force a rebuild"
+        );
+        // The manifest itself is still readable: this is a rebuild, not corruption.
+        assert!(read_segment_manifest(&res_dir).unwrap().is_some());
     }
 
     #[tokio::test]

--- a/crates/provider/src/size_tier.rs
+++ b/crates/provider/src/size_tier.rs
@@ -1,0 +1,167 @@
+//! Size-tiered merge policy, shared by every accumulating segment store.
+//!
+//! Two places in this codebase accumulate immutable, range-ordered segments and
+//! must periodically merge them to keep their count bounded: tlogfs series
+//! collapse, and the rollup cache's sealed runs. The policy for choosing WHICH
+//! segments to merge is identical in both, and depends on nothing but their
+//! sizes -- so it lives here once and is called from both, rather than being
+//! reimplemented alongside each store.
+//!
+//! That is not a stylistic preference. The archived rollup design instructed
+//! that a sibling module be mirrored "exactly" from an existing one; the two
+//! copies then drifted, and the resulting disagreements were the source of this
+//! branch's double-counting bugs. A tiering policy written twice is the same
+//! hazard: the copies are meant to agree, nothing forces them to, and the
+//! symptom of divergence is quiet write amplification rather than an error.
+
+use std::ops::Range;
+
+/// How many adjacent same-class segments merge into one.
+///
+/// The value trades write volume against read cost. A larger fanout writes
+/// slightly less but leaves up to `F - 1` live segments per class, and reads pay
+/// per live segment. At `F = 10` a store holds at most a few dozen live segments
+/// across all classes while keeping write amplification to a small constant.
+pub const MERGE_FANOUT: usize = 10;
+
+/// Size class of a segment, i.e. its magnitude in units of [`MERGE_FANOUT`].
+///
+/// Segments merge only with segments of the same class, which is what keeps a
+/// large accumulated segment from being rewritten every time a few small ones
+/// arrive.
+#[must_use]
+pub fn size_class(bytes: u64) -> u32 {
+    let mut class = 0u32;
+    let mut bound = MERGE_FANOUT as u64;
+    while bytes >= bound {
+        class += 1;
+        match bound.checked_mul(MERGE_FANOUT as u64) {
+            Some(next) => bound = next,
+            None => break,
+        }
+    }
+    class
+}
+
+/// Choose the contiguous window of segments to merge, or `None` for a no-op.
+///
+/// `sizes` are the on-disk byte counts of the live segments, ordered oldest
+/// content first; the returned half-open range indexes into that slice.
+///
+/// Size-tiered policy: merge the oldest group of [`MERGE_FANOUT`] *adjacent*
+/// segments sharing a size class. Merging only same-class neighbours is the
+/// whole point -- it is what stops a 96 MB accumulated segment from being
+/// rewritten to absorb 10 KB of new data.
+///
+/// `max_live` is a backstop for read cost. If no same-class group exists but the
+/// store has drifted past `max_live` segments, [`MERGE_FANOUT`] adjacent
+/// segments are merged regardless of class so the count stays bounded.
+///
+/// The backstop merges the CHEAPEST such window, not the oldest. Taking the
+/// oldest looks natural but is the one choice that defeats tiering: after any
+/// previous merge the oldest segment IS the large accumulated one, so a backstop
+/// anchored at index 0 rewrites megabytes to absorb kilobytes -- precisely the
+/// `O(N^2)` behaviour size classes exist to prevent. It also fires more often
+/// than it appears to, because callers may pass the same number as both the
+/// candidacy threshold and `max_live`, so every candidate satisfies
+/// `sizes.len() > max_live` by construction. Choosing by total bytes bounds the
+/// segment count just as well while keeping write volume at the minimum any
+/// window could achieve.
+#[must_use]
+pub fn choose_merge_window(sizes: &[u64], max_live: usize) -> Option<Range<usize>> {
+    if sizes.len() < 2 {
+        return None;
+    }
+
+    // Oldest same-class group of at least MERGE_FANOUT adjacent segments.
+    let classes: Vec<u32> = sizes.iter().copied().map(size_class).collect();
+    let mut start = 0usize;
+    while start < classes.len() {
+        let mut end = start + 1;
+        while end < classes.len() && classes[end] == classes[start] {
+            end += 1;
+        }
+        if end - start >= MERGE_FANOUT {
+            return Some(start..start + MERGE_FANOUT);
+        }
+        start = end;
+    }
+
+    // Backstop: bound live segment count even when classes are ragged. Every
+    // window of this width reduces the count identically, so pick the one that
+    // rewrites the fewest bytes; ties resolve to the oldest.
+    if sizes.len() > max_live {
+        let width = MERGE_FANOUT.min(sizes.len());
+        let cost = |start: usize| -> u128 {
+            sizes[start..start + width]
+                .iter()
+                .map(|&b| u128::from(b))
+                .sum()
+        };
+        let best = (0..=sizes.len() - width).min_by_key(|&start| cost(start))?;
+        return Some(best..best + width);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_class_counts_magnitudes_of_fanout() {
+        assert_eq!(size_class(0), 0);
+        assert_eq!(size_class(9), 0);
+        assert_eq!(size_class(10), 1);
+        assert_eq!(size_class(99), 1);
+        assert_eq!(size_class(100), 2);
+        // Must not overflow or spin on an enormous segment.
+        assert!(size_class(u64::MAX) > 0);
+    }
+
+    #[test]
+    fn no_window_below_two_segments() {
+        assert_eq!(choose_merge_window(&[], 1), None);
+        assert_eq!(choose_merge_window(&[5], 0), None);
+    }
+
+    #[test]
+    fn merges_oldest_full_group_of_one_class() {
+        // 12 same-class segments: the OLDEST ten merge, leaving the newest two.
+        let sizes = vec![5u64; 12];
+        assert_eq!(choose_merge_window(&sizes, 100), Some(0..10));
+    }
+
+    #[test]
+    fn leaves_a_large_segment_alone_when_small_ones_arrive() {
+        // One big accumulated segment followed by a few small ones: no group of
+        // ten shares a class and the count is under the backstop, so nothing is
+        // rewritten. Merging here would rewrite the large segment to absorb
+        // almost nothing, which is the O(N^2) trap.
+        let mut sizes = vec![10_000_000u64];
+        sizes.extend(std::iter::repeat_n(5u64, 4));
+        assert_eq!(choose_merge_window(&sizes, 100), None);
+    }
+
+    #[test]
+    fn backstop_picks_the_cheapest_window_not_the_oldest() {
+        // Ragged classes, over the backstop: the large accumulated segment sits
+        // oldest. Anchoring at 0 would rewrite it to absorb kilobytes.
+        let mut sizes = vec![10_000_000u64];
+        sizes.extend((0..14).map(|i| 5 + i as u64));
+        let w = choose_merge_window(&sizes, 10).expect("backstop must fire");
+        assert!(
+            w.start > 0,
+            "backstop anchored at the large oldest segment: {w:?}"
+        );
+        // Cheapest ten of the small tail are the ten smallest, i.e. indices 1..11.
+        assert_eq!(w, 1..11);
+    }
+
+    #[test]
+    fn backstop_does_not_fire_while_under_max_live() {
+        let sizes = vec![10_000_000u64, 5, 6, 7];
+        assert_eq!(choose_merge_window(&sizes, 100), None);
+    }
+}

--- a/crates/provider/src/size_tier.rs
+++ b/crates/provider/src/size_tier.rs
@@ -164,4 +164,36 @@ mod tests {
         let sizes = vec![10_000_000u64, 5, 6, 7];
         assert_eq!(choose_merge_window(&sizes, 100), None);
     }
+
+    #[test]
+    fn finds_a_full_group_that_does_not_start_at_the_oldest_segment() {
+        // A large accumulated segment, then twelve small ones. The scan must
+        // step OVER the ragged prefix and merge within the run behind it; a
+        // scan that only ever considered a group anchored at index 0 would
+        // find nothing here and leave the small segments to accumulate until
+        // the backstop fired.
+        let mut sizes = vec![10_000_000u64];
+        sizes.extend(std::iter::repeat_n(5u64, 12));
+        // The OLDEST ten OF THE RUN, not the newest ten and not the whole run.
+        assert_eq!(choose_merge_window(&sizes, 100), Some(1..11));
+    }
+
+    #[test]
+    fn same_class_segments_split_by_another_class_are_not_a_group() {
+        // Ten class-0 segments in total, but a large one sits between them.
+        // Adjacency is not a preference here: `sizes` is in content order and a
+        // merged segment inherits the range spanning its window, so merging
+        // across the interloper would produce a segment whose range covers data
+        // that still lives in the interloper -- an overlap, and a double count
+        // on read. Leaving them unmerged is the only correct answer.
+        let mut sizes = vec![5u64; 5];
+        sizes.push(10_000_000);
+        sizes.extend(std::iter::repeat_n(5u64, 5));
+        assert_eq!(
+            choose_merge_window(&sizes, 100),
+            None,
+            "non-adjacent same-class segments must not be merged across the \
+             segment separating them"
+        );
+    }
 }

--- a/crates/provider/src/size_tier.rs
+++ b/crates/provider/src/size_tier.rs
@@ -2,7 +2,7 @@
 //!
 //! Two places in this codebase accumulate immutable, range-ordered segments and
 //! must periodically merge them to keep their count bounded: tlogfs series
-//! collapse, and the rollup cache's sealed runs. The policy for choosing WHICH
+//! collapse, and the rollup cache's segments. The policy for choosing WHICH
 //! segments to merge is identical in both, and depends on nothing but their
 //! sizes -- so it lives here once and is called from both, rather than being
 //! reimplemented alongside each store.

--- a/crates/provider/src/version_cache.rs
+++ b/crates/provider/src/version_cache.rs
@@ -283,15 +283,15 @@ impl SidecarDir {
         live: &LiveVersions,
         retain: impl Fn(&FileVersionInfo) -> bool,
     ) -> CachedSet {
-        let files = live
+        let (files, missing) = live
             .as_slice()
             .iter()
             .filter(|v| retain(v))
             .map(|v| self.sidecar_path(live.node_id(), v))
-            .filter(|p| p.exists())
-            .collect();
+            .partition(|p| p.exists());
         CachedSet {
             files,
+            missing,
             fallback_dir: self.dir.clone(),
         }
     }
@@ -325,6 +325,10 @@ impl SidecarDir {
 #[derive(Debug, Clone)]
 pub struct CachedSet {
     files: Vec<PathBuf>,
+    /// Live versions that were retained by the caller's predicate but whose
+    /// sidecar is not on disk. Silently reading fewer rows is never correct, so
+    /// this is reported rather than dropped; see [`CachedSet::missing`].
+    missing: Vec<PathBuf>,
     /// Used only to recover a schema when no live sidecar is present yet.
     fallback_dir: PathBuf,
 }
@@ -340,6 +344,20 @@ impl CachedSet {
         self.files.is_empty()
     }
 
+    /// Retained live versions with no sidecar on disk.
+    ///
+    /// Normally empty: the caller caches every live version before reading. It
+    /// is non-empty when a concurrent reconciler deleted a sidecar this reader
+    /// still considers live (neither takes a lock), and it matters because a
+    /// caller that RECORDS what it read -- the rollup manifest names the live
+    /// source digests it covered -- would otherwise publish coverage it does not
+    /// have, and then reuse that undercount forever because the record agrees
+    /// with itself.
+    #[must_use]
+    pub fn missing(&self) -> &[PathBuf] {
+        &self.missing
+    }
+
     /// Absorb another node's cached set from the same directory.
     ///
     /// A [`SidecarNaming::NodeScoped`] directory is read as one table spanning
@@ -348,6 +366,7 @@ impl CachedSet {
     /// live versions, which is what keeps a superseded sidecar out.
     pub fn extend(&mut self, other: CachedSet) {
         self.files.extend(other.files);
+        self.missing.extend(other.missing);
     }
 
     /// An empty set that falls back to `dir` for schema recovery.
@@ -355,6 +374,7 @@ impl CachedSet {
     pub fn empty_in(dir: PathBuf) -> Self {
         Self {
             files: Vec::new(),
+            missing: Vec::new(),
             fallback_dir: dir,
         }
     }
@@ -662,6 +682,32 @@ mod tests {
         // v2 has no file yet, and the dead sidecar is not reachable at all.
         assert_eq!(set.files().len(), 1);
         assert!(set.files()[0].ends_with("v1_aaa.parquet"));
+
+        // v2 is live but absent, so it is REPORTED rather than silently
+        // dropped: a caller that records what it covered must not claim it.
+        assert_eq!(set.missing().len(), 1, "v2 is live with no sidecar");
+        assert!(set.missing()[0].ends_with("v2_bbb.parquet"));
+    }
+
+    #[test]
+    fn missing_excludes_versions_the_predicate_pruned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = SidecarDir::new(tmp.path().to_path_buf(), SidecarNaming::NodeOwned);
+        let n = node(1);
+        let v1 = version(1, Some("aaa"));
+        let v2 = version(2, Some("bbb"));
+        touch(&dir.sidecar_path(&n, &v1));
+
+        // v2 has no sidecar, but the predicate excluded it, so it was never
+        // going to be read: pruning for a query's bounds is not a lost race.
+        let live = LiveVersions::from_persistence(n, vec![v1, v2]);
+        let set = dir.cached_set(&live, |v| v.version < 2);
+        assert_eq!(set.files().len(), 1);
+        assert!(
+            set.missing().is_empty(),
+            "a pruned version is not missing: {:?}",
+            set.missing()
+        );
     }
 
     #[test]

--- a/crates/provider/src/version_cache.rs
+++ b/crates/provider/src/version_cache.rs
@@ -461,10 +461,11 @@ pub async fn merge_parquet_schemas(files: &[PathBuf], fallback_dir: &Path) -> Re
 
 /// Merge the schemas of every `.parquet` directly under `dir`.
 ///
-/// Only for schema recovery and for genuinely directory-shaped caches (the
-/// symlink glob dir, which is rebuilt from the live set on every query). Never
-/// use it to decide which files a read scans.
-pub async fn merge_parquet_schemas_in_dir(dir: &Path) -> Result<SchemaRef> {
+/// Private, and deliberately so: this is schema RECOVERY for the case where no
+/// live member exists to describe the data, never a way to decide which files a
+/// read scans. The last directory-shaped reader (the symlink glob dir) is gone;
+/// keeping this unexported is what stops another one appearing.
+async fn merge_parquet_schemas_in_dir(dir: &Path) -> Result<SchemaRef> {
     let mut schemas = Vec::new();
     if dir.exists() {
         let mut entries = tokio::fs::read_dir(dir).await?;

--- a/crates/provider/src/version_cache.rs
+++ b/crates/provider/src/version_cache.rs
@@ -309,7 +309,9 @@ impl SidecarDir {
     ) -> Result<PathBuf> {
         tokio::fs::create_dir_all(&self.dir).await?;
         let final_path = self.sidecar_path(node_id, version);
-        write_parquet_stream(&final_path, schema, stream).await?;
+        // The sidecar's identity is its filename (node, version, blake3 of the
+        // SOURCE), so the digest of the written Parquet is not recorded here.
+        let _digest = write_parquet_atomic(&final_path, schema, stream).await?;
         log::debug!("[SAVE] sidecar cache: wrote {}", final_path.display());
         Ok(final_path)
     }
@@ -387,16 +389,25 @@ impl CachedSet {
     }
 }
 
-/// Stream `stream` into a Parquet file at `path`, atomically.
-pub async fn write_parquet_stream(
+/// Stream `stream` into a Parquet file at `path` atomically (tmp + rename), and
+/// return the blake3 digest of the bytes written.
+///
+/// The single Parquet writer for every on-disk cache in this crate: the
+/// per-version sidecars, the rollup's sealed runs, and its hot file. They had
+/// diverged into two byte-identical copies differing only in whether the digest
+/// was returned, which is the shape of duplication that later drifts apart.
+/// Callers with nothing to record simply drop the digest.
+pub async fn write_parquet_atomic(
     path: &Path,
     schema: SchemaRef,
     mut stream: BatchStream,
-) -> Result<()> {
+) -> Result<String> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
-    let tmp_path = path.with_extension("parquet.tmp");
+    // Deliberately NOT `{stem}.parquet.tmp`: a partial write must not end in
+    // `.parquet`, or a `ListingTable` filtering on that extension would scan it.
+    let tmp_path = PathBuf::from(format!("{}.tmp", path.display()));
     let file = tokio::fs::File::create(&tmp_path).await?;
     let props = WriterProperties::builder()
         .set_compression(Compression::ZSTD(parquet::basic::ZstdLevel::default()))
@@ -416,8 +427,18 @@ pub async fn write_parquet_stream(
         .await
         .map_err(|e| crate::error::Error::Arrow(e.to_string()))?;
 
+    // Digest the temp file, before the rename publishes it.
+    let digest = file_blake3(&tmp_path)?;
     tokio::fs::rename(&tmp_path, path).await?;
-    Ok(())
+    Ok(digest)
+}
+
+/// Hex blake3 digest of a file's bytes.
+pub fn file_blake3(path: &Path) -> Result<String> {
+    let mut hasher = blake3::Hasher::new();
+    let mut file = std::fs::File::open(path).map_err(crate::error::Error::Io)?;
+    let _copied = std::io::copy(&mut file, &mut hasher).map_err(crate::error::Error::Io)?;
+    Ok(hasher.finalize().to_hex().to_string())
 }
 
 /// Read and merge the Arrow schemas of an explicit list of Parquet files.

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -181,36 +181,27 @@ struct CollapseCandidate {
     node_id: String,
 }
 
-/// Number of same-size-class runs merged into one run of the next class.
+/// How many adjacent same-class versions collapse into one run.
 ///
-/// This is the fanout of a size-tiered (LSM-style) compaction: each byte is
-/// rewritten once per class it is promoted through, so total write volume is
-/// `O(N log_F N)` rather than the `O(N^2)` of repeatedly rewriting the whole
-/// series.
-///
-/// The value trades write volume against read cost. A larger fanout writes
-/// slightly less but leaves up to `F - 1` live runs per class, and reads pay
-/// per live segment. At `F = 10` a series holds at most a few dozen live
-/// segments across all classes -- fewer than the ~100 loose versions the old
-/// scheme allowed between collapses -- while keeping write amplification to a
-/// small constant.
-pub const COLLAPSE_FANOUT: usize = 10;
+/// Re-exported from the shared size-tiered policy so that series collapse and
+/// the rollup cache's segment compaction cannot drift apart.
+pub use provider::size_tier::MERGE_FANOUT as COLLAPSE_FANOUT;
 
-/// Size class of a run, i.e. its magnitude in units of [`COLLAPSE_FANOUT`].
+/// Choose the contiguous window of live rows to merge, or `None` for a no-op.
 ///
-/// Runs merge only with runs of the same class, which is what keeps a large
-/// accumulated run from being rewritten every time a few small versions arrive.
-fn size_class(bytes: u64) -> u32 {
-    let mut class = 0u32;
-    let mut bound = COLLAPSE_FANOUT as u64;
-    while bytes >= bound {
-        class += 1;
-        match bound.checked_mul(COLLAPSE_FANOUT as u64) {
-            Some(next) => bound = next,
-            None => break,
-        }
-    }
-    class
+/// Thin adapter over [`provider::size_tier::choose_merge_window`]: the policy
+/// depends on nothing but segment sizes, so all this does is project the sizes
+/// out of the oplog rows. `size` is a nullable `i64` on disk; a missing or
+/// negative size is treated as zero, which puts the row in the smallest class
+/// and so makes it a merge candidate rather than an obstacle.
+///
+/// `live` must be ordered oldest content first; the returned range indexes it.
+fn choose_collapse_window(live: &[&OplogEntry], max_live: usize) -> Option<Range<usize>> {
+    let sizes: Vec<u64> = live
+        .iter()
+        .map(|r| r.size.unwrap_or(0).max(0) as u64)
+        .collect();
+    provider::size_tier::choose_merge_window(&sizes, max_live)
 }
 
 /// Temporal overrides the merged run must carry forward.
@@ -233,70 +224,6 @@ fn inherited_overrides(records: &[OplogEntry], lo: i64, hi: i64) -> (Option<i64>
         .filter(|r| r.min_override.is_some() || r.max_override.is_some())
         .max_by_key(|r| r.version)
         .map_or((None, None), |r| (r.min_override, r.max_override))
-}
-
-/// Choose the contiguous window of live rows to merge, or `None` for a no-op.
-///
-/// Size-tiered policy: merge the oldest group of [`COLLAPSE_FANOUT`] *adjacent*
-/// rows sharing a size class. Merging only same-class neighbours is the whole
-/// point -- it is what stops a 96 MB accumulated run from being rewritten to
-/// absorb 10 KB of new data.
-///
-/// `max_live` is a backstop for read cost. If no same-class group exists but the
-/// series has drifted past `max_live` segments, `COLLAPSE_FANOUT` adjacent rows
-/// are merged regardless of class so segment count stays bounded.
-///
-/// The backstop merges the CHEAPEST such window, not the oldest. Taking the
-/// oldest looks natural but is the one choice that defeats tiering: after any
-/// previous collapse the oldest row IS the large accumulated run, so a backstop
-/// anchored at index 0 rewrites megabytes to absorb kilobytes -- precisely the
-/// `O(N^2)` behaviour size classes exist to prevent. It also fires more often
-/// than it appears to, because callers pass the same number as both the
-/// candidacy threshold (`HAVING COUNT(*) > threshold`) and `max_live`, so every
-/// candidate satisfies `live.len() > max_live` by construction. Choosing by
-/// total bytes bounds the segment count just as well while keeping write volume
-/// at the minimum any window could achieve.
-///
-/// Returns a half-open index range into `live` (which must be ordered oldest
-/// content first).
-fn choose_collapse_window(live: &[&OplogEntry], max_live: usize) -> Option<Range<usize>> {
-    if live.len() < 2 {
-        return None;
-    }
-
-    // Oldest same-class group of at least COLLAPSE_FANOUT adjacent rows.
-    let classes: Vec<u32> = live
-        .iter()
-        .map(|r| size_class(r.size.unwrap_or(0).max(0) as u64))
-        .collect();
-    let mut start = 0usize;
-    while start < classes.len() {
-        let mut end = start + 1;
-        while end < classes.len() && classes[end] == classes[start] {
-            end += 1;
-        }
-        if end - start >= COLLAPSE_FANOUT {
-            return Some(start..start + COLLAPSE_FANOUT);
-        }
-        start = end;
-    }
-
-    // Backstop: bound live segment count even when classes are ragged. Every
-    // window of this width reduces the segment count identically, so pick the
-    // one that rewrites the fewest bytes; ties resolve to the oldest.
-    if live.len() > max_live {
-        let width = COLLAPSE_FANOUT.min(live.len());
-        let cost = |start: usize| -> u128 {
-            live[start..start + width]
-                .iter()
-                .map(|r| r.size.unwrap_or(0).max(0) as u128)
-                .sum()
-        };
-        let best = (0..=live.len() - width).min_by_key(|&start| cost(start))?;
-        return Some(best..best + width);
-    }
-
-    None
 }
 
 /// One reconstructed write transaction recovered from the data Delta
@@ -5219,8 +5146,9 @@ mod series_bounds_tests {
 
 #[cfg(test)]
 mod collapse_window_tests {
-    use super::{COLLAPSE_FANOUT, choose_collapse_window, size_class};
+    use super::{COLLAPSE_FANOUT, choose_collapse_window};
     use crate::schema::OplogEntry;
+    use provider::size_tier::size_class;
 
     /// A live row of the given byte size; only `size` affects window choice.
     fn row(size: i64) -> OplogEntry {

--- a/docs/archive/incremental-rollup-implementation.md
+++ b/docs/archive/incremental-rollup-implementation.md
@@ -1,3 +1,21 @@
+> **SUPERSEDED (see `docs/rollup-storage-redesign.md`).** Kept for history.
+>
+> Two of this document's load-bearing claims are no longer true of the code:
+>
+> - *"No watermark, no mutable state file."* There is a watermark and a
+>   `manifest.json` per resolution. Content addressing alone bounded neither the
+>   file count nor the per-build merge cost.
+> - *"Enabling invariant: sequential input."* The rollup no longer requires it.
+>   The cache is keyed by the time range each file covers, so late data unseals
+>   the segments covering it and recomputes them. The sequentiality frontier and
+>   the `--rebuild` recovery it needed are both gone; `--rebuild` survives only
+>   as a maintenance escape hatch.
+>
+> Its instruction to "mirror `format_cache.rs` **exactly**, in a new sibling
+> module" is also worth not repeating: the copies drifted, and the resulting
+> mechanisms were individually incomplete rather than redundant, so correctness
+> depended on all of them agreeing with nothing forcing it.
+
 # Incremental temporal-reduce rollup: repair design and plan
 
 Status: design + implementation plan. Phase 1 (decomposable-aggregate

--- a/docs/rollup-storage-redesign.md
+++ b/docs/rollup-storage-redesign.md
@@ -1,0 +1,547 @@
+# Rollup cache storage redesign: fewer files, correctly
+
+Status: proposed. Supersedes the storage decisions in
+`docs/archive/incremental-rollup-implementation.md` (PR #87), whose stated
+justification no longer holds.
+
+## 1. Summary
+
+The temporal-reduce rollup cache stores its state as a large number of very
+small Parquet files. Three separate populations grow without bound, on three
+different axes, and every one of the silent-double-counting bugs fixed in #122
+was a consequence of how those files are *keyed* rather than of the aggregation
+logic itself.
+
+This document proposes replacing the two-layer (per-version partials → sealed
+runs) design with a single layer: **immutable segments keyed by the output time
+range they cover, plus one open hot segment, compacted by the same size-tiered
+policy already used for physical-series collapse in tlogfs.**
+
+The per-version partials layer is deleted outright. Partial *aggregate state*
+(`__p_sum`, `__p_count`, …) is retained unchanged — that part is correct and
+conventional — but it becomes a column layout inside segments rather than a file
+naming scheme.
+
+Net effect: file count per resolution goes from *one per build, forever* to a
+number bounded by `O(FANOUT · log_FANOUT(total_bytes / target_bytes))` — a few
+dozen — and the cache stops being able to observe version collapse at all.
+
+## 2. What exists today
+
+### 2.1 Layers
+
+```
+{cache_dir}/
+  {scheme}_{node_id}/                       (A) format cache
+      v{version}-{blake3}.parquet                one file per source version
+  rollup_{cfg_hash}_{site_node}/
+      partials/                             (B) rollup partials
+          {node_id}_{version}_{blake3}.parquet   one file per source version
+      merged/res{secs}/                     (C) sealed runs
+          run-00000000.parquet                   one file per *build*
+          run-00000001.parquet
+          hot.parquet
+          manifest.json
+```
+
+- **(A) format cache** — `crates/provider/src/format_cache.rs`. The decoded
+  Parquet of each source version.
+- **(B) partials** — `crates/provider/src/factory/temporal_reduce.rs`,
+  `write_version_partial` (line 1301). Each source version pre-aggregated to the
+  *finest* interval, in mergeable partial columns.
+- **(C) sealed runs** — `crates/provider/src/rollup_cache.rs`, `SealedRun` /
+  `SealedManifest` (lines 287, 307). Output buckets below a watermark frozen
+  into immutable files; buckets above it recomputed into `hot.parquet` each
+  build.
+
+### 2.2 How a build proceeds
+
+`try_rollup_table_provider` (temporal_reduce.rs:431):
+
+1. For each source node, reconcile (B) against live versions, write a partial
+   for each live version missing one (line 530–605).
+2. Register all live partials as one table (line 611-620).
+3. Finest resolution: `build_level_from_partials` (line 1026) compares
+   `manifest.covered` — *a set of partial filenames* — against the current
+   directory listing to choose `Reuse` / `Incremental` / `Rebuild`.
+4. `seal_and_recompute` (line 951) seals `[sealed_hi, watermark)` into a new run
+   and rewrites `hot.parquet`.
+5. Coarser resolutions: `build_level_from_finer` (line 1172) folds the
+   next-finer level's *segments*, keyed on `source_digest`.
+
+Note step 5. The coarse levels already do the right thing.
+
+## 3. What is wrong
+
+### 3.1 Three unbounded populations, three axes
+
+| | grows per | bounded today? | garbage collected? |
+|---|---|---|---|
+| (A) format cache | source version ever written | **no** | **no** |
+| (B) partials | live source version | yes, since #122 | yes (`reconcile`) |
+| (C) sealed runs | **build** (wall-clock) | **no** | **no** |
+
+Specifics:
+
+**(A) is never collected.** `SidecarDir::reconcile` exists and works, but
+`grep -rn '\.reconcile('` shows exactly one non-test caller:
+temporal_reduce.rs:530, for partials. `format_cache` only ever calls
+`cached_set` (format_cache.rs:134). That call made reads *safe* — the scan names
+live files explicitly instead of listing the directory — but nothing deletes the
+superseded ones. A previously measured deployment held 21,659 files / 96 MB at
+~4.4 KB average. Every version collapse adds a merged file and orphans ten.
+
+**(C) grows with wall-clock time, not data.** `m.runs.push(...)`
+(temporal_reduce.rs:988) is the only writer to `SealedManifest::runs`;
+`listing_table_for_res_dir` (rollup_cache.rs:455) is the only reader. There is
+no compaction anywhere in the crate. `seal_and_recompute` appends a run whenever
+the watermark advances, which is every build that sees new data. Under hourly
+builds that is ~8,760 files per resolution per year, each holding one hour of
+buckets, and with a nesting chain of resolutions it is that figure times the
+number of levels.
+
+**(B) is now bounded but still mis-keyed** — see below.
+
+### 3.2 The two mistakes are independent
+
+It is worth separating them, because they have different fixes and different
+blast radii.
+
+**M1 — cache entries are keyed by the storage artifact that produced them, not
+by the content they summarize.**
+
+A partial is named `{node_id}_{version}_{blake3}`. But what it *contains* is "the
+aggregate of finest-interval buckets in some time range." Version identity is an
+implementation detail of how the source happens to be stored, and it is not
+stable: tlogfs collapse rewrites ten versions into one merged version with
+identical content and a *new, higher* version number.
+
+Every consequence of M1 shows up as a guard bolted on afterwards:
+
+- the sequentiality frontier (`read_frontier` / `write_frontier`,
+  rollup_cache.rs:170–232) and the disjointness argument at
+  temporal_reduce.rs:504–520;
+- the `disjoint_versions` split between series and non-series sources;
+- the `--rebuild` hard error when a version backfills a sealed bucket
+  (temporal_reduce.rs:1100);
+- `reconcile` itself, added in #122 because collapse leftovers were being summed
+  twice (testsuite 733);
+- the requirement that reads name files explicitly rather than list a directory.
+
+None of those guards would have anything to guard if the key were the covered
+time range. Two builds that summarize the same time range from the same content
+would produce the same key whether or not a collapse happened in between.
+
+**M2 — sealing is triggered by the watermark advancing, not by having enough
+data to justify a file.**
+
+`seal_and_recompute` seals on `wm > m.sealed_hi_secs`. That is a *time* trigger.
+The correct trigger for "should this become a file" is *size*. This is entirely
+independent of M1: even with a perfect key, sealing once per build produces one
+file per build.
+
+M2 is currently doing more damage than M1, and is much cheaper to fix.
+
+## 4. What conventional systems do
+
+The concept of partial aggregate state is universal and must be kept — you
+cannot merge `avg`, so you store `sum` and `count` and divide at read
+(`reconstruct_sql`, temporal_reduce.rs:2117). ClickHouse `AggregateFunction`
+state columns, TimescaleDB continuous aggregates, Druid metric rollup and Flink
+accumulators all do exactly this.
+
+What none of them do is key that state by *which input artifact produced it*.
+They key by the time bucket the state summarizes, and they solve the two
+resulting problems as follows:
+
+| problem | conventional answer | here today |
+|---|---|---|
+| small files accumulate | background compaction merges adjacent segments | *nothing* |
+| which range changed? | invalidation log / dirty ranges | diff the *filename set* (`manifest.covered`) |
+| late data | recompute the affected range | hard error, `--rebuild` |
+
+The important observation is that the conventional shape is **already in this
+codebase**: `build_level_from_finer` (temporal_reduce.rs:1172) folds the finer
+level's immutable range-keyed segments into the coarser level, keyed on
+`source_digest`. It is the finest level, and only the finest level, that reaches
+sideways into per-version files.
+
+So this is not a proposal to invent something. It is a proposal to make the
+finest level use the pattern the other levels already use, and to add the one
+piece nobody wrote: compaction.
+
+## 5. Proposed design
+
+### 5.1 Principle
+
+> One structure, at every level: a sequence of immutable segments keyed by the
+> half-open output-bucket range `[lo, hi)` they cover, plus one open hot
+> segment. Segments are merged by a size-tiered policy. Nothing anywhere is
+> keyed by a source version.
+
+### 5.2 On-disk layout
+
+```
+{cache_dir}/rollup_{cfg_hash}_{site_node}/merged/res{secs}/
+    seg-00000000.parquet     immutable, covers [lo, hi)
+    seg-00000007.parquet     immutable, covers [hi, hi')
+    hot.parquet              open buckets >= sealed_hi, recomputed each build
+    manifest.json
+```
+
+The `partials/` directory and the per-node `frontier` files are deleted. The
+column layout of a segment is exactly today's `partials-v2`: `time_bucket` plus
+the mergeable partial columns. `reconstruct_sql` at read time is unchanged.
+
+### 5.3 Manifest
+
+```rust
+pub struct SegmentManifest {
+    pub format: String,                 // bump to "segments-v3"
+    pub allowed_lateness_secs: i64,
+    pub sealed_hi_secs: Option<i64>,
+    pub next_seq: u64,
+    pub segments: Vec<Segment>,         // ascending, disjoint, contiguous
+    pub hot_digest: Option<String>,
+
+    /// Finest level only: blake3 of each LIVE source version this cache
+    /// reflects, with its event-time range. Replaces `covered`.
+    pub sources: BTreeMap<String, SourceVersion>,   // blake3 -> range
+
+    /// Coarser levels only: unchanged.
+    pub source_digest: Option<String>,
+}
+
+pub struct Segment {
+    pub name: String,
+    pub lo_secs: Option<i64>,   // None = genesis, unbounded below
+    pub hi_secs: i64,           // exclusive
+    pub rows: u64,
+    pub bytes: u64,             // drives the size-tiered policy
+    pub digest: String,
+}
+
+pub struct SourceVersion {
+    pub min_event_time: i64,
+    pub max_event_time: i64,
+}
+```
+
+`covered: BTreeSet<String>` (a set of *filenames*) is replaced by
+`sources: BTreeMap<blake3, range>` (a set of *content identities* with the time
+range each covers). This is the single most important change in the document.
+Note the size argument: the number of live versions is bounded by tlogfs
+collapse (`max_live`), so this map is bounded, whereas a directory of one file
+per version ever written was not.
+
+### 5.4 Build algorithm (finest level)
+
+Replaces `build_level_from_partials`.
+
+```
+1. Read manifest. Wipe if format or allowed_lateness mismatch.
+
+2. live := live versions of every source node (already computed at
+   temporal_reduce.rs:525 via LiveVersions::from_persistence).
+   now := { v.blake3 -> (v.min_event_time, v.max_event_time) }
+
+   For series sources these come free: min_event_time / max_event_time are
+   already surfaced on FileVersionInfo.extended_metadata
+   (tlogfs/src/persistence.rs:4601-4615). No scan.
+
+   For non-series sources, fall back to the existing version_bucket_span scan
+   (temporal_reduce.rs:776) for versions not already in `sources`.
+
+3. Plan:
+     now == m.sources                     -> Reuse
+     otherwise dirty := union of the event-time ranges of
+                        (now \ m.sources)  keyed by blake3
+              plus, for any digest in (m.sources \ now) that is NOT explained
+              by a collapse-equivalent replacement, its range too.
+              -> Incremental { dirty }
+     no compatible manifest               -> Rebuild
+
+4. Incremental:
+     - dirty_lo := floor(min(dirty) to output interval)
+     - if dirty_lo < sealed_hi: the dirty range reopens sealed segments.
+       Recompute those segments in place (§5.6) rather than erroring.
+     - advance watermark, seal, recompute hot  (as today)
+
+5. Compact (§5.5).
+
+6. Write manifest atomically, then delete files no longer referenced.
+```
+
+Step 2 is where partials die. The finest level aggregates **directly from the
+source**, not from a partial cache:
+
+```rust
+// today
+let sql = pieces.merge_partials_sql(interval, ts, partials_table, "time_bucket", lo, hi);
+
+// proposed
+let src = format_cache::listing_table_from_cache_bounded(
+    cache_dir, scheme, node_id, &live_versions,
+    &SeriesReadBounds::from_event_time_lo(dirty_lo_micros),   // prunes files
+    ctx,
+)?;
+let sql = pieces.partial_sql_ranged(interval, ts, src_table, &available, dirty_lo, dirty_hi);
+```
+
+This is the crux of why partials are unnecessary. `listing_table_from_cache_bounded`
+(format_cache.rs:124) *already* prunes to the version files whose recorded
+`max_event_time` reaches the requested lower bound. The per-version partial cache
+was buying "don't rescan old versions"; the bounded listing table buys the same
+thing, from data already on `OplogEntry`, without a second file population and
+without a version-shaped cache key.
+
+Two details to get right, both of which are latent hazards:
+
+- **`SeriesReadBounds` today has only a lower bound** (`event_time_lo`,
+  tinyfs/src/file.rs:25-34); there is no upper bound. That is *safe* — the
+  aggregation's `WHERE` clause bounds the buckets, so an over-broad file set
+  costs I/O rather than correctness — but it means an incremental build reads
+  every version at or after `dirty_lo`. For append-only ingest that is the tail
+  and is fine. If a use case makes it expensive, add `event_time_hi` rather than
+  working around it.
+- **Units differ.** `event_time_lo` is epoch *microseconds*
+  (tinyfs/src/file.rs:26); segment ranges and `sealed_hi_secs` are epoch
+  *seconds*. Conversion must be explicit and rounded *outward* (floor the lower
+  bound) so pruning can never drop a contributing version. Note that
+  `retains` already treats a missing bound as "retain", for the same reason.
+
+The extra cost is re-aggregating the raw rows of versions that overlap the dirty
+range, rather than reading their pre-aggregated partials. Under append-only
+ingest the dirty range is the tail, so that is one or two versions — precisely
+the versions the old design would have had to write partials for anyway.
+
+### 5.5 Compaction
+
+New. Deliberately reuses the policy already proven in
+`tlogfs::persistence::choose_collapse_window` (persistence.rs:262), including
+`size_class` (line 203) and `COLLAPSE_FANOUT = 10` (line 197).
+
+```
+loop {
+    let window = choose_merge_window(&m.segments, MAX_SEGMENTS)?;   // same rule
+    merge segments[window] into one new seg-{next_seq}.parquet
+        via merge_partials_sql over just those files,
+        covering [segments[window.start].lo, segments[window.end-1].hi)
+    replace them in m.segments
+}
+```
+
+Two properties carry over from the tlogfs policy and both matter:
+
+- **Merge only same-size-class neighbours.** This is what stops a large
+  accumulated segment from being rewritten to absorb a few kilobytes of new
+  buckets. Without it compaction is `O(N²)` in bytes written.
+- **The ragged-input backstop picks the *cheapest* window, not the oldest.**
+  Anchoring at index 0 defeats tiering, because after any previous merge the
+  oldest segment *is* the large one. This is documented at persistence.rs:249-254
+  and was itself a bug fixed on the #122 branch; it should not be rediscovered
+  here.
+
+Using literally the same function is preferable to writing a second one. If it
+cannot be shared directly (it takes `&[&OplogEntry]`), it should be refactored to
+take `&[u64]` of sizes and be called from both places. **Two tiering policies
+that are meant to agree but are written twice is exactly the duplication that
+produced this branch's bugs** — `docs/archive/incremental-rollup-implementation.md`
+§5 instructed "mirror `format_cache.rs` exactly, in a new sibling module", and the
+two copies then diverged.
+
+`MAX_SEGMENTS` bounds read fan-out; a target segment size (say 8 MB) bounds the
+small end. Both are settings, not constants, and belong with the other rollup
+settings.
+
+### 5.6 Late data stops being an error
+
+Today, data older than `sealed_hi` is a hard error recovered only by
+`--rebuild` (temporal_reduce.rs:1100, and again at line 559 for the frontier).
+That error exists because a sealed run is keyed by *nothing that would let you
+find it again* — you know the range, but merging into it would have had to
+reconcile against per-version partials that may have already been folded.
+
+With range-keyed segments, a late arrival is ordinary work: find the segments
+overlapping `[dirty_lo, dirty_hi)` — a range lookup in `m.segments` — recompute
+exactly those from source, and swap them in. It is the same operation as
+compaction, with a different window selection rule.
+
+This should be capped (e.g. refuse to recompute more than N segments in one
+build, then fall back to a full rebuild with a clear message) so a pathological
+backfill does not silently rewrite all history.
+
+### 5.7 Read path
+
+`listing_table_for_res_dir` (rollup_cache.rs:455) currently verifies that every
+manifest run exists, and then builds a `ListingTable` over the **whole
+directory**. Those two are not the same set. Any file in the directory that the
+manifest does not reference — an orphan from a crash between writing a segment
+and updating the manifest, or from a compaction that was interrupted before its
+inputs were deleted — is silently included in the scan and double-counted.
+
+This is the identical failure mode as the format-cache directory listing that
+#122 fixed, and compaction makes it far more reachable, because compaction's
+normal operation *creates* a window in which both the inputs and the output
+exist on disk.
+
+**The reader must name files explicitly from the manifest**, exactly as
+`CachedSet` does. `ListingTableConfig` accepts a list of file URLs; this is a
+small change and it should land whether or not the rest of this design does.
+
+Ordering guarantees are unaffected: segments remain individually sorted and
+mutually disjoint, so `split_file_groups_by_statistics` and the streaming
+`SortPreservingMergeExec` read path (temporal_reduce.rs:625-640) work as before.
+
+## 6. Correctness argument
+
+**Coverage.** `m.segments` is contiguous and disjoint from genesis to
+`sealed_hi`, and `hot` covers `[sealed_hi, ∞)`. Compaction replaces a contiguous
+sub-sequence with one segment covering the union of its ranges, which preserves
+both properties. Recompute-in-place preserves them likewise.
+
+**No double counting, structurally.** A bucket appears in exactly one segment
+or in hot, because the ranges partition the axis. There is no path by which a
+stale file participates, because the reader enumerates the manifest and the
+manifest holds one entry per range. Compare with today, where disjointness is a
+*precondition* on how the input versions happen to be laid out, asserted by the
+`disjoint_versions` flag and defended by the frontier.
+
+**Collapse invisibility.** A tlogfs collapse replaces versions `v1..v10` with a
+merged version whose content is their concatenation. The set of live blake3s
+changes, so `now != m.sources` and the plan is `Incremental` with the dirty
+range = the collapsed versions' event-time span. Recomputing that span from the
+merged version yields identical partial sums, because the row multiset is
+identical. The result is byte-identical segments. This is the property the
+current design cannot have, since its cache key changed.
+
+An optimization worth having: if the merged version's event-time range is
+exactly the union of the ranges of the versions it replaced, and the union of
+row counts matches, the rebuild is provably a no-op and can be skipped by
+rewriting `m.sources` in place. That turns "collapse forces a rebuild" into
+"collapse forces a manifest edit."
+
+**Idempotence.** Building twice with no source change is `Reuse` (`now ==
+m.sources`), which touches nothing.
+
+## 7. Resulting file counts
+
+Per resolution, with `FANOUT = 10` and an 8 MB target:
+
+| total rollup output | segments | today (hourly builds) |
+|---|---|---|
+| 80 MB | ~10 | 8,760 / year |
+| 800 MB | ~20 | 8,760 / year |
+| 8 GB | ~30 | 8,760 / year |
+
+Plus `hot.parquet` and `manifest.json`. The count is logarithmic in data volume
+and **independent of build frequency**, which is the actual defect being fixed.
+
+The format cache (population A) is a separate problem with the same shape; §10
+sequences it separately.
+
+## 8. What this deletes
+
+- `write_version_partial` (temporal_reduce.rs:1301)
+- `partials_dir`, `partials_dir_at`, `list_glob_members` (rollup_cache.rs:100-122,
+  248)
+- `read_frontier` / `write_frontier` / `frontier_path` (rollup_cache.rs:170-232)
+  and the whole sequentiality-frontier concept
+- `version_bucket_span` for series sources (retained for non-series)
+- the `disjoint_versions` branch (temporal_reduce.rs:519)
+- `SealedManifest::covered` and the filename-set diff (temporal_reduce.rs:1051-1080)
+- both `--rebuild` hard errors for backfill (temporal_reduce.rs:551-566, 1100-1114)
+- `reconcile`'s use for partials — the `SidecarDir` abstraction stays, for the
+  format cache
+
+That is roughly 400 lines of logic and, more to the point, every guard whose
+existence was owed to M1.
+
+## 9. Migration
+
+Free. These caches are derived data and disposable. Bumping `SEALED_FORMAT`
+(rollup_cache.rs:301) from `"partials-v2"` to `"segments-v3"` already causes
+`build_level_from_partials` to wipe and rebuild the res dir (line 1044). The old
+`partials/` directory should be removed once on first sight of a v3 manifest.
+
+No user-visible behaviour changes: `reconstruct_sql` output is column-for-column
+identical, and the export hint / digest contract is unchanged.
+
+## 10. Sequencing
+
+Ordered so that each step is independently valuable and independently
+revertible.
+
+**P0 — read by manifest, not by directory listing.** (§5.7) Small, strictly a
+bug fix, no format change. Should land regardless.
+
+**P1 — seal on size, not per build.** (M2) Accumulate frozen buckets in `hot`
+until they exceed the target size before writing a segment. Confined to
+`seal_and_recompute`; no key change, no format change beyond adding `bytes`.
+This alone removes the one-file-per-build growth, which is the worst of the
+three populations.
+
+**P2 — compaction.** (§5.5) Needs P1's `bytes`. Bounds the count permanently and
+lets P1's target be small.
+
+**P3 — re-key on content, delete partials.** (M1, §5.3–5.4) The large change:
+`sources` replaces `covered`, the finest level folds from the bounded source
+listing table, and the guards in §8 are deleted. Everything in §6 depends on
+this step.
+
+**P4 — reconcile the format cache.** Population A. Independent of P0–P3; a
+single `reconcile` call on the path that already computes live versions. Worth
+confirming first that nothing depends on a superseded version file remaining
+readable.
+
+**P5 — retire the stale design doc.** `docs/archive/incremental-rollup-implementation.md`
+still asserts "no watermark, no mutable state file" (void since Phase 2 added
+both) and the sequential-input invariant (void since series collapse). It should
+say what is actually true or be replaced by this document.
+
+## 11. Testing
+
+The recurring failure on the #122 branch was tests that ran the buggy scenario
+but asserted something *invariant under the bug* — testsuite 050 asserted `avg`,
+which is `SUM(sum)/SUM(count)` and therefore unchanged when both are doubled.
+Tests here must assert quantities that move:
+
+- **Assert `count` and `sum`, never only `avg`.**
+- **Collapse-invariance:** build a rollup; collapse the source series; rebuild;
+  assert the segment digests are byte-identical. This test is the entire point
+  of P3 and fails loudly today.
+- **Compaction shape:** after N builds, assert `segments.len()` is bounded and
+  that size classes are actually tiered — mirroring
+  `assert_tiered_beyond_a_watermark` in `steward/src/reclaim.rs`, which exists
+  because a test silently became toothless when everything collapsed into one
+  tier.
+- **Orphan rejection:** drop an unreferenced Parquet into a res dir, assert the
+  read result is unchanged. Fails today.
+- **Late data:** append data older than `sealed_hi`, assert the correct totals
+  rather than an error.
+- **Crash windows:** kill between segment write and manifest write; between
+  manifest write and input deletion. Assert reads are correct in both.
+- **Equivalence:** full single-pass `GROUP BY` over all source rows equals the
+  segmented result, as `test_partial_then_merge_equals_full_single_pass`
+  (temporal_reduce.rs:2718) already does for partials.
+
+## 12. Open questions
+
+1. **Target segment size and `MAX_SEGMENTS`.** 8 MB and ~50 are guesses. They
+   should be measured against the real water/septic series, not chosen here.
+2. **Should compaction be synchronous with the build?** Doing it inline is
+   simplest and the amortized cost is bounded, but it makes a single export
+   occasionally slow. The alternative is a `pond maintenance` step, which is
+   where `reclaim` already lives.
+3. **Non-series sources.** `FilePhysicalVersion` re-snapshots overlap, so its
+   versions are not disjoint and it has no `min/max_event_time`. The proposal
+   keeps `version_bucket_span` for it. It may be cleaner to declare rollup
+   unsupported for overlapping sources rather than carry the branch.
+4. **Cost of the collapse-triggered recompute.** §6 sketches a no-op
+   optimization; without it, a collapse recomputes the collapsed span from
+   source. That is bounded and correct, but its real cost on water/septic is
+   unmeasured — note that selfmon uses `series:///` and bypasses the rollup
+   cache entirely, so this has never been observed in production.
+5. **Whether `hot.parquet` should itself be several files** if
+   `allowed_lateness` is large. Probably not; if it is large enough to matter,
+   P1's size trigger already splits it.

--- a/docs/rollup-storage-redesign.md
+++ b/docs/rollup-storage-redesign.md
@@ -479,7 +479,8 @@ revertible. All landed; P4 was done before P3, being independent of it.
 | P2 | compaction | `d97ee7c4` |
 | P3 | re-key on content, delete partials | `03b633df`, renamed in `2cfd8662` |
 | P4 | reconcile the format cache | `64880b47` |
-| P5 | retire the stale design doc | this commit |
+| P5 | retire the stale design doc | `51540fa4` |
+| P6 | review fixes (§13) | this commit |
 
 **P0 — read by manifest, not by directory listing.** (§5.7) Small, strictly a
 bug fix, no format change. Should land regardless.
@@ -555,3 +556,54 @@ Tests here must assert quantities that move:
 5. **Whether `hot.parquet` should itself be several files** if
    `allowed_lateness` is large. Probably not; if it is large enough to matter,
    P1's size trigger already splits it.
+
+## 13. What the post-landing review found
+
+A read of the whole branch after P5 turned up four defects, all of them
+consequences of the same thing: P3 moved decisions from "which files exist" to
+"what the manifest records", and three places kept reasoning about the old
+question.
+
+**A watermark must be bucket-aligned.** `dirty_lo` was floored to the second,
+not to the output interval, and then used as the new watermark. Everything else
+treats `sealed_hi_secs` as a bucket boundary -- the read filters on a bucket
+START -- so an unaligned watermark leaves the bucket containing the dirty point
+in neither a segment (they stop at the aligned edge below it) nor the hot window
+(it begins at or above the watermark). That bucket, including the backfilled
+rows that made it dirty, is dropped, and the next build reuses. Fixed by
+`floor_secs_to_bucket`, applied at both levels.
+
+**Unsealing must propagate up the cascade.** A coarser level keyed its freshness
+on the finer level's digest plus whether it was *rebuilt*. Late data is not a
+rebuild -- it is the ordinary incremental path -- so the coarse level kept its
+own sealed segments and reported pre-backfill values forever. The finest level's
+dirty point is now passed up the chain, and each level unseals from it, aligned
+to its own interval.
+
+This surfaced a latent ambiguity: `changed_since: Option<i64>` carried three
+meanings on the same `None` -- "nothing changed", "rebuilt", and "the dirty
+range is unbounded". That is harmless for the export hint, which treats every
+`None` as "rewrite all", but the coarse level must unseal *everything* in the
+last two cases and *nothing* in the first. It is now the explicit
+`LevelChange::{Nothing, Since(secs), Everything}`.
+
+**Content-keying removed a self-correction.** `cached_set` silently skipped a
+live version whose sidecar was absent. Under the old design the key was the set
+of partial *filenames*, so a version with no file simply looked uncovered and
+was rebuilt; keying on content instead means the build records that version as
+covered while having read none of its rows -- an undercount that agrees with
+itself forever. `CachedSet` now reports those versions and the rollup fails the
+build rather than publishing coverage it does not have. The window is real
+because P4's `reconcile` deletes sidecars on the read path, which takes no lock.
+
+**`hot.parquet` is the one file mutated in place.** It is published before the
+manifest that records the watermark it was built for, so a crash between them
+leaves buckets in no member of the cache -- served indefinitely, because an
+unchanged source makes the next build reuse. The recorded `hot_digest` was never
+checked despite §5.7 claiming it was; it is now verified per build, and a
+disagreement rebuilds the resolution.
+
+The test lesson from §11 recurred a third time: `lateness_config` declared only
+`Max`, and `max(x, x) == x` is invariant under double-counting exactly as `avg`
+is. The seal and compaction tests were asserting a statistic that cannot move.
+They now carry `Sum`.

--- a/docs/rollup-storage-redesign.md
+++ b/docs/rollup-storage-redesign.md
@@ -470,7 +470,16 @@ identical, and the export hint / digest contract is unchanged.
 ## 10. Sequencing
 
 Ordered so that each step is independently valuable and independently
-revertible.
+revertible. All landed; P4 was done before P3, being independent of it.
+
+| | | |
+|---|---|---|
+| P0 | read by manifest | `61c08f53` |
+| P1 | seal on size | `bf9b0b1d` |
+| P2 | compaction | `d97ee7c4` |
+| P3 | re-key on content, delete partials | `03b633df`, renamed in `2cfd8662` |
+| P4 | reconcile the format cache | `64880b47` |
+| P5 | retire the stale design doc | this commit |
 
 **P0 — read by manifest, not by directory listing.** (§5.7) Small, strictly a
 bug fix, no format change. Should land regardless.
@@ -496,8 +505,9 @@ readable.
 
 **P5 — retire the stale design doc.** `docs/archive/incremental-rollup-implementation.md`
 still asserts "no watermark, no mutable state file" (void since Phase 2 added
-both) and the sequential-input invariant (void since series collapse). It should
-say what is actually true or be replaced by this document.
+both) and the sequential-input invariant (void since P3). It is archived
+history, so it now carries a header pointing here rather than being edited to
+say something it never said.
 
 ## 11. Testing
 

--- a/testsuite/tests/048-logfile-ingest-out-of-order-reduce.sh
+++ b/testsuite/tests/048-logfile-ingest-out-of-order-reduce.sh
@@ -96,6 +96,8 @@ aggregations:
     columns: ["well_depth_value"]
   - type: "max"
     columns: ["well_depth_value"]
+  - type: "count"
+    columns: ["well_depth_value"]
 YAML
 
 pond mknod temporal-reduce /reduced --config-path /tmp/reduce.yaml
@@ -122,6 +124,13 @@ LATE_AVG=$(pond cat /reduced/data/res=1h.series --format=table --sql "
   SELECT \"well_depth_value.avg\" AS v FROM source ORDER BY timestamp DESC LIMIT 1" 2>&1 \
   | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
 
+# Totals, not averages: avg = SUM(sum)/SUM(count) is invariant under a
+# double-count, so it cannot distinguish "counted once" from "counted twice"
+# (see test 733). Only a total sample count can.
+TOTAL_N=$(pond cat /reduced/data/res=1h.series --format=table \
+  --sql "SELECT CAST(SUM(\"well_depth_value.count\") AS BIGINT) AS n FROM source" 2>&1 \
+  | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+
 # ---- Verify ----
 echo ""
 echo "--- Verification ---"
@@ -146,5 +155,8 @@ check '[ "${EARLY_AVG}" = "42.2" ]' \
 
 check '[ "${LATE_AVG}" = "44.1" ]' \
   "09:00 bucket reconstructs avg(44.0,44.2)=44.1, got ${LATE_AVG}"
+
+check '[ "${TOTAL_N}" = "4" ]' \
+  "each of the 4 source samples is counted exactly once after the late append, got ${TOTAL_N}"
 
 check_finish

--- a/testsuite/tests/050-temporal-reduce-collapse-lateness.sh
+++ b/testsuite/tests/050-temporal-reduce-collapse-lateness.sh
@@ -18,15 +18,17 @@
 #   The original mitigation was to raise allowed_lateness so the collapse
 #   window stays inside the unsealed hot window (config/water.yaml sets 14d on
 #   every reduced instrument). That mitigation hid a deeper defect: the merged
-#   version's partial was ADDED to the rollup partials directory while the
-#   superseded versions' partials stayed, so at 14d the read did not fail --
-#   it silently summed the collapsed window twice (see test 733).
+#   version's rows were ADDED to the rollup while the superseded versions' rows
+#   stayed, so at 14d the read did not fail -- it silently summed the collapsed
+#   window twice (see test 733).
 #
-#   The real fix is reconciliation: the partials directory is now a projection
-#   of the source node's LIVE versions, so a collapse DELETES the superseded
-#   partials. A sealed run built from partials that no longer exist is no
-#   longer a valid incremental base, so the level is rebuilt from the live
-#   partials rather than either erroring or double-counting.
+#   The real fix is to stop keying the cache on version identity at all. The
+#   manifest now records the CONTENT of each live source version (its blake3 and
+#   its event-time range), so a collapse -- which rewrites N versions into one
+#   with identical content -- changes the version numbers but not the recorded
+#   ranges' union. What did change is dirty, and only that range is recomputed;
+#   the segments covering it are unsealed rather than rejected. A collapse that
+#   preserves content is therefore neither an error nor a double-count.
 #
 #   Both reduced nodes below read the SAME collapsed source; only their
 #   allowed_lateness differs, isolating the knob under test.

--- a/testsuite/tests/051-temporal-reduce-unseal-late-data.sh
+++ b/testsuite/tests/051-temporal-reduce-unseal-late-data.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# EXPERIMENT: genuinely late data must UNSEAL the segments that cover it.
+#
+# DESCRIPTION:
+#   Every other rollup test either never seals (the data is too small to reach
+#   `seal_target_bytes`) or exercises version COLLAPSE, where the source content
+#   is unchanged and the correct answer is to reuse the cache untouched. Neither
+#   reaches the path this branch introduced for real backfill:
+#
+#     a new source version whose event range dips BELOW the sealed watermark
+#     drops the segments covering it and lets the ordinary seal path recompute
+#     them from source, instead of hard-erroring with "--rebuild".
+#
+#   The unit tests cannot reach it either: MemoryPersistence records no event
+#   bounds, so every source version reads as SourceRange::UNKNOWN, the dirty
+#   range is unbounded and EVERY build unseals EVERYTHING. Only a tlogfs pond
+#   records real bounds, and only then is a segment ever partially retained.
+#
+#   `seal_target_bytes: 0` forces a seal on every build so a handful of rows is
+#   enough to produce segments; this is a cache-layout knob, so setting it
+#   changes nothing about the answer.
+#
+#   Two things can go wrong and both are silent:
+#     - unsealing too little: a bucket keeps its pre-backfill value, or the
+#       watermark stays above a dirty point that no segment covers, so buckets
+#       vanish entirely (the empty-span watermark hole).
+#     - unsealing too much, or failing to drop superseded segment files: the
+#       recomputed rows are summed alongside the stale ones and every affected
+#       sample is counted twice.
+#
+#   Totals expose both. avg does not: avg = SUM(sum)/SUM(count) is invariant
+#   under doubling, which is exactly how the original defect survived review
+#   (see test 733).
+#
+# EXPECTED:
+#   - The first pass seals; day 1..3 (72 hourly points) read back as 72 buckets
+#     summing to 72 samples.
+#   - A late point at day 1 12:30, far behind the sealed watermark, is accepted
+#     with no error and no "--rebuild" demand.
+#   - The rollup then totals 73 samples over 72 buckets: the late sample lands
+#     in the EXISTING 12:00 bucket, which must be recomputed from 1 sample to 2
+#     -- not left stale at 1, and not double-counted to 3.
+#   - A CASCADED rollup (1h then 1d) shows the same total. A coarse level is
+#     folded from the finer one and keys its freshness on the finer level's
+#     digest plus whether it was REBUILT; late data is not a rebuild, so unless
+#     the dirty point is propagated the coarse level keeps its own sealed
+#     segments and reports the pre-backfill total forever.
+set -e
+source check.sh
+
+echo "=== Experiment: late data unseals the segments covering it ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+# ---- Source: 72 hourly samples, 2026-07-15T00:00Z .. 2026-07-17T23:00Z ------
+# Each sample is exactly 1.0, so SUM over the rollup equals the sample COUNT
+# and any deviation is a miscount rather than a rounding difference.
+mkdir -p /var/log/well
+awk 'BEGIN {
+    start = 1784073600;
+    for (i = 0; i < 72; i++) {
+        e = start + i * 3600;
+        printf "{\"resourceMetrics\":[{\"resource\":{},\"scopeMetrics\":[{\"scope\":{\"name\":\"water\"},\"metrics\":[{\"name\":\"well_depth_value\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"%d000000000\",\"asDouble\":1.0}]}}]}]}]}\n", e;
+    }
+}' > /tmp/051-all.jsonl
+
+# The late sample: day 1 at 12:30, i.e. inside the 12:00 bucket, three days
+# behind the newest sample and far below any 1d sealed watermark.
+awk 'BEGIN {
+    e = 1784073600 + 12 * 3600 + 1800;
+    printf "{\"resourceMetrics\":[{\"resource\":{},\"scopeMetrics\":[{\"scope\":{\"name\":\"water\"},\"metrics\":[{\"name\":\"well_depth_value\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"%d000000000\",\"asDouble\":1.0}]}}]}]}]}\n", e;
+}' > /tmp/051-late.jsonl
+
+cat > /tmp/051-ingest.yaml << 'EOF'
+archived_pattern: /var/log/well/well.json.*
+active_pattern: /var/log/well/well.json
+pond_path: /ingest
+EOF
+
+pond mkdir -p /system/run >/dev/null
+pond mkdir -p /ingest >/dev/null
+pond mknod logfile-ingest /system/run/10-well --config-path /tmp/051-ingest.yaml >/dev/null
+
+# Several ingest runs, so the source has several live versions and the rollup
+# must reconcile a set rather than a single file.
+: > /var/log/well/well.json
+split -l 18 /tmp/051-all.jsonl /tmp/051-chunk.
+for c in /tmp/051-chunk.*; do
+    cat "$c" >> /var/log/well/well.json
+    pond run /system/run/10-well >/dev/null 2>&1
+done
+
+# ---- The rollup, forced to seal on every build ------------------------------
+cat > /tmp/051-reduce.yaml << 'YAML'
+in_pattern: "oteljson:///ingest/well.json"
+out_pattern: "data"
+time_column: "timestamp"
+resolutions: ["1h"]
+seal_target_bytes: 0
+aggregations:
+  - type: "sum"
+    columns: ["well_depth_value"]
+  - type: "count"
+    columns: ["well_depth_value"]
+YAML
+pond mknod temporal-reduce /reduced --config-path /tmp/051-reduce.yaml >/dev/null
+
+# The same rollup, cascaded: 1d is folded from 1h rather than from source.
+sed 's/resolutions: \["1h"\]/resolutions: ["1h", "1d"]/' /tmp/051-reduce.yaml \
+  > /tmp/051-reduce-cascade.yaml
+pond mknod temporal-reduce /reduced-cascade --config-path /tmp/051-reduce-cascade.yaml >/dev/null
+
+totals() {
+    pond cat /reduced/data/res=1h.series --format=table --sql \
+      'SELECT CAST(COUNT(*) AS BIGINT) AS b, CAST(SUM("well_depth_value.count") AS BIGINT) AS n FROM source' 2>&1
+}
+
+# The coarsest level of the cascade, folded from 1h rather than from source.
+daily_total() {
+    pond cat /reduced-cascade/data/res=1d.series --format=table --sql \
+      'SELECT CAST(SUM("well_depth_value.count") AS BIGINT) AS n FROM source' 2>&1 \
+      | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1
+}
+
+# One sample per bucket, so the 12:00 bucket is the one the late point joins.
+noon_count() {
+    pond cat /reduced/data/res=1h.series --format=table --sql \
+      'SELECT CAST("well_depth_value.count" AS BIGINT) AS c FROM source
+       WHERE timestamp = arrow_cast(1784116800000, '"'"'Timestamp(Millisecond, None)'"'"')' 2>&1 \
+      | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1
+}
+
+echo ""
+echo "--- First read: builds and seals ---"
+BEFORE_OUT=$(totals)
+echo "$BEFORE_OUT"
+BEFORE_B=$(echo "$BEFORE_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$2); print $2}')
+BEFORE_N=$(echo "$BEFORE_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+BEFORE_NOON=$(noon_count)
+BEFORE_DAILY=$(daily_total)
+
+# The seal must actually have happened, or this test proves nothing: a rollup
+# with zero segments cannot exercise unsealing at all.
+# 'seg-*' specifically: hot.parquet lives in the same directory and always
+# exists, so a plain '*.parquet' count would pass even if nothing ever sealed
+# and this whole test degenerated into "does a rollup work".
+SEGMENTS=$(find /pond -path '*/merged_*/res3600/*' -name 'seg-*.parquet' 2>/dev/null | wc -l | tr -d ' ')
+echo "segment files after the sealing pass: ${SEGMENTS}"
+
+echo ""
+echo "--- Append the late sample (day 1 12:30) ---"
+cat /tmp/051-late.jsonl >> /var/log/well/well.json
+pond run /system/run/10-well 2>&1 | tee /tmp/051-late-run.log | tail -3
+
+echo ""
+echo "--- Second read: must unseal and recompute, not error ---"
+AFTER_OUT=$(totals || true)
+echo "$AFTER_OUT"
+AFTER_B=$(echo "$AFTER_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$2); print $2}')
+AFTER_N=$(echo "$AFTER_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+AFTER_NOON=$(noon_count)
+AFTER_DAILY=$(daily_total)
+
+# A third read exercises the steady state: nothing changed, so the rollup must
+# reuse what it just wrote and still answer identically.
+THIRD_OUT=$(totals || true)
+THIRD_N=$(echo "$THIRD_OUT" | grep -E '^\| *[0-9]' | head -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+
+echo ""
+echo "--- Verification ---"
+
+check '[ "${BEFORE_B}" = "72" ]' \
+  "the first pass reads 72 hourly buckets, got ${BEFORE_B}"
+
+check '[ "${BEFORE_N}" = "72" ]' \
+  "the first pass counts each of the 72 samples once, got ${BEFORE_N}"
+
+check '[ "${SEGMENTS}" -ge 1 ]' \
+  "seal_target_bytes: 0 actually sealed a segment, so unsealing has something to do (${SEGMENTS} file(s))"
+
+check '[ "${BEFORE_NOON}" = "1" ]' \
+  "the 12:00 bucket starts with a single sample, got ${BEFORE_NOON}"
+
+check '! echo "$AFTER_OUT" | grep -qiE "backfills|precedes|--rebuild|error"' \
+  "data landing behind the sealed watermark is no longer an error"
+
+check '[ "${AFTER_B}" = "72" ]' \
+  "the late sample joins an existing bucket, so the bucket count is unchanged at 72, got ${AFTER_B}"
+
+check '[ "${AFTER_N}" = "73" ]' \
+  "the late sample is counted exactly once (72 = it was dropped, 74+ = double-counted), got ${AFTER_N}"
+
+check '[ "${AFTER_NOON}" = "2" ]' \
+  "the sealed 12:00 bucket was recomputed from 1 sample to 2 (1 = stale segment kept, 3 = stale and fresh both summed), got ${AFTER_NOON}"
+
+check '[ "${BEFORE_DAILY}" = "72" ]' \
+  "the cascaded 1d level totals 72 before the backfill, got ${BEFORE_DAILY}"
+
+check '[ "${AFTER_DAILY}" = "73" ]' \
+  "the backfill propagates to the cascaded 1d level, which is folded from 1h and would otherwise keep its own sealed segments (72 = the dirty point stopped at the finest level), got ${AFTER_DAILY}"
+
+check '[ "${THIRD_N}" = "73" ]' \
+  "a repeat read with no new data still totals 73, got ${THIRD_N}"
+
+check_finish


### PR DESCRIPTION
Rebuilds the rollup/format caching layer so that a late arrival costs work
proportional to what it changed rather than to the whole history, and so that
the cache can say what it covers without listing a directory.

## What changed

The old design kept one partial per source version and reduced them on every
read, which made a query O(N) in the number of appends and made a backfill a
hard error demanding `--rebuild`. Segments are now keyed by **bucket range**,
so "which files hold this instant" is a lookup: a backfill drops the segments
covering it, lowers `sealed_hi`, and recomputes only that span.

Around that:

- **Reads enumerate the manifest**, never the directory. Orphans arise in
  normal operation and a directory-shaped scan double-counts them.
- **`hot.parquet` is the only file mutated in place.** Segments are immutable,
  published before the manifest naming them and deleted only after it is
  durable, so a crash at any point leaves a readable cache.
- **Sealing is driven by accumulated size**, not by every build, so a busy
  pond does not produce a file per advance.
- **Compaction is size-tiered** and shares `size_tier.rs` with tlogfs series
  collapse rather than being a second implementation of the same idea.
- **The format cache reconciles** instead of only ever adding, and the symlink
  glob farm is replaced by the cached set.
- Four Parquet writers and blake3 helpers collapse to one each.

## Review pass

A review of the finished branch turned up two real defects, both instances of
the same failure mode — *the cache records coverage it does not have, the next
build compares that record against reality, they agree, and the wrong answer is
served forever*:

- A coarse level missed a backfill that a **sibling build had already
  consumed**. Fixed by having every level record its own source set and compute
  its own dirty floor, rather than trusting the finer level's digest. The
  obvious alternative — unseal everything on digest mismatch — is correct but
  restores the O(N²) rebuild this branch exists to remove, since `res=1h` and
  `res=1d` are separate builds.
- A **session table leaked** on an error path. The name is deterministic, so one
  transient failure poisoned that resolution permanently.

Two error-handling fixes: `hot_bytes` no longer swallows a stat failure into
`0` (the value is persisted and read by the seal gate, so `0` disables sealing
forever and lets the hot window grow unbounded), and the sidecar coverage check
is now a named, tested function.

One review finding was a **false positive** — `source_version_key` looks like it
collapses two identical-content versions, but the stored blake3 for a series is
cumulative over all versions, so re-appending identical bytes still yields a
different digest. That fact lives two crates away, so it is now documented and
pinned by a test.

## The coverage gap worth knowing about

`compaction_bounds_segment_count_without_changing_answers` passed, and also
passed with a `panic!` on the first line of the merge — as did every other test
in the crate. `compact_segments` had no coverage at all.

The cause was the fixture, not the code: `MemoryPersistence` records no
event-time bounds, so the dirty range was always unbounded, every append
unsealed the whole history, and the cache never held two segments at once.
Giving each version real bounds makes segments accumulate and merge for real.
The count assertion is now an equality, because landing *below* the backstop is
the signature of never having accumulated.

Every test added in that pass was mutation-verified: the guard was deliberately
broken and the test confirmed to fail. Several natural assertions turned out to
be satisfied by the code path never running, which is how this class of gap
survives.

## Validation

- `cargo test --workspace`: 42 suites, ~1600 tests, 0 failures
- `cargo clippy --workspace --all-targets`: at the pre-existing 69-error
  baseline (`crates/cmd/tests/` unwrap lints), unchanged by this branch
- `cargo fmt --all --check`: clean
- Integration tests 048, 050, 051 pass; 051 is new and adds 206 lines covering
  partial unsealing on late data
