### PR TITLE
Keep rollups incremental: record event-time bounds, and replicate node metadata

### DIFF
--- a/crates/provider/src/factory/journal_ingest.rs
+++ b/crates/provider/src/factory/journal_ingest.rs
@@ -403,7 +403,13 @@ async fn write_entries(
 
         writer.write_all(content.as_bytes()).await.map_other()?;
 
-        // Set temporal metadata if we have bounds for this file
+        // Record the event-time bounds computed from the records themselves.
+        // journald output is read whole rather than tailed by byte offset, and
+        // every entry carries __REALTIME_TIMESTAMP, so a group without bounds
+        // means the configured field does not match the records -- declare the
+        // requirement and let the write fail rather than store an unbounded
+        // version that forces downstream rollups to recompute all history.
+        writer.require_temporal_metadata(config.timestamp_field.clone());
         if let Some(bounds) = file_bounds.get(filename) {
             writer.set_temporal_metadata(
                 bounds.min_timestamp,

--- a/crates/provider/src/factory/logfile_ingest.rs
+++ b/crates/provider/src/factory/logfile_ingest.rs
@@ -81,6 +81,80 @@ pub struct LogfileIngestConfig {
     /// Destination path within the pond (relative to pond root)
     /// Example: "logs/casparwater"
     pub pond_path: String,
+
+    /// JSON key holding the event time of a record, looked up at any depth in
+    /// each line. Example: "timeUnixNano" for OTLP metrics JSON.
+    ///
+    /// Absent by default, which leaves versions without event-time bounds.
+    /// That is not free: `temporal-reduce` reads these bounds to decide which
+    /// cached segments a new source version can have touched, and a version
+    /// without them is taken to span all of time (`SourceRange::UNKNOWN`), so
+    /// every build unseals every segment and recomputes the whole history from
+    /// source. Setting this is what keeps an incremental build incremental.
+    #[serde(default)]
+    pub timestamp_field: Option<String>,
+
+    /// Unit of the `timestamp_field` values. OTLP's `timeUnixNano` is
+    /// nanoseconds; journald's `__REALTIME_TIMESTAMP` is microseconds.
+    #[serde(default)]
+    pub timestamp_unit: TimestampUnit,
+}
+
+/// Unit of the values found under `timestamp_field`.
+///
+/// tlogfs records event times in microseconds, so everything is converted to
+/// that. Microseconds is the default because it is what tlogfs itself uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TimestampUnit {
+    Seconds,
+    Milliseconds,
+    #[default]
+    Microseconds,
+    Nanoseconds,
+}
+
+impl TimestampUnit {
+    /// Microseconds per unit.
+    fn per_micro(self) -> (i64, bool) {
+        // (factor, divide) -- divide when the unit is finer than a microsecond.
+        match self {
+            TimestampUnit::Seconds => (1_000_000, false),
+            TimestampUnit::Milliseconds => (1_000, false),
+            TimestampUnit::Microseconds => (1, false),
+            TimestampUnit::Nanoseconds => (1_000, true),
+        }
+    }
+
+    /// Convert to microseconds, rounding DOWN.
+    ///
+    /// Rounding direction matters: these bounds gate which cached buckets get
+    /// recomputed, so each end must round outward. A lower bound that rounded
+    /// up could place a record after the range that claims to contain it, and
+    /// the buckets it feeds would never be invalidated.
+    fn to_micros_floor(self, raw: i64) -> Option<i64> {
+        let (factor, divide) = self.per_micro();
+        if divide {
+            Some(raw.div_euclid(factor))
+        } else {
+            raw.checked_mul(factor)
+        }
+    }
+
+    /// Convert to microseconds, rounding UP. See `to_micros_floor`.
+    fn to_micros_ceil(self, raw: i64) -> Option<i64> {
+        let (factor, divide) = self.per_micro();
+        if divide {
+            let q = raw.div_euclid(factor);
+            if raw.rem_euclid(factor) == 0 {
+                Some(q)
+            } else {
+                q.checked_add(1)
+            }
+        } else {
+            raw.checked_mul(factor)
+        }
+    }
 }
 
 impl LogfileIngestConfig {
@@ -104,7 +178,123 @@ impl LogfileIngestConfig {
             ));
         }
 
+        if self.timestamp_field.as_deref() == Some("") {
+            return Err(tinyfs::Error::Other(
+                "timestamp_field cannot be empty".to_string(),
+            ));
+        }
+
         Ok(())
+    }
+}
+
+/// Event-time bounds of one version's content, in microseconds, `max`
+/// inclusive -- the shape `set_temporal_metadata` wants.
+///
+/// Returns `None` when bounds cannot be established for the whole slice, and
+/// the caller then writes the version without them. That is the safe
+/// direction: a missing bound makes the downstream rollup pessimistic (it
+/// recomputes everything), whereas a bound that is too narrow would let it
+/// skip buckets this content belongs to and silently keep stale aggregates.
+/// So every uncertainty here -- an unparseable line, a timestamp that is not
+/// an integer, an overflowing conversion -- abandons the scan rather than
+/// guessing.
+///
+/// Cost is proportional to the bytes being written, not to the file: the
+/// append path passes only the new tail.
+fn scan_temporal_bounds(content: &[u8], field: &str, unit: TimestampUnit) -> Option<(i64, i64)> {
+    let text = std::str::from_utf8(content).ok()?;
+    let mut acc: Option<(i64, i64)> = None;
+
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(line).ok()?;
+        if !fold_timestamps(&value, field, &mut acc) {
+            return None;
+        }
+    }
+
+    let (min_raw, max_raw) = acc?;
+    Some((
+        unit.to_micros_floor(min_raw)?,
+        unit.to_micros_ceil(max_raw)?,
+    ))
+}
+
+/// Fold every value stored under `field`, at any depth of `value`, into `acc`
+/// as a running (min, max).
+///
+/// Returns false if a value under that key is not an integer, which abandons
+/// the scan -- see `scan_temporal_bounds` for why that is preferred to
+/// skipping it.
+fn fold_timestamps(value: &Value, field: &str, acc: &mut Option<(i64, i64)>) -> bool {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if key == field {
+                    // OTLP writes 64-bit times as JSON strings; journald and
+                    // plain numeric logs write them as numbers.
+                    let Some(ts) = (match child {
+                        Value::String(s) => s.parse::<i64>().ok(),
+                        Value::Number(n) => n.as_i64(),
+                        _ => None,
+                    }) else {
+                        return false;
+                    };
+                    *acc = Some(match *acc {
+                        Some((lo, hi)) => (lo.min(ts), hi.max(ts)),
+                        None => (ts, ts),
+                    });
+                } else if !fold_timestamps(child, field, acc) {
+                    return false;
+                }
+            }
+            true
+        }
+        Value::Array(items) => items.iter().all(|v| fold_timestamps(v, field, acc)),
+        _ => true,
+    }
+}
+
+/// Record event-time bounds on a version about to be finalized, when the
+/// config asks for them.
+///
+/// Must be called after the content is written and before `shutdown`, which is
+/// when the metadata is folded into the oplog entry.
+///
+/// A slice whose bounds cannot be determined is written without them and warns
+/// rather than failing: ingest keeping the data flowing matters more than the
+/// downstream rollup staying pruned, and the rollup degrades to a correct (if
+/// expensive) full recompute. The warning is there because that degradation is
+/// otherwise invisible -- it shows up only as a slow, memory-hungry build.
+fn attach_temporal_bounds(
+    writer: &mut std::pin::Pin<Box<dyn tinyfs::FileMetadataWriter>>,
+    config: &LogfileIngestConfig,
+    content: &[u8],
+    pond_dest: &str,
+) {
+    let Some(field) = config.timestamp_field.as_deref() else {
+        return;
+    };
+
+    match scan_temporal_bounds(content, field, config.timestamp_unit) {
+        Some((min_us, max_us)) => {
+            debug!(
+                "Temporal bounds for {}: [{}, {}] us from '{}'",
+                pond_dest, min_us, max_us, field
+            );
+            writer.set_temporal_metadata(min_us, max_us, field.to_string());
+        }
+        None => warn!(
+            "No usable '{}' timestamps in {} bytes for {}; writing without event-time bounds \
+             (downstream temporal-reduce will treat this version as spanning all time and \
+             recompute its cache in full)",
+            field,
+            content.len(),
+            pond_dest
+        ),
     }
 }
 
@@ -823,6 +1013,7 @@ async fn ingest_new_file(
 
     // Write content and finalize
     writer.write_all(&content).await.map_other()?;
+    attach_temporal_bounds(&mut writer, config, &content, &pond_dest);
     writer.shutdown().await.map_other()?;
 
     info!("Wrote file to pond: {}", pond_dest);
@@ -900,6 +1091,7 @@ async fn ingest_append(
     // Write only the new content (as a new version in the FilePhysicalSeries)
     // The ChainedReader will concatenate all versions when reading
     writer.write_all(&new_content).await.map_other()?;
+    attach_temporal_bounds(&mut writer, config, &new_content, &pond_dest);
     writer.shutdown().await.map_other()?;
 
     info!(
@@ -998,6 +1190,7 @@ async fn append_to_active_pond_file(
         .await?;
 
     writer.write_all(new_data).await.map_other()?;
+    attach_temporal_bounds(&mut writer, config, new_data, &pond_dest);
     writer.shutdown().await.map_other()?;
 
     info!("Appended missed bytes to pond file: {}", pond_dest);
@@ -1034,6 +1227,8 @@ mod tests {
             archived_pattern: "/var/log/test-*.json".to_string(),
             active_pattern: "/var/log/test.json".to_string(),
             pond_path: "logs/test".to_string(),
+            timestamp_field: None,
+            timestamp_unit: TimestampUnit::default(),
         };
 
         assert!(config.validate().is_ok());
@@ -1045,6 +1240,8 @@ mod tests {
             archived_pattern: "/var/log/test-*.json".to_string(),
             active_pattern: "/var/log/test.json".to_string(),
             pond_path: "".to_string(),
+            timestamp_field: None,
+            timestamp_unit: TimestampUnit::default(),
         };
 
         assert!(config.validate().is_err());
@@ -1145,5 +1342,199 @@ mod tests {
         mutated[BLOCK_SIZE / 2] ^= 0x01;
         let host = write_host(&mutated);
         assert!(!verify_prefix_matches(host.path(), &state).unwrap().0);
+    }
+
+    // ---- event-time bounds -------------------------------------------------
+    //
+    // These bounds are what keeps `temporal-reduce` from unsealing its whole
+    // cache on every build, so the cases that matter most are the ones where a
+    // bound must NOT be produced: a wrong-but-plausible bound is worse than no
+    // bound, because it silently suppresses a recompute.
+
+    /// One OTLP metrics line, shaped like the real ingest input.
+    fn otlp_line(times_ns: &[&str]) -> String {
+        let points: Vec<String> = times_ns
+            .iter()
+            .map(|t| format!(r#"{{"timeUnixNano":"{}","asDouble":1.5}}"#, t))
+            .collect();
+        format!(
+            r#"{{"resourceMetrics":[{{"resource":{{}},"scopeMetrics":[{{"scope":{{"name":"modbus"}},"metrics":[{{"name":"m","gauge":{{"dataPoints":[{}]}}}}]}}]}}]}}"#,
+            points.join(",")
+        )
+    }
+
+    #[test]
+    fn nanosecond_bounds_round_outward() {
+        // 1779907425563251857ns = 1779907425563251.857us: the low end must
+        // floor and the high end must ceil, so neither can land inside the
+        // data it is supposed to enclose.
+        let line = otlp_line(&["1779907425563251857"]);
+        let (min_us, max_us) =
+            scan_temporal_bounds(line.as_bytes(), "timeUnixNano", TimestampUnit::Nanoseconds)
+                .expect("bounds");
+        assert_eq!(min_us, 1779907425563251);
+        assert_eq!(max_us, 1779907425563252);
+    }
+
+    #[test]
+    fn bounds_span_every_line_and_every_point() {
+        let content = format!(
+            "{}\n{}\n",
+            otlp_line(&["2000000000", "5000000000"]),
+            otlp_line(&["1000000000", "3000000000"])
+        );
+        let (min_us, max_us) = scan_temporal_bounds(
+            content.as_bytes(),
+            "timeUnixNano",
+            TimestampUnit::Nanoseconds,
+        )
+        .expect("bounds");
+        assert_eq!(min_us, 1_000_000);
+        assert_eq!(max_us, 5_000_000);
+    }
+
+    #[test]
+    fn blank_lines_are_skipped_not_fatal() {
+        // A trailing newline is normal for an appended slice.
+        let content = format!("{}\n\n", otlp_line(&["1000000000"]));
+        assert!(
+            scan_temporal_bounds(
+                content.as_bytes(),
+                "timeUnixNano",
+                TimestampUnit::Nanoseconds
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn an_unparseable_line_abandons_the_scan() {
+        // A torn write must not yield bounds covering only the lines that did
+        // parse -- the rest of the slice would then be outside its own range.
+        let content = format!("{}\n{{\"resourceMetrics\":\n", otlp_line(&["1000000000"]));
+        assert_eq!(
+            scan_temporal_bounds(
+                content.as_bytes(),
+                "timeUnixNano",
+                TimestampUnit::Nanoseconds
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn a_non_integer_timestamp_abandons_the_scan() {
+        let content =
+            r#"{"resourceMetrics":[{"gauge":{"dataPoints":[{"timeUnixNano":"not-a-number"}]}}]}"#;
+        assert_eq!(
+            scan_temporal_bounds(
+                content.as_bytes(),
+                "timeUnixNano",
+                TimestampUnit::Nanoseconds
+            ),
+            None
+        );
+
+        let nested = r#"{"timeUnixNano":{"oops":1}}"#;
+        assert_eq!(
+            scan_temporal_bounds(
+                nested.as_bytes(),
+                "timeUnixNano",
+                TimestampUnit::Nanoseconds
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn a_line_without_the_field_yields_no_bounds() {
+        let content = r#"{"resourceMetrics":[{"scopeMetrics":[]}]}"#;
+        assert_eq!(
+            scan_temporal_bounds(
+                content.as_bytes(),
+                "timeUnixNano",
+                TimestampUnit::Nanoseconds
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn numeric_and_string_timestamps_are_both_accepted() {
+        // journald writes microseconds as a string; other logs use a number.
+        let as_number = r#"{"ts":1700000000000000}"#;
+        let as_string = r#"{"ts":"1700000000000000"}"#;
+        let expected = Some((1700000000000000, 1700000000000000));
+        assert_eq!(
+            scan_temporal_bounds(as_number.as_bytes(), "ts", TimestampUnit::Microseconds),
+            expected
+        );
+        assert_eq!(
+            scan_temporal_bounds(as_string.as_bytes(), "ts", TimestampUnit::Microseconds),
+            expected
+        );
+    }
+
+    #[test]
+    fn coarser_units_scale_up() {
+        assert_eq!(
+            scan_temporal_bounds(br#"{"ts":1700000000}"#, "ts", TimestampUnit::Seconds),
+            Some((1_700_000_000_000_000, 1_700_000_000_000_000))
+        );
+        assert_eq!(
+            scan_temporal_bounds(
+                br#"{"ts":1700000000000}"#,
+                "ts",
+                TimestampUnit::Milliseconds
+            ),
+            Some((1_700_000_000_000_000, 1_700_000_000_000_000))
+        );
+    }
+
+    #[test]
+    fn an_overflowing_conversion_yields_no_bounds() {
+        let content = format!(r#"{{"ts":{}}}"#, i64::MAX);
+        assert_eq!(
+            scan_temporal_bounds(content.as_bytes(), "ts", TimestampUnit::Seconds),
+            None
+        );
+    }
+
+    #[test]
+    fn config_without_timestamp_fields_still_parses() {
+        // Every deployed config predates these fields; none may start failing
+        // validation, and all must keep today's no-bounds behaviour.
+        let yaml = "archived_pattern: /data/x-*.json\n\
+                    active_pattern: /data/x.json\n\
+                    pond_path: /ingest\n";
+        let parsed = validate_config(yaml.as_bytes()).expect("valid");
+        let config: LogfileIngestConfig = serde_json::from_value(parsed).expect("round-trip");
+        assert_eq!(config.timestamp_field, None);
+        assert_eq!(config.timestamp_unit, TimestampUnit::Microseconds);
+    }
+
+    #[test]
+    fn config_with_timestamp_fields_parses() {
+        let yaml = "archived_pattern: /data/x-*.json\n\
+                    active_pattern: /data/x.json\n\
+                    pond_path: /ingest\n\
+                    timestamp_field: timeUnixNano\n\
+                    timestamp_unit: nanoseconds\n";
+        let parsed = validate_config(yaml.as_bytes()).expect("valid");
+        let config: LogfileIngestConfig = serde_json::from_value(parsed).expect("round-trip");
+        assert_eq!(config.timestamp_field.as_deref(), Some("timeUnixNano"));
+        assert_eq!(config.timestamp_unit, TimestampUnit::Nanoseconds);
+    }
+
+    #[test]
+    fn an_empty_timestamp_field_is_rejected() {
+        let config = LogfileIngestConfig {
+            archived_pattern: "/var/log/test-*.json".to_string(),
+            active_pattern: "/var/log/test.json".to_string(),
+            pond_path: "logs/test".to_string(),
+            timestamp_field: Some("".to_string()),
+            timestamp_unit: TimestampUnit::default(),
+        };
+        assert!(config.validate().is_err());
     }
 }

--- a/crates/provider/src/factory/logfile_ingest.rs
+++ b/crates/provider/src/factory/logfile_ingest.rs
@@ -319,6 +319,13 @@ fn attach_temporal_bounds(
     pond_dest: &str,
 ) {
     let Some(field) = config.timestamp_field.as_deref() else {
+        debug!(
+            "No timestamp_field configured for {}; storing {} bytes with null event-time bounds. \
+             A downstream temporal-reduce reads a null range as spanning all time and recomputes \
+             its cache in full, so set timestamp_field if these records carry logs or metrics.",
+            pond_dest,
+            content.len()
+        );
         return;
     };
 

--- a/crates/provider/src/factory/logfile_ingest.rs
+++ b/crates/provider/src/factory/logfile_ingest.rs
@@ -258,17 +258,60 @@ fn fold_timestamps(value: &Value, field: &str, acc: &mut Option<(i64, i64)>) -> 
     }
 }
 
+/// The portion of `slice` that should be stored now.
+///
+/// An actively-written log is tailed by byte offset, so a slice taken from it
+/// routinely ends mid-line -- the station is still writing that record. Storing
+/// such a slice verbatim splits one record across two versions, and neither
+/// version can then read its own timestamps: the first cannot parse its
+/// trailing fragment, the second cannot parse its leading one.
+///
+/// Holding the fragment back instead keeps every stored version a whole number
+/// of records, so bounds are always computable and the next version always
+/// starts at a record boundary. Nothing is lost: appends are detected by
+/// comparing the host size against the pond's cumulative size, so the withheld
+/// bytes simply appear as growth on the next tick, once the writer has finished
+/// the line.
+///
+/// Two cases are deliberately exempt and are stored byte-for-byte:
+///
+/// - No `timestamp_field`. The operator has not said these are records, so the
+///   file is an opaque byte stream -- possibly with no newlines at all, in
+///   which case aligning would withhold it forever.
+/// - A final file. Once rotated or archived it is no longer being appended to,
+///   so its last line is complete whether or not it ends in a newline.
+fn ingestible_slice<'a>(
+    config: &LogfileIngestConfig,
+    slice: &'a [u8],
+    final_file: bool,
+) -> &'a [u8] {
+    if final_file || config.timestamp_field.is_none() {
+        return slice;
+    }
+    complete_lines(slice)
+}
+
+/// The prefix of `slice` up to and including the last newline.
+fn complete_lines(slice: &[u8]) -> &[u8] {
+    match slice.iter().rposition(|&b| b == b'\n') {
+        Some(idx) => &slice[..=idx],
+        None => &[],
+    }
+}
+
 /// Record event-time bounds on a version about to be finalized, when the
 /// config asks for them.
 ///
 /// Must be called after the content is written and before `shutdown`, which is
 /// when the metadata is folded into the oplog entry.
 ///
-/// A slice whose bounds cannot be determined is written without them and warns
-/// rather than failing: ingest keeping the data flowing matters more than the
-/// downstream rollup staying pruned, and the rollup degrades to a correct (if
-/// expensive) full recompute. The warning is there because that degradation is
-/// otherwise invisible -- it shows up only as a slow, memory-hungry build.
+/// Naming a `timestamp_field` is the operator saying "this node carries logs or
+/// metrics", so the requirement is declared on the writer before the scan runs.
+/// A slice whose bounds cannot then be determined fails the write rather than
+/// storing an unbounded version: with line-aligned slices the benign cause (a
+/// torn trailing line) can no longer occur, so what remains is a real problem
+/// -- the wrong field name, the wrong unit, or corrupt input -- and silently
+/// degrading it only reappears later as a slow, memory-hungry rollup.
 fn attach_temporal_bounds(
     writer: &mut std::pin::Pin<Box<dyn tinyfs::FileMetadataWriter>>,
     config: &LogfileIngestConfig,
@@ -279,22 +322,14 @@ fn attach_temporal_bounds(
         return;
     };
 
-    match scan_temporal_bounds(content, field, config.timestamp_unit) {
-        Some((min_us, max_us)) => {
-            debug!(
-                "Temporal bounds for {}: [{}, {}] us from '{}'",
-                pond_dest, min_us, max_us, field
-            );
-            writer.set_temporal_metadata(min_us, max_us, field.to_string());
-        }
-        None => warn!(
-            "No usable '{}' timestamps in {} bytes for {}; writing without event-time bounds \
-             (downstream temporal-reduce will treat this version as spanning all time and \
-             recompute its cache in full)",
-            field,
-            content.len(),
-            pond_dest
-        ),
+    writer.require_temporal_metadata(field.to_string());
+
+    if let Some((min_us, max_us)) = scan_temporal_bounds(content, field, config.timestamp_unit) {
+        debug!(
+            "Temporal bounds for {}: [{}, {}] us from '{}'",
+            pond_dest, min_us, max_us, field
+        );
+        writer.set_temporal_metadata(min_us, max_us, field.to_string());
     }
 }
 
@@ -885,9 +920,9 @@ async fn process_active_file(
                 "Ingesting new file: {} ({} bytes)",
                 filename, host_file.size
             );
-            ingest_new_file(context, config, host_file).await?;
+            let written = ingest_new_file(context, config, host_file, false).await?;
             stats.new_files.0 += 1;
-            stats.new_files.1 += host_file.size;
+            stats.new_files.1 += written;
         }
         Some(pond_state) => {
             // Existing file: detect append
@@ -898,9 +933,9 @@ async fn process_active_file(
                     filename, new_bytes, pond_state.cumulative_size, host_file.size
                 );
 
-                ingest_append(context, config, host_file, pond_state).await?;
+                let written = ingest_append(context, config, host_file, pond_state).await?;
                 stats.appended.0 += 1;
-                stats.appended.1 += new_bytes;
+                stats.appended.1 += written;
             } else if host_file.size < pond_state.cumulative_size {
                 warn!(
                     "Active file {} SHRUNK from {} to {} bytes - unexpected!",
@@ -941,9 +976,9 @@ async fn process_archived_file(
                 "Ingesting new archived file: {} ({} bytes)",
                 filename, host_file.size
             );
-            ingest_new_file(context, config, host_file).await?;
+            let written = ingest_new_file(context, config, host_file, true).await?;
             stats.new_files.0 += 1;
-            stats.new_files.1 += host_file.size;
+            stats.new_files.1 += written;
         }
         Some(pond_state) => {
             // Verify archived file hasn't changed (should be immutable)
@@ -978,23 +1013,36 @@ async fn ingest_new_file(
     context: &FactoryContext,
     config: &LogfileIngestConfig,
     host_file: &HostFileState,
-) -> Result<(), tinyfs::Error> {
-    let content = std::fs::read(&host_file.path).map_other()?;
+    final_file: bool,
+) -> Result<u64, tinyfs::Error> {
+    let raw = std::fs::read(&host_file.path).map_other()?;
     let filename = host_file
         .path
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| tinyfs::Error::Other("Invalid filename".to_string()))?;
 
-    let blake3_hash = blake3::hash(&content);
+    let content = ingestible_slice(config, &raw, final_file);
+
+    if content.is_empty() {
+        debug!(
+            "New file {} has no complete line yet ({} bytes buffered); deferring",
+            host_file.path.display(),
+            raw.len()
+        );
+        return Ok(0);
+    }
+
+    let blake3_hash = blake3::hash(content);
 
     let pond_dest = format!("{}/{}", config.pond_path, filename);
 
     info!(
-        "Ingesting new file: {} -> {} ({} bytes, blake3={})",
+        "Ingesting new file: {} -> {} ({} of {} bytes, blake3={})",
         host_file.path.display(),
         pond_dest,
         content.len(),
+        raw.len(),
         &blake3_hash.to_hex()[..16]
     );
 
@@ -1012,13 +1060,13 @@ async fn ingest_new_file(
         .await?;
 
     // Write content and finalize
-    writer.write_all(&content).await.map_other()?;
-    attach_temporal_bounds(&mut writer, config, &content, &pond_dest);
+    writer.write_all(content).await.map_other()?;
+    attach_temporal_bounds(&mut writer, config, content, &pond_dest);
     writer.shutdown().await.map_other()?;
 
     info!("Wrote file to pond: {}", pond_dest);
 
-    Ok(())
+    Ok(content.len() as u64)
 }
 
 /// Ingest an append to an existing active file
@@ -1027,7 +1075,7 @@ async fn ingest_append(
     config: &LogfileIngestConfig,
     host_file: &HostFileState,
     pond_state: &PondFileState,
-) -> Result<(), tinyfs::Error> {
+) -> Result<u64, tinyfs::Error> {
     let filename = host_file
         .path
         .file_name()
@@ -1084,23 +1132,38 @@ async fn ingest_append(
     // Write new version as FilePhysicalSeries
     // TinyFS automatically maintains cumulative blake3 and bao_outboard
     use tokio::io::AsyncWriteExt;
+
+    // The active file is still being written, so the slice may end mid-record.
+    // Withhold that fragment: the next tick sees it as growth and picks it up
+    // once the line is complete.
+    let new_content = ingestible_slice(config, &new_content, false);
+    if new_content.is_empty() {
+        debug!(
+            "Append to {} contains no complete line yet ({} bytes buffered); deferring",
+            filename, bytes_to_read
+        );
+        return Ok(0);
+    }
+
     let mut writer = root
         .async_writer_path_with_type(&pond_dest, EntryType::FilePhysicalSeries)
         .await?;
 
     // Write only the new content (as a new version in the FilePhysicalSeries)
     // The ChainedReader will concatenate all versions when reading
-    writer.write_all(&new_content).await.map_other()?;
-    attach_temporal_bounds(&mut writer, config, &new_content, &pond_dest);
+    writer.write_all(new_content).await.map_other()?;
+    attach_temporal_bounds(&mut writer, config, new_content, &pond_dest);
     writer.shutdown().await.map_other()?;
 
     info!(
-        "Wrote append to pond: {} version {}",
+        "Wrote append to pond: {} version {} ({} of {} new bytes)",
         pond_dest,
-        pond_state.version + 1
+        pond_state.version + 1,
+        new_content.len(),
+        bytes_to_read
     );
 
-    Ok(())
+    Ok(new_content.len() as u64)
 }
 
 /// Find which archived file matches the pond's tracked content (for rotation detection)
@@ -1409,8 +1472,10 @@ mod tests {
 
     #[test]
     fn an_unparseable_line_abandons_the_scan() {
-        // A torn write must not yield bounds covering only the lines that did
-        // parse -- the rest of the slice would then be outside its own range.
+        // Bounds covering only the lines that parsed would leave the rest of
+        // the slice outside its own range. Since slices are line-aligned before
+        // they are written, reaching this case means genuinely corrupt input,
+        // and the declared temporal requirement turns it into a failed write.
         let content = format!("{}\n{{\"resourceMetrics\":\n", otlp_line(&["1000000000"]));
         assert_eq!(
             scan_temporal_bounds(
@@ -1536,5 +1601,104 @@ mod tests {
             timestamp_unit: TimestampUnit::default(),
         };
         assert!(config.validate().is_err());
+    }
+}
+
+#[cfg(test)]
+mod line_alignment_tests {
+    use super::*;
+
+    fn timestamped() -> LogfileIngestConfig {
+        LogfileIngestConfig {
+            active_pattern: String::new(),
+            archived_pattern: String::new(),
+            pond_path: "/ingest".to_string(),
+            timestamp_field: Some("timeUnixNano".to_string()),
+            timestamp_unit: Default::default(),
+        }
+    }
+
+    fn opaque() -> LogfileIngestConfig {
+        LogfileIngestConfig {
+            timestamp_field: None,
+            ..timestamped()
+        }
+    }
+
+    #[test]
+    fn an_opaque_stream_is_never_withheld() {
+        // Without a timestamp_field the operator has not said these are
+        // records, and the file may contain no newline at all -- aligning
+        // would withhold it forever rather than merely until the next tick.
+        let no_newline = &b"\x00\x01binary"[..];
+        assert_eq!(ingestible_slice(&opaque(), no_newline, false), no_newline);
+
+        let partial = &b"{\"a\":1}\n{\"b\":"[..];
+        assert_eq!(ingestible_slice(&opaque(), partial, false), partial);
+    }
+
+    #[test]
+    fn a_final_file_is_never_withheld() {
+        // A rotated or archived file is no longer appended to, so its last
+        // line is complete with or without a trailing newline.
+        let unterminated = &b"{\"a\":1}\n{\"b\":2}"[..];
+        assert_eq!(
+            ingestible_slice(&timestamped(), unterminated, true),
+            unterminated
+        );
+        assert_eq!(
+            ingestible_slice(&timestamped(), unterminated, false),
+            b"{\"a\":1}\n"
+        );
+    }
+
+    #[test]
+    fn a_trailing_partial_line_is_withheld() {
+        let slice = b"{\"a\":1}\n{\"b\":2}\n{\"c\":";
+        assert_eq!(complete_lines(slice), b"{\"a\":1}\n{\"b\":2}\n");
+    }
+
+    #[test]
+    fn a_slice_ending_on_a_newline_is_kept_whole() {
+        let slice = b"{\"a\":1}\n{\"b\":2}\n";
+        assert_eq!(complete_lines(slice), slice);
+    }
+
+    #[test]
+    fn a_slice_with_no_newline_yet_yields_nothing() {
+        // One record still being written. Deferring keeps the pond's cumulative
+        // size behind the host's, so the next tick sees it as growth.
+        assert_eq!(complete_lines(b"{\"a\":"), b"");
+        assert_eq!(complete_lines(b""), b"");
+    }
+
+    #[test]
+    fn successive_aligned_slices_reconstruct_the_source() {
+        // The property the pond depends on: withholding a fragment must lose no
+        // bytes and must leave every slice starting at a record boundary.
+        let source = b"{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n";
+        let mut consumed = 0usize;
+        let mut versions: Vec<&[u8]> = Vec::new();
+
+        // Feed the source in awkward chunks that mostly split mid-record.
+        for end in [3usize, 9, 12, 17, 20, source.len()] {
+            let slice = complete_lines(&source[consumed..end]);
+            if slice.is_empty() {
+                continue;
+            }
+            versions.push(slice);
+            consumed += slice.len();
+        }
+
+        assert_eq!(consumed, source.len());
+        assert_eq!(versions.concat(), source);
+        for version in &versions {
+            assert!(version.ends_with(b"\n"));
+            // Every version is independently parseable, which is what makes
+            // its temporal bounds computable.
+            for line in std::str::from_utf8(version).unwrap().lines() {
+                assert!(serde_json::from_str::<Value>(line).is_ok(), "line: {line}");
+            }
+        }
     }
 }

--- a/crates/steward/src/content_diff.rs
+++ b/crates/steward/src/content_diff.rs
@@ -115,8 +115,14 @@ fn by_name<'a>(index: &'a ContentTreeIndex, key: &NodeKey) -> BTreeMap<&'a str, 
 /// Recursively diff two physical directories whose tree hashes already differ.
 ///
 /// `prefix` is the slash-rooted path of the directory itself (empty for the
-/// root).  Only subtrees whose `child_hash` differs are descended into; equal
-/// child hashes prune the whole subtree.
+/// root).  Only subtrees that differ are descended into; an entry whose
+/// `child_hash` *and* node metadata both match prunes the whole subtree.
+///
+/// Metadata counts as content here.  A version's metadata -- when it was
+/// written, the event-time range it covers -- is data about that immutable
+/// version, committed to by the directory entry, so two entries that agree on
+/// bytes but disagree on metadata are `Modified`.  Pruning on `child_hash`
+/// alone would let the roots differ while the descent reported nothing.
 fn diff_dir(
     prefix: &str,
     left_key: &NodeKey,
@@ -149,8 +155,8 @@ fn diff_dir(
                 kind: DiffKind::Added,
             }),
             (Some(lc), Some(rc)) => {
-                if lc.child_hash == rc.child_hash {
-                    continue; // identical subtree -- prune.
+                if lc.child_hash == rc.child_hash && lc.versions == rc.versions {
+                    continue; // identical subtree and metadata -- prune.
                 }
                 if lc.entry_type != rc.entry_type {
                     out.push(ContentDiff {
@@ -160,9 +166,13 @@ fn diff_dir(
                     continue;
                 }
                 match (&lc.child_dir_key, &rc.child_dir_key) {
-                    // Both physical directories: descend for path-level detail.
-                    (Some(lk), Some(rk)) => diff_dir(&path, lk, left, rk, right, out),
-                    // Same non-directory kind with differing content.
+                    // Both physical directories with differing subtrees:
+                    // descend for path-level detail.
+                    (Some(lk), Some(rk)) if lc.child_hash != rc.child_hash => {
+                        diff_dir(&path, lk, left, rk, right, out);
+                    }
+                    // Same kind, differing content -- either differing bytes or
+                    // identical bytes with differing node metadata.
                     _ => out.push(ContentDiff {
                         path,
                         kind: DiffKind::Modified,

--- a/crates/steward/src/content_pull.rs
+++ b/crates/steward/src/content_pull.rs
@@ -22,8 +22,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 
 use crate::content_source::ContentSource;
 use sync_store::content::{
-    Commit, ManifestEntry, ObjectHash, TreeEntry, decode_manifest, decode_recipe, decode_series,
-    decode_tree,
+    Commit, ManifestEntry, ObjectHash, TreeEntry, VersionMeta, decode_manifest, decode_recipe,
+    decode_series, decode_tree,
 };
 use tinyfs::{EntryType, NodeID, WD};
 use tlogfs::PondUserMetadata;
@@ -352,6 +352,24 @@ enum VersionSource {
     External(ObjectHash),
 }
 
+/// One version to write during a rebuild: where its bytes come from, plus the
+/// node metadata the source recorded for it.
+///
+/// The metadata rides alongside the bytes because a replica cannot derive it:
+/// a raw JSON-lines blob's event-time range depends on the *source pond's*
+/// ingest configuration (which field, which unit), which the replica never
+/// sees. Without carrying it, every replicated series version would land with
+/// NULL bounds, and consumers that key off those bounds -- notably the
+/// temporal-reduce rollup cache -- would treat each one as spanning all time
+/// and rebuild all history on every run.
+#[derive(Debug, Clone)]
+struct PlannedVersion {
+    /// Where this version's bytes come from.
+    source: VersionSource,
+    /// Node metadata to reapply on the replica.
+    meta: VersionMeta,
+}
+
 /// One filesystem operation in an incremental rebuild plan, in apply order.
 ///
 /// The plan is a `node_id`-keyed diff of the fetched source manifest against
@@ -387,7 +405,7 @@ enum ApplyOp {
         node_id: String,
         create: bool,
         entry_type: EntryType,
-        versions: Vec<VersionSource>,
+        versions: Vec<PlannedVersion>,
         /// When set, the first written version replaces (collapses) every
         /// version the target already held -- replicating a source-side series
         /// compaction. `versions` then holds the full post-collapse list, not an
@@ -402,6 +420,8 @@ enum ApplyOp {
         node_id: String,
         create: bool,
         target: String,
+        /// The source's mtime, adopted verbatim (see [`VersionMeta::timestamp`]).
+        mtime: Option<i64>,
     },
     /// Create (adopting `node_id`) or rewrite a dynamic node from its recipe.
     Dynamic {
@@ -411,6 +431,8 @@ enum ApplyOp {
         create: bool,
         factory: String,
         config: Vec<u8>,
+        /// The source's mtime, adopted verbatim (see [`VersionMeta::timestamp`]).
+        mtime: Option<i64>,
     },
     /// Unlink a target node that is absent from the source.
     Delete { parent_path: String, name: String },
@@ -961,7 +983,11 @@ fn plan_one(
                 outcome.files += 1;
             }
             let versions = if content_changed {
-                vec![version_source(graph, entry.child_hash)?]
+                vec![planned_version(
+                    graph,
+                    entry.child_hash,
+                    entry.versions.first(),
+                )?]
             } else {
                 Vec::new()
             };
@@ -1006,6 +1032,7 @@ fn plan_one(
                     node_id: entry.node_id.clone(),
                     create,
                     target,
+                    mtime: replicated_mtime(entry),
                 });
             }
         }
@@ -1025,11 +1052,21 @@ fn plan_one(
                     create,
                     factory,
                     config,
+                    mtime: replicated_mtime(entry),
                 });
             }
         }
     }
     Ok(())
+}
+
+/// The mtime a single-version node (symlink, dynamic recipe) should adopt.
+///
+/// Such a node has exactly one [`VersionMeta`], so the last entry is the node's
+/// current state; a node whose source recorded no mtime gets the local clock,
+/// as before.
+fn replicated_mtime(entry: &ManifestEntry) -> Option<i64> {
+    entry.versions.last().and_then(|meta| meta.timestamp)
 }
 
 /// Decide which series version blobs to write and whether the first replaces the
@@ -1049,8 +1086,23 @@ fn plan_series_versions(
     graph: &FetchedGraph,
     target_series: &HashMap<String, Vec<ObjectHash>>,
     existing_child_hash: Option<ObjectHash>,
-) -> Result<(Vec<VersionSource>, bool), StewardError> {
-    let incoming = series_hashes(graph, entry.child_hash)?;
+) -> Result<(Vec<PlannedVersion>, bool), StewardError> {
+    let incoming = series_versions(graph, entry.child_hash)?;
+
+    // The manifest entry carries one VersionMeta per live version, in the same
+    // order as the series object's hashes. A mismatch means the two objects
+    // disagree about the node's shape, so the metadata cannot be aligned with
+    // the bytes it describes; rebuilding from it would silently attach the
+    // wrong bounds to a version.
+    if !entry.versions.is_empty() && entry.versions.len() != incoming.len() {
+        return Err(StewardError::Content(format!(
+            "series node {} has {} version(s) but its entry carries {} metadata record(s)",
+            entry.node_id,
+            incoming.len(),
+            entry.versions.len()
+        )));
+    }
+    let meta_at = |index: usize| entry.versions.get(index);
 
     let held = match existing_child_hash {
         None => &[][..],
@@ -1071,7 +1123,8 @@ fn plan_series_versions(
     if incoming.len() >= held.len() && incoming[..held.len()] == *held {
         let suffix = incoming[held.len()..]
             .iter()
-            .map(|hash| version_source(graph, *hash))
+            .enumerate()
+            .map(|(offset, hash)| planned_version(graph, *hash, meta_at(held.len() + offset)))
             .collect::<Result<Vec<_>, _>>()?;
         return Ok((suffix, false));
     }
@@ -1081,7 +1134,8 @@ fn plan_series_versions(
     // the first version collapses everything the target held.
     let full = incoming
         .iter()
-        .map(|hash| version_source(graph, *hash))
+        .enumerate()
+        .map(|(index, hash)| planned_version(graph, *hash, meta_at(index)))
         .collect::<Result<Vec<_>, _>>()?;
     Ok((full, true))
 }
@@ -1171,12 +1225,13 @@ async fn apply_ops(
                 node_id,
                 create,
                 target,
+                mtime,
             } => {
                 let pwd = parent_wd(&dir_wd, parent)?;
                 if !create {
                     pwd.remove_entry(name).await?;
                 }
-                pwd.insert_symlink_with_id(name, parse_node_id(node_id)?, target)
+                pwd.insert_symlink_with_id(name, parse_node_id(node_id)?, target, *mtime)
                     .await?;
             }
             ApplyOp::Dynamic {
@@ -1186,13 +1241,20 @@ async fn apply_ops(
                 create,
                 factory,
                 config,
+                mtime,
             } => {
                 let pwd = parent_wd(&dir_wd, parent)?;
                 if !create {
                     pwd.remove_entry(name).await?;
                 }
-                pwd.insert_dynamic_with_id(name, parse_node_id(node_id)?, factory, config.clone())
-                    .await?;
+                pwd.insert_dynamic_with_id(
+                    name,
+                    parse_node_id(node_id)?,
+                    factory,
+                    config.clone(),
+                    *mtime,
+                )
+                .await?;
             }
         }
     }
@@ -1205,11 +1267,11 @@ async fn apply_ops(
 /// large blob never lands in a single buffer (D7).
 async fn write_version(
     mut writer: std::pin::Pin<Box<dyn tinyfs::FileMetadataWriter>>,
-    version: &VersionSource,
+    version: &PlannedVersion,
     entry_type: EntryType,
     remote: &dyn ContentSource,
 ) -> Result<(), StewardError> {
-    match version {
+    match &version.source {
         VersionSource::Inline(bytes) => {
             writer.write_all(bytes).await?;
         }
@@ -1217,7 +1279,7 @@ async fn write_version(
             stream_external_blob(&mut writer, *hash, remote).await?;
         }
     }
-    finalize_writer(writer, entry_type).await
+    finalize_writer(writer, entry_type, &version.meta).await
 }
 
 /// Stream a large external blob from the remote blob store into `writer` in
@@ -1263,19 +1325,44 @@ async fn stream_external_blob(
     Ok(())
 }
 
-/// Finalize a version writer: a table series infers its temporal bounds from
-/// the parquet footer (which also shuts the writer down); every other kind just
-/// closes.
+/// Finalize a version writer, reapplying the node metadata the source recorded.
+///
+/// The mtime, when carried, is adopted verbatim so the mirrored version keeps
+/// the timestamp it was originally written with rather than claiming to have
+/// been modified at pull time. When the source recorded an event-time range,
+/// the replica sets it explicitly so the replicated node carries the same
+/// bounds as the original. Otherwise a table series can still recover its range
+/// from the parquet footer it just wrote (which also shuts the writer down);
+/// every other kind just closes, leaving the bounds NULL as before.
 async fn finalize_writer(
     mut writer: std::pin::Pin<Box<dyn tinyfs::FileMetadataWriter>>,
     entry_type: EntryType,
+    meta: &VersionMeta,
 ) -> Result<(), StewardError> {
-    if entry_type == EntryType::TablePhysicalSeries {
+    if let Some(mtime) = meta.timestamp {
+        writer.set_mtime(mtime);
+    }
+    if let Some((min, max)) = meta.bounds() {
+        writer.set_temporal_metadata(min, max, timestamp_column(meta));
+        writer.shutdown().await?;
+    } else if entry_type == EntryType::TablePhysicalSeries {
         let _ = writer.infer_temporal_bounds().await?;
     } else {
         writer.shutdown().await?;
     }
     Ok(())
+}
+
+/// The timestamp column named by a version's replicated extended attributes,
+/// falling back to the system default when they say nothing.
+fn timestamp_column(meta: &VersionMeta) -> String {
+    meta.extended_attributes
+        .as_deref()
+        .and_then(|json| tlogfs::schema::ExtendedAttributes::from_json(json).ok())
+        .map_or_else(
+            || "Timestamp".to_string(),
+            |attrs| attrs.timestamp_column().to_string(),
+        )
 }
 
 /// Look up a parent directory's working directory by `node_id`, erroring if it
@@ -1366,8 +1453,21 @@ fn version_source(graph: &FetchedGraph, hash: ObjectHash) -> Result<VersionSourc
     }
 }
 
-/// Resolve a series object to its ordered list of version blob hashes.
-fn series_hashes(
+/// Resolve a planned series version: its bytes source plus the node metadata
+/// the source's directory entry recorded for it.
+fn planned_version(
+    graph: &FetchedGraph,
+    hash: ObjectHash,
+    meta: Option<&VersionMeta>,
+) -> Result<PlannedVersion, StewardError> {
+    Ok(PlannedVersion {
+        source: version_source(graph, hash)?,
+        meta: meta.cloned().unwrap_or_default(),
+    })
+}
+
+/// Resolve a series object to its ordered versions (blob hash plus metadata).
+fn series_versions(
     graph: &FetchedGraph,
     series_hash: ObjectHash,
 ) -> Result<&[ObjectHash], StewardError> {

--- a/crates/steward/src/content_tree.rs
+++ b/crates/steward/src/content_tree.rs
@@ -39,9 +39,9 @@ use std::sync::Arc;
 use datafusion::execution::context::SessionContext;
 
 use sync_store::content::{
-    Commit, ManifestEntry, ObjectHash, Provenance, TreeEntry, decode_manifest, encode_manifest,
-    encode_recipe, encode_series, encode_tree, manifest_hash, node_merkle_rebuild_root,
-    recipe_hash, series_hash,
+    Commit, ManifestEntry, ObjectHash, Provenance, TreeEntry, VersionMeta, decode_manifest,
+    encode_manifest, encode_recipe, encode_series, encode_tree, manifest_hash,
+    node_merkle_rebuild_root, recipe_hash, series_hash,
 };
 use tinyfs::{EntryType, ROOT_UUID};
 use tlogfs::schema::{CollapseRange, OplogEntry, decode_directory_entries, live_series_versions};
@@ -109,7 +109,11 @@ pub(crate) async fn materialize_tlog(
 #[derive(Debug, Clone)]
 pub struct ContentTreeReport {
     /// The content hash of the local pond's root directory tree.  Equal roots
-    /// mean byte-identical content across the whole pond.
+    /// mean identical content across the whole pond -- identical bytes *and*
+    /// the node metadata the directory entries commit to, since a version's
+    /// metadata is data about that version.  A replica has an equal root; two
+    /// ponds written independently from the same bytes do not, because their
+    /// versions were created at different times.
     pub root_tree_hash: ObjectHash,
     /// Number of distinct nodes folded into the root.
     pub nodes_hashed: usize,
@@ -185,6 +189,10 @@ pub(crate) struct ChildRef {
     /// The child directory's node key, present only when the child is a
     /// physical directory (the only kind a diff can descend into).
     pub child_dir_key: Option<NodeKey>,
+    /// Node metadata for the child's live versions, oldest first: one entry for
+    /// a single-version node, one per version for a series, none for a
+    /// directory (whose state is its subtree).
+    pub versions: Vec<VersionMeta>,
 }
 
 /// An in-memory index of a pond's content tree: the root hash plus, for every
@@ -226,6 +234,9 @@ struct NodeFacts {
     /// into the recipe hash so the content commits to the factory, not just its
     /// config (Decision D4).
     factory: Option<String>,
+    /// The node metadata of this node's latest version, carried on the parent
+    /// directory's entry so a replica can restore it.
+    meta: VersionMeta,
 }
 
 /// One version of a series: its blob hash plus the inline bytes when the
@@ -234,6 +245,7 @@ struct NodeFacts {
 struct VersionBlob {
     hash: ObjectHash,
     content: Option<Vec<u8>>,
+    meta: VersionMeta,
 }
 
 /// Compute the local pond's `root_tree_hash` from its live filesystem state.
@@ -309,7 +321,7 @@ pub(crate) async fn build_content_tree_for_table(
 pub(crate) fn node_manifest_entries(index: &ContentTreeIndex) -> Vec<ManifestEntry> {
     let local_pond = &index.root_key.0;
     let mut entries = Vec::with_capacity(index.nodes_hashed.max(1));
-    entries.push(ManifestEntry::new(
+    entries.push(ManifestEntry::bare(
         index.root_key.1.clone(),
         String::new(),
         String::new(),
@@ -328,6 +340,7 @@ pub(crate) fn node_manifest_entries(index: &ContentTreeIndex) -> Vec<ManifestEnt
                 child.name.clone(),
                 child.entry_type,
                 child.child_hash,
+                child.versions.clone(),
             ));
         }
     }
@@ -512,11 +525,16 @@ pub(crate) async fn incremental_spine_inputs(
     // Baseline drawn from the prior manifest: every node's current child_hash,
     // type, parent, and each directory's content-child listing.
     let mut child_hash: HashMap<String, ObjectHash> = HashMap::new();
+    // Node metadata per node, seeded from the prior manifest and replaced for
+    // every node this transaction touched.  Carried alongside `child_hash`
+    // because a metadata-only change leaves the content hash untouched.
+    let mut child_versions: HashMap<String, Vec<VersionMeta>> = HashMap::new();
     let mut etype_of: HashMap<String, EntryType> = HashMap::new();
     let mut parent_of: HashMap<String, String> = HashMap::new();
     let mut dir_children: HashMap<String, Vec<ChildLite>> = HashMap::new();
     for e in &prior {
         let _ = child_hash.insert(e.node_id.clone(), e.child_hash);
+        let _ = child_versions.insert(e.node_id.clone(), e.versions.clone());
         let _ = etype_of.insert(e.node_id.clone(), e.entry_type);
         if e.node_id == ROOT_UUID {
             continue;
@@ -536,7 +554,7 @@ pub(crate) async fn incremental_spine_inputs(
     // the latest leaf row, and the accumulated series version blobs per node.
     let mut dir_rows: HashMap<String, (i64, Vec<u8>)> = HashMap::new();
     let mut leaf_latest: HashMap<String, OplogEntry> = HashMap::new();
-    let mut series_new: HashMap<String, BTreeMap<i64, ObjectHash>> = HashMap::new();
+    let mut series_new: HashMap<String, BTreeMap<i64, (ObjectHash, VersionMeta)>> = HashMap::new();
     let mut series_ranges: HashMap<String, Vec<(i64, CollapseRange)>> = HashMap::new();
     let mut changed: BTreeSet<String> = BTreeSet::new();
     for row in uncommitted {
@@ -552,10 +570,18 @@ pub(crate) async fn incremental_spine_inputs(
         match row.file_type {
             EntryType::FilePhysicalSeries | EntryType::TablePhysicalSeries => {
                 let hash = row_blob_hash(&row.blake3, row.content.as_deref());
-                let _ = series_new
-                    .entry(node.clone())
-                    .or_default()
-                    .insert(row.version, hash);
+                let _ = series_new.entry(node.clone()).or_default().insert(
+                    row.version,
+                    (
+                        hash,
+                        version_meta(
+                            row.timestamp,
+                            row.min_event_time,
+                            row.max_event_time,
+                            row.extended_attributes.as_ref(),
+                        ),
+                    ),
+                );
                 series_ranges
                     .entry(node)
                     .or_default()
@@ -604,6 +630,15 @@ pub(crate) async fn incremental_spine_inputs(
             }
         };
         let _ = child_hash.insert(node.clone(), hash);
+        let _ = child_versions.insert(
+            node.clone(),
+            vec![version_meta(
+                row.timestamp,
+                row.min_event_time,
+                row.max_event_time,
+                row.extended_attributes.as_ref(),
+            )],
+        );
     }
 
     // New content hash of every touched series: its committed version blobs
@@ -613,19 +648,21 @@ pub(crate) async fn incremental_spine_inputs(
     for (node, appended) in &series_new {
         let (mut versions, mut ranges) =
             read_series_committed(committed_table.clone(), local_pond_id, node).await?;
-        for (version, hash) in appended {
-            let _ = versions.insert(*version, *hash);
+        for (version, version_obj) in appended {
+            let _ = versions.insert(*version, version_obj.clone());
         }
         // This transaction's rows shadow the committed rows of the same version.
         if let Some(new_ranges) = series_ranges.get(node) {
             ranges.retain(|(v, _)| !new_ranges.iter().any(|(nv, _)| nv == v));
             ranges.extend(new_ranges.iter().copied());
         }
-        let ordered: Vec<ObjectHash> = live_series_versions(&ranges)
+        let ordered: Vec<(ObjectHash, VersionMeta)> = live_series_versions(&ranges)
             .into_iter()
-            .filter_map(|version| versions.get(&version).copied())
+            .filter_map(|version| versions.get(&version).cloned())
             .collect();
-        let _ = child_hash.insert(node.clone(), series_hash(&ordered));
+        let hashes: Vec<ObjectHash> = ordered.iter().map(|(h, _)| *h).collect();
+        let _ = child_hash.insert(node.clone(), series_hash(&hashes));
+        let _ = child_versions.insert(node.clone(), ordered.into_iter().map(|(_, m)| m).collect());
     }
 
     // Replace the listing of every modified directory, skipping the entries the
@@ -692,7 +729,11 @@ pub(crate) async fn incremental_spine_inputs(
                     kid.node_id
                 ))
             })?;
-            tree_entries.push(TreeEntry::new(kid.name, kid.entry_type, *ch));
+            let versions = child_versions
+                .get(&kid.node_id)
+                .cloned()
+                .unwrap_or_default();
+            tree_entries.push(TreeEntry::new(kid.name, kid.entry_type, *ch, versions));
         }
         let encoded = encode_tree(&tree_entries).map_err(StewardError::Content)?;
         let _ = child_hash.insert(dir, ObjectHash::of_bytes(&encoded));
@@ -705,7 +746,7 @@ pub(crate) async fn incremental_spine_inputs(
     // Rebuild the manifest by walking the live tree from the root, so deleted
     // (now-unreachable) subtrees drop out and only live nodes are recorded.
     let mut manifest: Vec<ManifestEntry> = Vec::with_capacity(prior.len());
-    manifest.push(ManifestEntry::new(
+    manifest.push(ManifestEntry::bare(
         ROOT_UUID.to_string(),
         String::new(),
         String::new(),
@@ -731,6 +772,10 @@ pub(crate) async fn incremental_spine_inputs(
                 kid.name,
                 kid.entry_type,
                 *ch,
+                child_versions
+                    .get(&kid.node_id)
+                    .cloned()
+                    .unwrap_or_default(),
             ));
             if kid.entry_type == EntryType::DirectoryPhysical {
                 stack.push(kid.node_id);
@@ -786,13 +831,20 @@ async fn read_series_committed(
     table: deltalake::DeltaTable,
     pond_id: &str,
     node_id: &str,
-) -> Result<(BTreeMap<i64, ObjectHash>, Vec<(i64, CollapseRange)>), StewardError> {
+) -> Result<
+    (
+        BTreeMap<i64, (ObjectHash, VersionMeta)>,
+        Vec<(i64, CollapseRange)>,
+    ),
+    StewardError,
+> {
     let ctx = SessionContext::new();
     let _previous = ctx
         .register_table("series_live", Arc::new(table))
         .map_err(|e| StewardError::DeltaLake(e.to_string()))?;
     let sql = format!(
-        "SELECT version, blake3, content, collapsed_from, collapsed_through FROM series_live \
+        "SELECT version, timestamp, blake3, content, collapsed_from, collapsed_through, \
+         min_event_time, max_event_time, extended_attributes FROM series_live \
          WHERE pond_id = '{pond_id}' AND node_id = '{node_id}' ORDER BY version",
     );
     let batches = ctx
@@ -817,25 +869,38 @@ async fn read_series_committed(
             )
         })
         .collect();
-    let mut versions: BTreeMap<i64, ObjectHash> = BTreeMap::new();
+    let mut versions: BTreeMap<i64, (ObjectHash, VersionMeta)> = BTreeMap::new();
     for row in rows {
         let _ = versions.insert(
             row.version,
-            row_blob_hash(&row.blake3, row.content.as_deref()),
+            (
+                row_blob_hash(&row.blake3, row.content.as_deref()),
+                version_meta(
+                    row.timestamp,
+                    row.min_event_time,
+                    row.max_event_time,
+                    row.extended_attributes.as_ref(),
+                ),
+            ),
         );
     }
     Ok((versions, ranges))
 }
 
 /// One committed series version row: its version and the fields
-/// [`row_blob_hash`] needs, plus the collapse range columns.
+/// [`row_blob_hash`] needs, plus the collapse range columns and the node
+/// metadata a replica cannot recompute.
 #[derive(serde::Deserialize)]
 struct SeriesVersionRow {
     version: i64,
+    timestamp: i64,
     blake3: Option<String>,
     content: Option<Vec<u8>>,
     collapsed_from: Option<i64>,
     collapsed_through: Option<i64>,
+    min_event_time: Option<i64>,
+    max_event_time: Option<i64>,
+    extended_attributes: Option<String>,
 }
 
 /// Read the reserved commit-log node's leaves from `table` in commit order:
@@ -1227,6 +1292,12 @@ fn fold_rows(
                 VersionBlob {
                     hash,
                     content: row.content.clone(),
+                    meta: version_meta(
+                        row.timestamp,
+                        row.min_event_time,
+                        row.max_event_time,
+                        row.extended_attributes.as_ref(),
+                    ),
                 },
             );
             series_ranges
@@ -1238,6 +1309,12 @@ fn fold_rows(
         let _ = latest.insert(
             key,
             NodeFacts {
+                meta: version_meta(
+                    row.timestamp,
+                    row.min_event_time,
+                    row.max_event_time,
+                    row.extended_attributes.as_ref(),
+                ),
                 content: row.content,
                 blake3: row.blake3,
                 factory: row.factory,
@@ -1320,6 +1397,43 @@ fn row_blob_hash(blake3: &Option<String>, content: Option<&[u8]>) -> ObjectHash 
     ObjectHash::of_bytes(content.unwrap_or(&[]))
 }
 
+/// Canonicalize an extended-attributes JSON object so two ponds holding the
+/// same attributes serialize them identically.
+///
+/// The stored form comes from `serde_json` over a `HashMap`, whose key order is
+/// nondeterministic. That is harmless while the string is only ever read back
+/// locally, but a directory entry *hashes* it: if a source and its mirror
+/// emitted different key orders for equal attributes, their `tree_hash` would
+/// never converge and every pull would rewrite the series forever. Re-encoding
+/// through a `BTreeMap` sorts the keys and makes the encoding canonical.
+///
+/// Anything that does not parse as a flat JSON object is passed through
+/// verbatim -- an unrecognized shape is still node state and must not be lost.
+fn canonical_attributes(attrs: Option<&String>) -> Option<String> {
+    let raw = attrs?;
+    match serde_json::from_str::<BTreeMap<String, String>>(raw) {
+        Ok(sorted) => serde_json::to_string(&sorted)
+            .ok()
+            .or_else(|| Some(raw.clone())),
+        Err(_) => Some(raw.clone()),
+    }
+}
+
+/// Extract the node metadata a replica cannot recompute from content bytes.
+fn version_meta(
+    timestamp: i64,
+    min_event_time: Option<i64>,
+    max_event_time: Option<i64>,
+    extended_attributes: Option<&String>,
+) -> VersionMeta {
+    VersionMeta {
+        timestamp: Some(timestamp),
+        min_event_time,
+        max_event_time,
+        extended_attributes: canonical_attributes(extended_attributes),
+    }
+}
+
 /// Fold one directory (by key) into its recursive [`tree_hash`], recording its
 /// child list into `dirs` for later comparison.  When `sink` is `Some`, the
 /// encoded tree object bytes (and, via `hash_child`, descendant object bytes)
@@ -1383,7 +1497,7 @@ fn hash_directory(
         if child_key.1 == tinyfs::INDEX_NODE_UUID || child_key.1 == tinyfs::LOG_NODE_UUID {
             continue;
         }
-        let child_hash = hash_child(
+        let (child_hash, versions) = hash_child(
             &child_key,
             entry.entry_type,
             latest,
@@ -1405,8 +1519,14 @@ fn hash_directory(
             child_hash,
             child_node_id,
             child_dir_key,
+            versions: versions.clone(),
         });
-        tree_entries.push(TreeEntry::new(entry.name, entry.entry_type, child_hash));
+        tree_entries.push(TreeEntry::new(
+            entry.name,
+            entry.entry_type,
+            child_hash,
+            versions,
+        ));
     }
 
     let _ = in_progress.pop();
@@ -1434,16 +1554,20 @@ fn hash_child(
     in_progress: &mut Vec<NodeKey>,
     dirs: &mut HashMap<NodeKey, Vec<ChildRef>>,
     sink: Option<&mut MaterializedObjects>,
-) -> Result<ObjectHash, StewardError> {
+) -> Result<(ObjectHash, Vec<VersionMeta>), StewardError> {
     match entry_type {
         EntryType::DirectoryPhysical => {
-            hash_directory(key, latest, series_versions, memo, in_progress, dirs, sink)
+            // A directory carries no metadata of its own: its state is the
+            // subtree its tree_hash already commits to.
+            let hash = hash_directory(key, latest, series_versions, memo, in_progress, dirs, sink)?;
+            Ok((hash, Vec::new()))
         }
         EntryType::FilePhysicalSeries | EntryType::TablePhysicalSeries => {
             let versions = series_versions.get(key).ok_or_else(|| {
                 StewardError::DeltaLake(format!("missing series node {}/{}", key.0, key.1))
             })?;
             let ordered: Vec<ObjectHash> = versions.iter().map(|v| v.hash).collect();
+            let metas: Vec<VersionMeta> = versions.iter().map(|v| v.meta.clone()).collect();
             let series = series_hash(&ordered);
             if let Some(sink) = sink {
                 // The series manifest object, plus each version blob: small
@@ -1453,7 +1577,7 @@ fn hash_child(
                     record_blob(sink, v.hash, v.content.as_deref());
                 }
             }
-            Ok(series)
+            Ok((series, metas))
         }
         // Symlinks hash their target bytes; dynamic nodes hash their recipe
         // (factory type plus config), so the content commits to the factory and
@@ -1466,7 +1590,7 @@ fn hash_child(
                 // Symlink targets are small; always inline.
                 sink.put_inline(hash, bytes.to_vec());
             }
-            Ok(hash)
+            Ok((hash, vec![facts.meta.clone()]))
         }
         EntryType::DirectoryDynamic | EntryType::FileDynamic | EntryType::TableDynamic => {
             let facts = leaf_facts(key, latest)?;
@@ -1482,7 +1606,7 @@ fn hash_child(
                 // Recipes (factory + config) are small; always inline.
                 sink.put_inline(hash, encode_recipe(factory, config));
             }
-            Ok(hash)
+            Ok((hash, vec![facts.meta.clone()]))
         }
         // Single-version physical file or table: the version blob hash.
         EntryType::FilePhysicalVersion | EntryType::TablePhysicalVersion => {
@@ -1491,7 +1615,7 @@ fn hash_child(
             if let Some(sink) = sink {
                 record_blob(sink, hash, facts.content.as_deref());
             }
-            Ok(hash)
+            Ok((hash, vec![facts.meta.clone()]))
         }
     }
 }

--- a/crates/steward/src/fsck.rs
+++ b/crates/steward/src/fsck.rs
@@ -226,7 +226,7 @@ pub async fn fsck(ship: &Ship, opts: FsckOptions) -> Result<FsckReport, StewardE
             });
         }
 
-        pond_root_entries.push(TreeEntry::new(
+        pond_root_entries.push(TreeEntry::bare(
             pond_id.clone(),
             EntryType::DirectoryPhysical,
             index.root_tree_hash,

--- a/crates/steward/tests/commit_spine_test.rs
+++ b/crates/steward/tests/commit_spine_test.rs
@@ -8,6 +8,7 @@
 //! through `parent_commit_hash == previous commit_hash`.
 
 use steward::Ship;
+use sync_store::ContentRemote;
 use tempfile::tempdir;
 use tinyfs::async_helpers::convenience::create_file_path;
 use tlogfs::PondUserMetadata;
@@ -25,6 +26,36 @@ async fn write_file(ship: &mut Ship, path: &str, bytes: &[u8]) {
     })
     .await
     .expect("write transaction");
+}
+
+/// Build a genuine replica of `src`.
+///
+/// Replication is the only way to obtain a second pond with identical content:
+/// a version's metadata -- when it was created, the event-time range it covers
+/// -- is data about that immutable version, and the directory entry commits to
+/// it.  Two ponds written independently from the same bytes therefore do *not*
+/// have identical content.  A replica adopts the source's metadata verbatim,
+/// so it does.
+async fn replica_of(src: &Ship, label: &str) -> (tempfile::TempDir, tempfile::TempDir, Ship) {
+    let pond_id = uuid::Uuid::parse_str(src.data_persistence().pond_id()).expect("pond id");
+    let remote_dir = tempdir().expect("remote dir");
+    let mut remote = ContentRemote::create_at(remote_dir.path().join("remote"), pond_id)
+        .await
+        .expect("create remote");
+    let _ = steward::push_content_to_remote(src, &mut remote, "main")
+        .await
+        .expect("push");
+    let graph = steward::fetch_object_graph(&remote, "main")
+        .await
+        .expect("fetch");
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), label)
+        .await
+        .expect("create replica");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("rebuild");
+    (remote_dir, dst_dir, dst)
 }
 
 /// The persisted `root_tree_hash` for the latest commit equals the read-side
@@ -107,22 +138,18 @@ async fn successive_commits_chain_through_parent_hash() {
     );
 }
 
-/// Two ponds with identical content produce identical persisted
-/// `root_tree_hash` values, even though their `commit_hash` values differ
-/// (provenance differs by pond_id and time).
+/// A pond and its replica produce identical persisted `root_tree_hash` values,
+/// even though their `commit_hash` values differ (provenance differs by pond_id
+/// and time).
 #[tokio::test]
-async fn identical_content_same_root_hash_different_commit_hash() {
+async fn replica_same_root_hash_different_commit_hash() {
     let tmp_a = tempdir().expect("tempdir a");
-    let tmp_b = tempdir().expect("tempdir b");
     let mut ship_a = Ship::create_pond(tmp_a.path().join("pond"), "pond-a")
         .await
         .expect("create pond a");
-    let mut ship_b = Ship::create_pond(tmp_b.path().join("pond"), "pond-b")
-        .await
-        .expect("create pond b");
 
     write_file(&mut ship_a, "/a.txt", b"same content").await;
-    write_file(&mut ship_b, "/a.txt", b"same content").await;
+    let (_rt, _dt, ship_b) = replica_of(&ship_a, "pond-b").await;
 
     let seq_a = ship_a.last_write_seq();
     let seq_b = ship_b.last_write_seq();

--- a/crates/steward/tests/content_diff_test.rs
+++ b/crates/steward/tests/content_diff_test.rs
@@ -8,6 +8,7 @@
 //! to the minimal set of divergent paths.
 
 use steward::{DiffKind, Ship, compare_content_trees};
+use sync_store::ContentRemote;
 use tempfile::tempdir;
 use tinyfs::async_helpers::convenience::create_file_path;
 use tlogfs::PondUserMetadata;
@@ -49,10 +50,62 @@ async fn new_pond(label: &str) -> (tempfile::TempDir, Ship) {
     (tmp, ship)
 }
 
-/// Identical content across two ponds compares equal with no differences,
-/// regardless of pond identity or lineage.
+/// Build a genuine replica of `src`.
+///
+/// Replication is the only way to obtain a second pond with identical content:
+/// a version's metadata -- when it was created, the event-time range it covers
+/// -- is data about that immutable version, and the directory entry commits to
+/// it.  Two ponds written independently from the same bytes therefore do *not*
+/// have identical content.  A replica adopts the source's metadata verbatim,
+/// so it does.
+async fn replica_of(src: &Ship, label: &str) -> (tempfile::TempDir, tempfile::TempDir, Ship) {
+    let pond_id = uuid::Uuid::parse_str(src.data_persistence().pond_id()).expect("pond id");
+    let remote_dir = tempdir().expect("remote dir");
+    let mut remote = ContentRemote::create_at(remote_dir.path().join("remote"), pond_id)
+        .await
+        .expect("create remote");
+    let _ = steward::push_content_to_remote(src, &mut remote, "main")
+        .await
+        .expect("push");
+    let graph = steward::fetch_object_graph(&remote, "main")
+        .await
+        .expect("fetch");
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), label)
+        .await
+        .expect("create replica");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("rebuild");
+    (remote_dir, dst_dir, dst)
+}
+
+/// A replica compares equal to its source with no differences, regardless of
+/// pond identity or lineage.
 #[tokio::test]
-async fn identical_ponds_compare_equal() {
+async fn replica_compares_equal_to_source() {
+    let (_ta, mut a) = new_pond("pond-a").await;
+    write_file(&mut a, "/a.txt", b"hello").await;
+    mkdir_and_file(&mut a, "/sub", "/sub/b.txt", b"world").await;
+
+    let (_rt, _dt, b) = replica_of(&a, "pond-b").await;
+
+    let cmp = compare_content_trees(&a, &b).await.expect("compare");
+    assert!(
+        cmp.equal,
+        "a replica must compare equal to its source: {:?}",
+        cmp.differences
+    );
+    assert!(cmp.differences.is_empty());
+}
+
+/// Two ponds written independently from the same bytes are not equal, because
+/// their versions were created at different times -- and the divergence must be
+/// *reported*.  Pruning the descent on `child_hash` alone once let the roots
+/// differ while the diff listed nothing, which is the least useful answer a
+/// comparison can give.
+#[tokio::test]
+async fn independently_written_ponds_differ_by_metadata() {
     let (_ta, mut a) = new_pond("pond-a").await;
     let (_tb, mut b) = new_pond("pond-b").await;
 
@@ -62,8 +115,20 @@ async fn identical_ponds_compare_equal() {
     }
 
     let cmp = compare_content_trees(&a, &b).await.expect("compare");
-    assert!(cmp.equal, "identical content must compare equal");
-    assert!(cmp.differences.is_empty());
+    assert!(
+        !cmp.equal,
+        "independent writes do not share version metadata"
+    );
+    let paths: Vec<&str> = cmp.differences.iter().map(|d| d.path.as_str()).collect();
+    assert!(
+        paths.contains(&"/a.txt") && paths.contains(&"/sub/b.txt"),
+        "every differing leaf is reported, got {paths:?}"
+    );
+    assert!(
+        cmp.differences.iter().all(|d| d.kind == DiffKind::Modified),
+        "same bytes, different metadata is a modification, got {:?}",
+        cmp.differences
+    );
 }
 
 /// A single differing file is reported as exactly one `Modified` path; the
@@ -71,12 +136,12 @@ async fn identical_ponds_compare_equal() {
 #[tokio::test]
 async fn single_modified_file_is_isolated() {
     let (_ta, mut a) = new_pond("pond-a").await;
-    let (_tb, mut b) = new_pond("pond-b").await;
+    write_file(&mut a, "/shared.txt", b"same").await;
+    mkdir_and_file(&mut a, "/sub", "/sub/keep.txt", b"identical").await;
+    // The shared base must be *replicated* rather than rewritten, or every
+    // common path would differ by its version metadata too.
+    let (_rt, _dt, mut b) = replica_of(&a, "pond-b").await;
 
-    for ship in [&mut a, &mut b] {
-        write_file(ship, "/shared.txt", b"same").await;
-        mkdir_and_file(ship, "/sub", "/sub/keep.txt", b"identical").await;
-    }
     // Diverge one nested file only.
     write_file(&mut a, "/sub/diff.txt", b"left").await;
     write_file(&mut b, "/sub/diff.txt", b"right").await;
@@ -92,12 +157,10 @@ async fn single_modified_file_is_isolated() {
 #[tokio::test]
 async fn added_and_removed_entries_are_classified() {
     let (_ta, mut a) = new_pond("pond-a").await;
-    let (_tb, mut b) = new_pond("pond-b").await;
+    // Common base, replicated so it is genuinely common.
+    write_file(&mut a, "/common.txt", b"base").await;
+    let (_rt, _dt, mut b) = replica_of(&a, "pond-b").await;
 
-    // Common base.
-    for ship in [&mut a, &mut b] {
-        write_file(ship, "/common.txt", b"base").await;
-    }
     // Only-left and only-right files.
     write_file(&mut a, "/only_left.txt", b"L").await;
     write_file(&mut b, "/only_right.txt", b"R").await;

--- a/crates/steward/tests/content_objects_test.rs
+++ b/crates/steward/tests/content_objects_test.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeSet;
 
 use steward::{ObjectKind, Ship, inventory_content_objects};
+use sync_store::ContentRemote;
 use tempfile::tempdir;
 use tinyfs::async_helpers::convenience::create_file_path;
 use tlogfs::PondUserMetadata;
@@ -49,6 +50,36 @@ async fn new_pond(label: &str) -> (tempfile::TempDir, Ship) {
     (tmp, ship)
 }
 
+/// Build a genuine replica of `src`.
+///
+/// Replication is the only way to obtain a second pond with identical content:
+/// a version's metadata -- when it was created, the event-time range it covers
+/// -- is data about that immutable version, and the directory entry commits to
+/// it.  Two ponds written independently from the same bytes therefore do *not*
+/// have identical content.  A replica adopts the source's metadata verbatim,
+/// so it does.
+async fn replica_of(src: &Ship, label: &str) -> (tempfile::TempDir, tempfile::TempDir, Ship) {
+    let pond_id = uuid::Uuid::parse_str(src.data_persistence().pond_id()).expect("pond id");
+    let remote_dir = tempdir().expect("remote dir");
+    let mut remote = ContentRemote::create_at(remote_dir.path().join("remote"), pond_id)
+        .await
+        .expect("create remote");
+    let _ = steward::push_content_to_remote(src, &mut remote, "main")
+        .await
+        .expect("push");
+    let graph = steward::fetch_object_graph(&remote, "main")
+        .await
+        .expect("fetch");
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), label)
+        .await
+        .expect("create replica");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("rebuild");
+    (remote_dir, dst_dir, dst)
+}
+
 /// The inventory contains the root tree plus a tree object per physical
 /// directory and a blob per file version.
 #[tokio::test]
@@ -76,16 +107,14 @@ async fn inventory_covers_trees_and_blobs() {
     assert!(blobs >= 2, "expected two file blobs, got {blobs}");
 }
 
-/// Two identical ponds produce identical inventories, so the set difference is
-/// empty in both directions (a clone needs nothing transferred).
+/// A pond and its replica produce identical inventories, so the set difference
+/// is empty in both directions (a clone needs nothing transferred).
 #[tokio::test]
-async fn identical_ponds_have_no_object_difference() {
+async fn replica_has_no_object_difference() {
     let (_ta, mut a) = new_pond("pond-a").await;
-    let (_tb, mut b) = new_pond("pond-b").await;
-    for ship in [&mut a, &mut b] {
-        write_file(ship, "/a.txt", b"same").await;
-        mkdir_and_file(ship, "/d", "/d/c.txt", b"more").await;
-    }
+    write_file(&mut a, "/a.txt", b"same").await;
+    mkdir_and_file(&mut a, "/d", "/d/c.txt", b"more").await;
+    let (_rt, _dt, b) = replica_of(&a, "pond-b").await;
 
     let inv_a = inventory_content_objects(&a).await.expect("a");
     let inv_b = inventory_content_objects(&b).await.expect("b");

--- a/crates/steward/tests/content_tree_test.rs
+++ b/crates/steward/tests/content_tree_test.rs
@@ -6,6 +6,7 @@
 //! content-tree fold that produces a pond's `root_tree_hash` from live state.
 
 use steward::Ship;
+use sync_store::ContentRemote;
 use tempfile::tempdir;
 use tinyfs::async_helpers::convenience::create_file_path;
 use tlogfs::PondUserMetadata;
@@ -37,6 +38,36 @@ async fn mkdir_and_file(ship: &mut Ship, dir: &str, file: &str, bytes: &[u8]) {
     })
     .await
     .expect("mkdir transaction");
+}
+
+/// Build a genuine replica of `src`.
+///
+/// Replication is the only way to obtain a second pond with identical content:
+/// a version's metadata -- when it was created, the event-time range it covers
+/// -- is data about that immutable version, and the directory entry commits to
+/// it.  Two ponds written independently from the same bytes therefore do *not*
+/// have identical content.  A replica adopts the source's metadata verbatim,
+/// so it does.
+async fn replica_of(src: &Ship, label: &str) -> (tempfile::TempDir, tempfile::TempDir, Ship) {
+    let pond_id = uuid::Uuid::parse_str(src.data_persistence().pond_id()).expect("pond id");
+    let remote_dir = tempdir().expect("remote dir");
+    let mut remote = ContentRemote::create_at(remote_dir.path().join("remote"), pond_id)
+        .await
+        .expect("create remote");
+    let _ = steward::push_content_to_remote(src, &mut remote, "main")
+        .await
+        .expect("push");
+    let graph = steward::fetch_object_graph(&remote, "main")
+        .await
+        .expect("fetch");
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), label)
+        .await
+        .expect("create replica");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("rebuild");
+    (remote_dir, dst_dir, dst)
 }
 
 /// The root tree hash is stable across repeated computations and changes when
@@ -74,23 +105,19 @@ async fn content_tree_root_is_deterministic_and_data_sensitive() {
     );
 }
 
-/// Two ponds built with identical content produce identical root tree hashes,
-/// independent of pond identity and lineage (Goal 2: comparison).
+/// A replica produces the same root tree hash as its source, independent of
+/// pond identity and lineage (Goal 2: comparison).
 #[tokio::test]
-async fn identical_content_yields_identical_root_across_ponds() {
+async fn replica_yields_identical_root_across_ponds() {
     let tmp_a = tempdir().expect("tempdir a");
-    let tmp_b = tempdir().expect("tempdir b");
     let mut ship_a = Ship::create_pond(tmp_a.path().join("pond"), "pond-a")
         .await
         .expect("create pond a");
-    let mut ship_b = Ship::create_pond(tmp_b.path().join("pond"), "pond-b")
-        .await
-        .expect("create pond b");
 
-    for ship in [&mut ship_a, &mut ship_b] {
-        write_file(ship, "/a.txt", b"same content").await;
-        mkdir_and_file(ship, "/d", "/d/c.txt", b"more").await;
-    }
+    write_file(&mut ship_a, "/a.txt", b"same content").await;
+    mkdir_and_file(&mut ship_a, "/d", "/d/c.txt", b"more").await;
+
+    let (_rt, _dt, ship_b) = replica_of(&ship_a, "pond-b").await;
 
     let ra = steward::compute_content_tree(&ship_a).await.expect("a");
     let rb = steward::compute_content_tree(&ship_b).await.expect("b");

--- a/crates/steward/tests/materialize_test.rs
+++ b/crates/steward/tests/materialize_test.rs
@@ -7,6 +7,7 @@
 //! Section 8.4 / Decision D7).
 
 use steward::{Ship, inventory_content_objects, materialize_content_objects};
+use sync_store::ContentRemote;
 use sync_store::content::ObjectHash;
 use tempfile::tempdir;
 use tinyfs::async_helpers::convenience::create_file_path;
@@ -47,6 +48,36 @@ async fn new_pond(label: &str) -> (tempfile::TempDir, Ship) {
         .await
         .expect("create pond");
     (tmp, ship)
+}
+
+/// Build a genuine replica of `src`.
+///
+/// Replication is the only way to obtain a second pond with identical content:
+/// a version's metadata -- when it was created, the event-time range it covers
+/// -- is data about that immutable version, and the directory entry commits to
+/// it.  Two ponds written independently from the same bytes therefore do *not*
+/// have identical content.  A replica adopts the source's metadata verbatim,
+/// so it does.
+async fn replica_of(src: &Ship, label: &str) -> (tempfile::TempDir, tempfile::TempDir, Ship) {
+    let pond_id = uuid::Uuid::parse_str(src.data_persistence().pond_id()).expect("pond id");
+    let remote_dir = tempdir().expect("remote dir");
+    let mut remote = ContentRemote::create_at(remote_dir.path().join("remote"), pond_id)
+        .await
+        .expect("create remote");
+    let _ = steward::push_content_to_remote(src, &mut remote, "main")
+        .await
+        .expect("push");
+    let graph = steward::fetch_object_graph(&remote, "main")
+        .await
+        .expect("fetch");
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), label)
+        .await
+        .expect("create replica");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("rebuild");
+    (remote_dir, dst_dir, dst)
 }
 
 /// The content-addressing invariant: every inline object's bytes hash to its
@@ -103,16 +134,14 @@ async fn materialized_hashes_match_inventory() {
     );
 }
 
-/// Two ponds with identical content materialize identical object maps -- the
-/// property that lets one clone the other by transferring only missing hashes.
+/// A pond and its replica materialize identical object maps -- the property
+/// that lets one clone the other by transferring only missing hashes.
 #[tokio::test]
-async fn identical_ponds_materialize_identical_objects() {
+async fn replica_materializes_identical_objects() {
     let (_ta, mut a) = new_pond("pond-a").await;
-    let (_tb, mut b) = new_pond("pond-b").await;
-    for ship in [&mut a, &mut b] {
-        write_file(ship, "/a.txt", b"same").await;
-        mkdir_and_file(ship, "/d", "/d/c.txt", b"more").await;
-    }
+    write_file(&mut a, "/a.txt", b"same").await;
+    mkdir_and_file(&mut a, "/d", "/d/c.txt", b"more").await;
+    let (_rt, _dt, b) = replica_of(&a, "pond-b").await;
 
     let ma = materialize_content_objects(&a).await.expect("a");
     let mb = materialize_content_objects(&b).await.expect("b");

--- a/crates/sync-store/src/content/manifest.rs
+++ b/crates/sync-store/src/content/manifest.rs
@@ -20,16 +20,17 @@
 
 use tinyfs::EntryType;
 
-use super::{Cursor, ObjectHash, push_len_prefixed};
+use super::tree::{push_version_metas, take_version_metas};
+use super::{Cursor, ObjectHash, VersionMeta, push_len_prefixed};
 
 /// Magic header distinguishing a serialized node manifest from a raw blob (D2).
-const MANIFEST_MAGIC: &[u8] = b"dp.manifest.1\n";
+const MANIFEST_MAGIC: &[u8] = b"dp.manifest.2\n";
 
 /// Minimum on-wire size of a single manifest entry: three length-prefixed
 /// strings (4-byte length each, all empty), a 1-byte entry-type discriminant,
 /// and a 32-byte child hash. Used to bound decode pre-allocation against a
 /// hostile element count.
-const MANIFEST_ENTRY_MIN_BYTES: usize = 4 + 4 + 4 + 1 + 32;
+const MANIFEST_ENTRY_MIN_BYTES: usize = 4 + 4 + 4 + 1 + 32 + 4;
 
 /// One node's identity record in a manifest.
 ///
@@ -50,6 +51,10 @@ pub struct ManifestEntry {
     /// The node's content address (the same `child_hash` its tree entry
     /// carries; for the root, its `tree_hash`).
     pub child_hash: ObjectHash,
+    /// Node metadata for this node's live versions, oldest first -- the same
+    /// list its tree entry carries, mirrored here so an incremental pull can
+    /// diff and reapply it from the `node_id`-keyed manifest alone.
+    pub versions: Vec<VersionMeta>,
 }
 
 impl ManifestEntry {
@@ -61,6 +66,7 @@ impl ManifestEntry {
         name: impl Into<String>,
         entry_type: EntryType,
         child_hash: ObjectHash,
+        versions: Vec<VersionMeta>,
     ) -> Self {
         Self {
             node_id: node_id.into(),
@@ -68,7 +74,27 @@ impl ManifestEntry {
             name: name.into(),
             entry_type,
             child_hash,
+            versions,
         }
+    }
+
+    /// Construct a manifest entry whose node metadata is unknown.
+    #[must_use]
+    pub fn bare(
+        node_id: impl Into<String>,
+        parent_node_id: impl Into<String>,
+        name: impl Into<String>,
+        entry_type: EntryType,
+        child_hash: ObjectHash,
+    ) -> Self {
+        Self::new(
+            node_id,
+            parent_node_id,
+            name,
+            entry_type,
+            child_hash,
+            Vec::new(),
+        )
     }
 }
 
@@ -85,6 +111,7 @@ impl ManifestEntry {
 ///   u32 LE  name length + name bytes (UTF-8)
 ///   u8      entry_type discriminant
 ///   32      child_hash bytes
+///   u32 LE  version count, then that many VersionMeta records
 /// ```
 ///
 /// Entries are sorted by `node_id` so the encoding is canonical regardless of
@@ -118,6 +145,7 @@ pub fn encode_manifest(entries: &[ManifestEntry]) -> Result<Vec<u8>, String> {
         push_len_prefixed(&mut buf, entry.name.as_bytes());
         buf.push(entry.entry_type as u8);
         buf.extend_from_slice(entry.child_hash.as_bytes());
+        push_version_metas(&mut buf, &entry.versions);
     }
     Ok(buf)
 }
@@ -153,12 +181,14 @@ pub fn decode_manifest(bytes: &[u8]) -> Result<Vec<ManifestEntry>, String> {
         let name = cur.take_len_prefixed_string()?;
         let entry_type = EntryType::try_from(cur.take_u8()?)?;
         let child_hash = cur.take_hash()?;
+        let versions = take_version_metas(&mut cur)?;
         entries.push(ManifestEntry::new(
             node_id,
             parent_node_id,
             name,
             entry_type,
             child_hash,
+            versions,
         ));
     }
     if !cur.is_empty() {
@@ -179,7 +209,7 @@ mod tests {
     }
 
     fn file(node_id: &str, parent: &str, name: &str) -> ManifestEntry {
-        ManifestEntry::new(
+        ManifestEntry::bare(
             node_id,
             parent,
             name,
@@ -198,7 +228,7 @@ mod tests {
     #[test]
     fn manifest_hash_changes_with_child_hash() {
         let base = vec![file("n1", "root", "a")];
-        let changed = vec![ManifestEntry::new(
+        let changed = vec![ManifestEntry::bare(
             "n1",
             "root",
             "a",
@@ -216,7 +246,7 @@ mod tests {
         // Same node_id and content, different name -- a rename must change the
         // manifest hash so the consumer detects it.
         let before = vec![file("n1", "root", "old")];
-        let after = vec![ManifestEntry::new(
+        let after = vec![ManifestEntry::bare(
             "n1",
             "root",
             "new",
@@ -248,13 +278,13 @@ mod tests {
     #[test]
     fn decode_round_trips_encode() {
         let entries = vec![
-            ManifestEntry::new("root", "", "", EntryType::DirectoryPhysical, h("roottree")),
+            ManifestEntry::bare("root", "", "", EntryType::DirectoryPhysical, h("roottree")),
             file("n2", "root", "b"),
             file("n1", "root", "a"),
-            ManifestEntry::new("n3", "root", "d", EntryType::DirectoryPhysical, h("dir")),
-            ManifestEntry::new("n4", "root", "s", EntryType::Symlink, h("target")),
-            ManifestEntry::new("n5", "n3", "v", EntryType::TablePhysicalSeries, h("ser")),
-            ManifestEntry::new("n6", "n3", "dyn", EntryType::TableDynamic, h("recipe")),
+            ManifestEntry::bare("n3", "root", "d", EntryType::DirectoryPhysical, h("dir")),
+            ManifestEntry::bare("n4", "root", "s", EntryType::Symlink, h("target")),
+            ManifestEntry::bare("n5", "n3", "v", EntryType::TablePhysicalSeries, h("ser")),
+            ManifestEntry::bare("n6", "n3", "dyn", EntryType::TableDynamic, h("recipe")),
         ];
         let bytes = encode_manifest(&entries).unwrap();
         let decoded = decode_manifest(&bytes).unwrap();
@@ -273,7 +303,7 @@ mod tests {
 
     #[test]
     fn root_entry_has_empty_parent_and_name() {
-        let entries = vec![ManifestEntry::new(
+        let entries = vec![ManifestEntry::bare(
             "root",
             "",
             "",
@@ -326,14 +356,14 @@ mod tests {
     fn length_prefix_prevents_field_ambiguity() {
         // Moving a character across the node_id/parent boundary must change the
         // hash, proving the framing is unambiguous.
-        let a = vec![ManifestEntry::new(
+        let a = vec![ManifestEntry::bare(
             "ab",
             "c",
             "n",
             EntryType::FilePhysicalVersion,
             h("x"),
         )];
-        let b = vec![ManifestEntry::new(
+        let b = vec![ManifestEntry::bare(
             "a",
             "bc",
             "n",

--- a/crates/sync-store/src/content/mod.rs
+++ b/crates/sync-store/src/content/mod.rs
@@ -10,9 +10,22 @@
 //! - **blob** -- the exact stored bytes of one file version.  A blob's
 //!   identity is simply `blake3(bytes)`; there is no dedicated type because a
 //!   blob *is* its bytes.  Use [`ObjectHash::of_bytes`].
-//! - **tree** -- a directory as its sorted entries (see [`tree`]).
+//! - **tree** -- a directory as its sorted entries, each carrying the node
+//!   metadata that directory records for its child (see [`tree`]).
 //! - **commit** -- one transaction, the only object carrying lineage (see
 //!   [`commit`]).
+//!
+//! # Metadata is content
+//!
+//! A version's metadata -- when it was created, the event-time range it
+//! covers, its extended attributes -- is data about an immutable version, not
+//! an annotation on the side, so a tree entry commits to it along with the
+//! child's hash (see [`VersionMeta`]).  Two consequences follow.  A replica,
+//! which adopts the source's metadata verbatim, has an identical root tree
+//! hash; but two ponds written independently from the same bytes do *not*,
+//! because their versions were created at different times.  Blobs stay purely
+//! byte-addressed, so identical bytes are still stored and transferred once no
+//! matter how many entries describe them.
 //!
 //! # The store invariant
 //!
@@ -40,8 +53,8 @@ pub use commit::{Commit, Provenance};
 pub use manifest::{ManifestEntry, decode_manifest, encode_manifest, manifest_hash};
 pub use node_merkle::{NodeMerkle, rebuild_root as node_merkle_rebuild_root};
 pub use tree::{
-    TreeEntry, decode_recipe, decode_series, decode_tree, encode_recipe, encode_series,
-    encode_tree, recipe_hash, series_hash, tree_hash,
+    TreeEntry, VersionMeta, decode_recipe, decode_series, decode_tree, encode_recipe,
+    encode_series, encode_tree, recipe_hash, series_hash, tree_hash,
 };
 
 use std::fmt;

--- a/crates/sync-store/src/content/node_merkle.rs
+++ b/crates/sync-store/src/content/node_merkle.rs
@@ -260,14 +260,21 @@ fn flip_bit(key: &mut [u8; 32], depth: usize) {
 /// the key, not part of the value.
 ///
 /// `blake3(entry_type || len-prefixed name || len-prefixed parent_node_id ||
-/// child_hash)`; the length prefixes keep the `name`/`parent` boundary
-/// unambiguous, mirroring [`super::encode_manifest`].
+/// child_hash || version metadata)`; the length prefixes keep the
+/// `name`/`parent` boundary unambiguous, mirroring [`super::encode_manifest`].
+///
+/// The per-version metadata is part of the value because a metadata-only change
+/// leaves `child_hash` untouched: the node's content is the same bytes, only
+/// what is known *about* those bytes changed. Omitting it would make such a
+/// change invisible to the node-keyed diff, so a replica holding stale metadata
+/// would never be told to repair it.
 fn entry_value(entry: &ManifestEntry) -> [u8; 32] {
     let mut buf = Vec::with_capacity(1 + 8 + entry.name.len() + entry.parent_node_id.len() + 32);
     buf.push(entry.entry_type as u8);
     push_len_prefixed(&mut buf, entry.name.as_bytes());
     push_len_prefixed(&mut buf, entry.parent_node_id.as_bytes());
     buf.extend_from_slice(entry.child_hash.as_bytes());
+    super::tree::push_version_metas(&mut buf, &entry.versions);
     *blake3::hash(&buf).as_bytes()
 }
 
@@ -327,7 +334,7 @@ mod tests {
     }
 
     fn entry(node_id: &str, parent: &str, name: &str, child: &str) -> ManifestEntry {
-        ManifestEntry::new(
+        ManifestEntry::bare(
             node_id,
             parent,
             name,

--- a/crates/sync-store/src/content/tree.rs
+++ b/crates/sync-store/src/content/tree.rs
@@ -31,7 +31,11 @@ use tinyfs::EntryType;
 use super::{Cursor, ObjectHash, push_len_prefixed};
 
 /// Magic header distinguishing a serialized tree from a raw blob (D2).
-const TREE_MAGIC: &[u8] = b"dp.tree.1\n";
+///
+/// Version 2 adds per-version [`VersionMeta`] to each entry: a directory now
+/// records what it knows about its children, mirroring a real filesystem where
+/// the node's metadata lives beside the name that refers to it.
+const TREE_MAGIC: &[u8] = b"dp.tree.2\n";
 
 /// Magic header for the cumulative series hash (D2).
 const SERIES_MAGIC: &[u8] = b"dp.series.1\n";
@@ -40,19 +44,97 @@ const SERIES_MAGIC: &[u8] = b"dp.series.1\n";
 const RECIPE_MAGIC: &[u8] = b"dp.recipe.1\n";
 
 /// Minimum on-wire size of a single tree entry: a length-prefixed name (4-byte
-/// length + 0 bytes for an empty name), a 1-byte entry-type discriminant, and a
-/// 32-byte child hash. Used to bound decode pre-allocation against a hostile
-/// element count.
-const TREE_ENTRY_MIN_BYTES: usize = 4 + 1 + 32;
+/// length + 0 bytes for an empty name), a 1-byte entry-type discriminant, a
+/// 32-byte child hash, and a 4-byte version count (zero versions). Used to
+/// bound decode pre-allocation against a hostile element count.
+const TREE_ENTRY_MIN_BYTES: usize = 4 + 1 + 32 + 4;
+
+/// Minimum on-wire size of one version's metadata: the presence-flag byte
+/// alone, with every field absent.
+const VERSION_META_MIN_BYTES: usize = 1;
 
 /// Size of an [`ObjectHash`] on the wire (a series version hash).
 const HASH_BYTES: usize = 32;
 
-/// One entry in a tree: a named child with its type and content address.
+/// Presence bit for [`VersionMeta::min_event_time`].
+const META_HAS_MIN: u8 = 0b0000_0001;
+/// Presence bit for [`VersionMeta::max_event_time`].
+const META_HAS_MAX: u8 = 0b0000_0010;
+/// Presence bit for [`VersionMeta::extended_attributes`].
+const META_HAS_ATTRS: u8 = 0b0000_0100;
+/// Presence bit for [`VersionMeta::timestamp`].
+const META_HAS_MTIME: u8 = 0b0000_1000;
+
+/// Every defined [`VersionMeta`] presence bit; any other bit set on the wire is
+/// from a newer encoding this build cannot faithfully round-trip.
+const META_KNOWN_FLAGS: u8 = META_HAS_MIN | META_HAS_MAX | META_HAS_ATTRS | META_HAS_MTIME;
+
+/// Per-version node metadata a directory records about one of its children.
 ///
-/// The triple `(name, entry_type, child_hash)` is the entire value an entry
-/// contributes to its parent's hash -- no node identity, no partition, no
-/// timestamp.
+/// The content-addressed model reduces a node to a `child_hash`, on the
+/// implicit assumption that everything else about it is either structural
+/// (name, type, parent) or a pure function of its bytes (blake3, size, a
+/// parquet footer's min/max). Real node metadata is neither: an mtime is a fact
+/// about *when the node was written*, and a raw JSON-lines blob's event-time
+/// range depends on the ingest configuration of the pond that created it --
+/// which key holds the event time, in which unit. A replica receiving only
+/// bytes cannot recover either, so both must travel as state.
+///
+/// Historically they did: before the content-addressed rewrite, replication
+/// shipped whole `OplogEntry` rows and these columns rode along for free. This
+/// struct is exactly that row's replicable metadata, restored to the wire --
+/// which is also why it lives on the *directory entry* rather than inside the
+/// node's own content object. A filesystem's directory holds names that refer
+/// to nodes, and the metadata belongs beside the name; keeping it out of the
+/// blob and series objects leaves those purely content-addressed, so identical
+/// bytes still dedup no matter what metadata describes them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VersionMeta {
+    /// When this version was written, in microseconds since the Unix epoch
+    /// (the node's mtime). A replica adopts the source's value rather than
+    /// minting its own, exactly as `rsync -t` or `cp -p` preserve mtime.
+    pub timestamp: Option<i64>,
+    /// Smallest event time observed in this version's data, in microseconds.
+    pub min_event_time: Option<i64>,
+    /// Largest event time observed in this version's data, in microseconds.
+    pub max_event_time: Option<i64>,
+    /// The version's extended attributes as their stored JSON object (it
+    /// carries, among other things, the series' timestamp column name).
+    ///
+    /// Producers must serialize this canonically -- the stored form comes from
+    /// a `HashMap`, whose key order is nondeterministic, and this string is
+    /// hashed. Two ponds that emitted different key orders for equal attributes
+    /// would never converge.
+    pub extended_attributes: Option<String>,
+}
+
+impl VersionMeta {
+    /// Whether this version knows a complete event-time range.
+    #[must_use]
+    pub fn bounds(&self) -> Option<(i64, i64)> {
+        self.min_event_time.zip(self.max_event_time)
+    }
+
+    /// Whether nothing at all is known about this version.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.timestamp.is_none()
+            && self.min_event_time.is_none()
+            && self.max_event_time.is_none()
+            && self.extended_attributes.is_none()
+    }
+}
+
+/// One entry in a tree: a named child with its type, content address, and the
+/// node metadata this directory records for it.
+///
+/// `(name, entry_type, child_hash)` is the child's structural and content
+/// identity; `versions` is what the directory knows about the node that name
+/// refers to -- one [`VersionMeta`] per live version, oldest first. A
+/// single-version file has one, a series has one per version, a directory has
+/// none. Because it is part of the entry, a metadata-only change moves this
+/// directory's `tree_hash` and every ancestor hash, so replication notices and
+/// repairs it without any node's own content object changing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TreeEntry {
     /// The child's name within this directory.
@@ -62,18 +144,128 @@ pub struct TreeEntry {
     /// The child's content address (see the module table for how it is
     /// derived per node kind).
     pub child_hash: ObjectHash,
+    /// Node metadata for the child's live versions, oldest first.
+    pub versions: Vec<VersionMeta>,
 }
 
 impl TreeEntry {
-    /// Construct a tree entry.
+    /// Construct a tree entry carrying node metadata for its child's versions.
     #[must_use]
-    pub fn new(name: impl Into<String>, entry_type: EntryType, child_hash: ObjectHash) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        entry_type: EntryType,
+        child_hash: ObjectHash,
+        versions: Vec<VersionMeta>,
+    ) -> Self {
         Self {
             name: name.into(),
             entry_type,
             child_hash,
+            versions,
         }
     }
+
+    /// Construct a tree entry whose child metadata is unknown.
+    #[must_use]
+    pub fn bare(name: impl Into<String>, entry_type: EntryType, child_hash: ObjectHash) -> Self {
+        Self::new(name, entry_type, child_hash, Vec::new())
+    }
+}
+
+/// Serialize one version's metadata: a presence-flag byte then only the fields
+/// that are present.
+pub(crate) fn push_version_meta(buf: &mut Vec<u8>, meta: &VersionMeta) {
+    let mut flags = 0u8;
+    if meta.min_event_time.is_some() {
+        flags |= META_HAS_MIN;
+    }
+    if meta.max_event_time.is_some() {
+        flags |= META_HAS_MAX;
+    }
+    if meta.extended_attributes.is_some() {
+        flags |= META_HAS_ATTRS;
+    }
+    if meta.timestamp.is_some() {
+        flags |= META_HAS_MTIME;
+    }
+    buf.push(flags);
+    if let Some(min) = meta.min_event_time {
+        buf.extend_from_slice(&min.to_le_bytes());
+    }
+    if let Some(max) = meta.max_event_time {
+        buf.extend_from_slice(&max.to_le_bytes());
+    }
+    if let Some(attrs) = &meta.extended_attributes {
+        push_len_prefixed(buf, attrs.as_bytes());
+    }
+    if let Some(mtime) = meta.timestamp {
+        buf.extend_from_slice(&mtime.to_le_bytes());
+    }
+}
+
+/// Serialize a whole per-version metadata list: a count then each entry.
+pub(crate) fn push_version_metas(buf: &mut Vec<u8>, versions: &[VersionMeta]) {
+    let count = u32::try_from(versions.len()).expect("version count exceeds u32::MAX");
+    buf.extend_from_slice(&count.to_le_bytes());
+    for meta in versions {
+        push_version_meta(buf, meta);
+    }
+}
+
+/// Deserialize one version's metadata (the inverse of [`push_version_meta`]).
+///
+/// # Errors
+///
+/// Returns an error if the buffer is truncated or a presence flag outside
+/// [`META_KNOWN_FLAGS`] is set -- an unknown field cannot be skipped, because
+/// its width is unknown, and silently dropping node state is what this encoding
+/// exists to prevent.
+pub(crate) fn take_version_meta(cur: &mut Cursor<'_>) -> Result<VersionMeta, String> {
+    let flags = cur.take_u8()?;
+    if flags & !META_KNOWN_FLAGS != 0 {
+        return Err(format!("unknown version metadata flags: {flags:#04x}"));
+    }
+    let min_event_time = if flags & META_HAS_MIN != 0 {
+        Some(cur.take_i64()?)
+    } else {
+        None
+    };
+    let max_event_time = if flags & META_HAS_MAX != 0 {
+        Some(cur.take_i64()?)
+    } else {
+        None
+    };
+    let extended_attributes = if flags & META_HAS_ATTRS != 0 {
+        Some(cur.take_len_prefixed_string()?)
+    } else {
+        None
+    };
+    let timestamp = if flags & META_HAS_MTIME != 0 {
+        Some(cur.take_i64()?)
+    } else {
+        None
+    };
+    Ok(VersionMeta {
+        timestamp,
+        min_event_time,
+        max_event_time,
+        extended_attributes,
+    })
+}
+
+/// Deserialize a per-version metadata list (the inverse of
+/// [`push_version_metas`]).
+///
+/// # Errors
+///
+/// Propagates truncation and unknown-flag errors from [`take_version_meta`].
+pub(crate) fn take_version_metas(cur: &mut Cursor<'_>) -> Result<Vec<VersionMeta>, String> {
+    let count = cur.take_u32()? as usize;
+    let mut versions = Vec::with_capacity(cur.bounded_capacity(count, VERSION_META_MIN_BYTES));
+    for _ in 0..count {
+        versions.push(take_version_meta(cur)?);
+    }
+    Ok(versions)
 }
 
 /// Serialize a directory's entries into the canonical tree wire format.
@@ -88,6 +280,13 @@ impl TreeEntry {
 ///   name bytes (UTF-8)
 ///   u8      entry_type discriminant
 ///   32      child_hash bytes
+///   u32 LE  version count
+///   repeated, one per live version, oldest first:
+///     u8    VersionMeta presence flags
+///     i64 LE  min_event_time, if present
+///     i64 LE  max_event_time, if present
+///     u32 LE length + UTF-8 extended_attributes, if present
+///     i64 LE  timestamp (mtime), if present
 /// ```
 ///
 /// The returned bytes *are* the tree object; its [`tree_hash`] is
@@ -116,6 +315,7 @@ pub fn encode_tree(entries: &[TreeEntry]) -> Result<Vec<u8>, String> {
         push_len_prefixed(&mut buf, entry.name.as_bytes());
         buf.push(entry.entry_type as u8);
         buf.extend_from_slice(entry.child_hash.as_bytes());
+        push_version_metas(&mut buf, &entry.versions);
     }
     Ok(buf)
 }
@@ -145,12 +345,17 @@ pub fn tree_hash(entries: &[TreeEntry]) -> Result<ObjectHash, String> {
 /// repeated: 32 bytes per version blob hash, in order
 /// ```
 ///
+/// The series object is deliberately *pure content*: the per-version metadata
+/// a replica needs travels on the directory entry that names this series (see
+/// [`VersionMeta`]), not here, so two ponds holding identical bytes share this
+/// hash regardless of what metadata describes them.
+///
 /// The returned bytes *are* the series object; its [`series_hash`] is
 /// `blake3` of these bytes.  This is the simple-start encoding of the "stable
 /// bao root over all versions" the design calls for (D2, not frozen).
 #[must_use]
 pub fn encode_series(version_hashes: &[ObjectHash]) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(SERIES_MAGIC.len() + 4 + version_hashes.len() * 32);
+    let mut buf = Vec::with_capacity(SERIES_MAGIC.len() + 4 + version_hashes.len() * HASH_BYTES);
     buf.extend_from_slice(SERIES_MAGIC);
     let count = u32::try_from(version_hashes.len()).expect("version count exceeds u32::MAX");
     buf.extend_from_slice(&count.to_le_bytes());
@@ -187,7 +392,8 @@ pub fn decode_tree(bytes: &[u8]) -> Result<Vec<TreeEntry>, String> {
         let name = cur.take_len_prefixed_string()?;
         let entry_type = EntryType::try_from(cur.take_u8()?)?;
         let child_hash = cur.take_hash()?;
-        entries.push(TreeEntry::new(name, entry_type, child_hash));
+        let versions = take_version_metas(&mut cur)?;
+        entries.push(TreeEntry::new(name, entry_type, child_hash, versions));
     }
     if !cur.is_empty() {
         return Err(format!("{} trailing byte(s) after tree", cur.remaining()));
@@ -273,7 +479,7 @@ mod tests {
     }
 
     fn file(name: &str, content: &str) -> TreeEntry {
-        TreeEntry::new(name, EntryType::FilePhysicalVersion, h(content))
+        TreeEntry::bare(name, EntryType::FilePhysicalVersion, h(content))
     }
 
     #[test]
@@ -294,7 +500,7 @@ mod tests {
     #[test]
     fn tree_hash_changes_with_entry_type() {
         let as_file = vec![file("a", "1")];
-        let as_dir = vec![TreeEntry::new("a", EntryType::DirectoryPhysical, h("1"))];
+        let as_dir = vec![TreeEntry::bare("a", EntryType::DirectoryPhysical, h("1"))];
         assert_ne!(tree_hash(&as_file).unwrap(), tree_hash(&as_dir).unwrap());
     }
 
@@ -306,12 +512,12 @@ mod tests {
         let right = tree_hash(&[file("x", "right-data")]).unwrap();
 
         let normal = vec![
-            TreeEntry::new("dirA", EntryType::DirectoryPhysical, left),
-            TreeEntry::new("dirB", EntryType::DirectoryPhysical, right),
+            TreeEntry::bare("dirA", EntryType::DirectoryPhysical, left),
+            TreeEntry::bare("dirB", EntryType::DirectoryPhysical, right),
         ];
         let swapped = vec![
-            TreeEntry::new("dirA", EntryType::DirectoryPhysical, right),
-            TreeEntry::new("dirB", EntryType::DirectoryPhysical, left),
+            TreeEntry::bare("dirA", EntryType::DirectoryPhysical, right),
+            TreeEntry::bare("dirB", EntryType::DirectoryPhysical, left),
         ];
         assert_ne!(tree_hash(&normal).unwrap(), tree_hash(&swapped).unwrap());
     }
@@ -354,8 +560,8 @@ mod tests {
         let entries = vec![
             file("b", "2"),
             file("a", "1"),
-            TreeEntry::new("d", EntryType::DirectoryPhysical, h("dir")),
-            TreeEntry::new("c", EntryType::Symlink, h("target")),
+            TreeEntry::bare("d", EntryType::DirectoryPhysical, h("dir")),
+            TreeEntry::bare("c", EntryType::Symlink, h("target")),
         ];
         let bytes = encode_tree(&entries).unwrap();
         let decoded = decode_tree(&bytes).unwrap();
@@ -465,5 +671,98 @@ mod tests {
     #[test]
     fn decode_recipe_rejects_bad_magic() {
         assert!(decode_recipe(b"not a recipe").is_err());
+    }
+
+    fn full_meta() -> VersionMeta {
+        VersionMeta {
+            timestamp: Some(1_700_000_000_000_000),
+            min_event_time: Some(-42),
+            max_event_time: Some(i64::MAX),
+            extended_attributes: Some(r#"{"watertown.timestamp_column":"Timestamp"}"#.to_string()),
+        }
+    }
+
+    #[test]
+    fn version_meta_round_trips_every_combination() {
+        let full = full_meta();
+        // Every subset of the presence flags must survive a round trip, so a
+        // partially-known node keeps exactly what it knew and nothing more.
+        for mask in 0u8..16 {
+            let meta = VersionMeta {
+                timestamp: (mask & 1 != 0).then_some(full.timestamp.unwrap()),
+                min_event_time: (mask & 2 != 0).then_some(full.min_event_time.unwrap()),
+                max_event_time: (mask & 4 != 0).then_some(full.max_event_time.unwrap()),
+                extended_attributes: (mask & 8 != 0)
+                    .then(|| full.extended_attributes.clone().unwrap()),
+            };
+            let mut buf = Vec::new();
+            push_version_meta(&mut buf, &meta);
+            let mut cur = Cursor::new(&buf);
+            assert_eq!(take_version_meta(&mut cur).unwrap(), meta, "mask {mask}");
+        }
+    }
+
+    #[test]
+    fn empty_version_meta_costs_one_byte() {
+        let mut buf = Vec::new();
+        push_version_meta(&mut buf, &VersionMeta::default());
+        assert_eq!(buf.len(), VERSION_META_MIN_BYTES);
+        assert!(VersionMeta::default().is_empty());
+        assert!(!full_meta().is_empty());
+    }
+
+    #[test]
+    fn take_version_meta_rejects_unknown_flags() {
+        // A newer encoding's field cannot be skipped -- its width is unknown --
+        // and silently dropping node state is the failure this encoding exists
+        // to prevent, so decoding must fail loudly.
+        let buf = vec![META_KNOWN_FLAGS | 0b1000_0000];
+        let mut cur = Cursor::new(&buf);
+        let err = take_version_meta(&mut cur).unwrap_err();
+        assert!(err.contains("unknown version metadata flags"), "{err}");
+    }
+
+    #[test]
+    fn tree_round_trips_version_metadata() {
+        let entries = vec![
+            TreeEntry::new(
+                "series",
+                EntryType::FilePhysicalSeries,
+                h("ser"),
+                vec![full_meta(), VersionMeta::default()],
+            ),
+            TreeEntry::bare("dir", EntryType::DirectoryPhysical, h("dir")),
+        ];
+        let decoded = decode_tree(&encode_tree(&entries).unwrap()).unwrap();
+        let mut expected = entries.clone();
+        expected.sort_by(|a, b| a.name.as_bytes().cmp(b.name.as_bytes()));
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn tree_hash_changes_with_version_metadata_alone() {
+        // The whole point: metadata drift must move the hash even though the
+        // child_hash is untouched, or replication can never notice or repair it.
+        let bare = vec![TreeEntry::bare("a", EntryType::FilePhysicalVersion, h("1"))];
+        let with_meta = vec![TreeEntry::new(
+            "a",
+            EntryType::FilePhysicalVersion,
+            h("1"),
+            vec![full_meta()],
+        )];
+        assert_ne!(tree_hash(&bare).unwrap(), tree_hash(&with_meta).unwrap());
+
+        let mut other = full_meta();
+        other.timestamp = Some(full_meta().timestamp.unwrap() + 1);
+        let mtime_only = vec![TreeEntry::new(
+            "a",
+            EntryType::FilePhysicalVersion,
+            h("1"),
+            vec![other],
+        )];
+        assert_ne!(
+            tree_hash(&with_meta).unwrap(),
+            tree_hash(&mtime_only).unwrap()
+        );
     }
 }

--- a/crates/sync-store/src/content_remote.rs
+++ b/crates/sync-store/src/content_remote.rs
@@ -52,7 +52,10 @@ const POND_ID_KEY: &str = "pond_id";
 /// All rows are written under the source pond's `pond_id`, matching the
 /// store's per-`pond_id` physical partitioning.  Object hashes are
 /// content-only and lineage-independent, so two ponds with identical content
-/// produce identical object bytes under identical keys.
+/// produce identical object bytes under identical keys.  A node's content
+/// includes the metadata its directory entry commits to, so a pond and its
+/// replica share keys while two independently written ponds share only their
+/// blobs.
 pub struct ContentRemote {
     store: Store,
     pond_id: Uuid,

--- a/crates/sync-store/src/lib.rs
+++ b/crates/sync-store/src/lib.rs
@@ -35,8 +35,8 @@ pub mod tlog;
 pub use s3_registration::register_s3_handlers;
 
 pub use content::{
-    Commit, ManifestEntry, NodeMerkle, ObjectHash, Provenance, TreeEntry, decode_series,
-    decode_tree, node_merkle_rebuild_root, series_hash, tree_hash,
+    Commit, ManifestEntry, NodeMerkle, ObjectHash, Provenance, TreeEntry, VersionMeta,
+    decode_series, decode_tree, node_merkle_rebuild_root, series_hash, tree_hash,
 };
 pub use content_remote::ContentRemote;
 pub use error::{Result, StoreError};

--- a/crates/tinyfs/src/caching_persistence.rs
+++ b/crates/tinyfs/src/caching_persistence.rs
@@ -176,13 +176,18 @@ impl<P: PersistenceLayer + Send + Sync + 'static> PersistenceLayer for CachingPe
     }
 
     /// Create symlink node with caching
-    async fn create_symlink_node(&self, id: FileID, target: &Path) -> Result<Node> {
+    async fn create_symlink_node(
+        &self,
+        id: FileID,
+        target: &Path,
+        mtime: Option<i64>,
+    ) -> Result<Node> {
         debug!(
             "CachingPersistence: create_symlink_node({}, {:?})",
             id, target
         );
 
-        let node = self.inner.create_symlink_node(id, target).await?;
+        let node = self.inner.create_symlink_node(id, target, mtime).await?;
 
         // Cache the created node
         self.cache_node(id, node.clone()).await;
@@ -196,6 +201,7 @@ impl<P: PersistenceLayer + Send + Sync + 'static> PersistenceLayer for CachingPe
         id: FileID,
         factory_type: &str,
         config_content: Vec<u8>,
+        mtime: Option<i64>,
     ) -> Result<Node> {
         debug!(
             "CachingPersistence: create_dynamic_node({}, factory={})",
@@ -204,7 +210,7 @@ impl<P: PersistenceLayer + Send + Sync + 'static> PersistenceLayer for CachingPe
 
         let node = self
             .inner
-            .create_dynamic_node(id, factory_type, config_content)
+            .create_dynamic_node(id, factory_type, config_content, mtime)
             .await?;
 
         // Cache the created node

--- a/crates/tinyfs/src/file.rs
+++ b/crates/tinyfs/src/file.rs
@@ -88,6 +88,29 @@ pub trait FileMetadataWriter: AsyncWrite + Send + Unpin {
     /// Set temporal metadata for series files (used when metadata is known at write time)
     fn set_temporal_metadata(&mut self, min: i64, max: i64, timestamp_column: String);
 
+    /// Declare that this version carries event-timestamped records, making it
+    /// an error to finalize it without temporal bounds.
+    ///
+    /// `TablePhysicalSeries` gets this guarantee for free: its bounds come from
+    /// the parquet footer, so a version without them is already rejected. A
+    /// byte-oriented `FilePhysicalSeries` has no footer to consult, and the
+    /// storage layer cannot tell a timestamped log from an opaque blob -- so
+    /// the writer has to say. Ingest factories call this whenever their config
+    /// names a timestamp field, which is precisely "we know we are carrying
+    /// logs or metrics".
+    ///
+    /// Without it, a version whose timestamps could not be read is stored with
+    /// no bounds at all, which downstream `temporal-reduce` must treat as
+    /// spanning all of time -- so it drops every sealed segment and recomputes
+    /// its whole history on every build. That degradation is invisible except
+    /// as a slow, memory-hungry build, which is exactly how it went unnoticed.
+    ///
+    /// `timestamp_column` names the configured field, so the failure can say
+    /// which one it looked for.
+    ///
+    /// The default is a no-op, for backends that do not persist bounds.
+    fn require_temporal_metadata(&mut self, _timestamp_column: String) {}
+
     /// Adopt an explicit modification time (microseconds since the Unix epoch)
     /// instead of stamping the version with the current wall clock.
     ///

--- a/crates/tinyfs/src/file.rs
+++ b/crates/tinyfs/src/file.rs
@@ -88,6 +88,17 @@ pub trait FileMetadataWriter: AsyncWrite + Send + Unpin {
     /// Set temporal metadata for series files (used when metadata is known at write time)
     fn set_temporal_metadata(&mut self, min: i64, max: i64, timestamp_column: String);
 
+    /// Adopt an explicit modification time (microseconds since the Unix epoch)
+    /// instead of stamping the version with the current wall clock.
+    ///
+    /// Replication uses this so a mirrored version keeps the mtime the source
+    /// recorded, the way `rsync -t` or `cp -p` preserve it. Without it every
+    /// replicated node would claim to have been modified at pull time, and two
+    /// ponds holding identical data would never agree on their metadata.
+    ///
+    /// The default is a no-op, for backends that do not persist an mtime.
+    fn set_mtime(&mut self, _timestamp: i64) {}
+
     /// Infer temporal bounds from the written parquet file by reading only the footer.
     /// After calling this, further writes will fail. Calls shutdown() internally.
     /// Returns (min_timestamp, max_timestamp, timestamp_column_name)

--- a/crates/tinyfs/src/fs.rs
+++ b/crates/tinyfs/src/fs.rs
@@ -140,7 +140,9 @@ impl FS {
         let id = parent_id.new_child_id(EntryType::Symlink);
 
         let target_path = std::path::Path::new(target);
-        self.persistence.create_symlink_node(id, target_path).await
+        self.persistence
+            .create_symlink_node(id, target_path, None)
+            .await
     }
 
     /// List all versions of a file
@@ -160,9 +162,10 @@ impl FS {
         id: FileID,
         factory_type: &str,
         config_content: Vec<u8>,
+        mtime: Option<i64>,
     ) -> Result<Node> {
         self.persistence
-            .create_dynamic_node(id, factory_type, config_content)
+            .create_dynamic_node(id, factory_type, config_content, mtime)
             .await
     }
 

--- a/crates/tinyfs/src/hostmount/overlay_persistence.rs
+++ b/crates/tinyfs/src/hostmount/overlay_persistence.rs
@@ -96,8 +96,13 @@ impl PersistenceLayer for OverlayPersistence {
         self.inner.create_directory_node(id).await
     }
 
-    async fn create_symlink_node(&self, id: FileID, target: &Path) -> Result<Node> {
-        self.inner.create_symlink_node(id, target).await
+    async fn create_symlink_node(
+        &self,
+        id: FileID,
+        target: &Path,
+        mtime: Option<i64>,
+    ) -> Result<Node> {
+        self.inner.create_symlink_node(id, target, mtime).await
     }
 
     async fn create_dynamic_node(
@@ -105,9 +110,10 @@ impl PersistenceLayer for OverlayPersistence {
         id: FileID,
         factory_type: &str,
         config_content: Vec<u8>,
+        mtime: Option<i64>,
     ) -> Result<Node> {
         self.inner
-            .create_dynamic_node(id, factory_type, config_content)
+            .create_dynamic_node(id, factory_type, config_content, mtime)
             .await
     }
 

--- a/crates/tinyfs/src/hostmount/persistence.rs
+++ b/crates/tinyfs/src/hostmount/persistence.rs
@@ -176,7 +176,12 @@ impl PersistenceLayer for HostmountPersistence {
         }
     }
 
-    async fn create_symlink_node(&self, _id: FileID, _target: &Path) -> Result<Node> {
+    async fn create_symlink_node(
+        &self,
+        _id: FileID,
+        _target: &Path,
+        _mtime: Option<i64>,
+    ) -> Result<Node> {
         Err(Error::Other(
             "Symlinks are not supported on hostmount".to_string(),
         ))
@@ -187,6 +192,7 @@ impl PersistenceLayer for HostmountPersistence {
         _id: FileID,
         _factory_type: &str,
         _config_content: Vec<u8>,
+        _mtime: Option<i64>,
     ) -> Result<Node> {
         Err(Error::Other(
             "Dynamic nodes are not supported on hostmount".to_string(),

--- a/crates/tinyfs/src/hostmount/tests.rs
+++ b/crates/tinyfs/src/hostmount/tests.rs
@@ -86,7 +86,7 @@ async fn test_symlinks_not_supported() {
     let dir = create_test_tree();
     let persistence = HostmountPersistence::new(dir.path().to_path_buf()).unwrap();
     let result = persistence
-        .create_symlink_node(FileID::root(), std::path::Path::new("/tmp"))
+        .create_symlink_node(FileID::root(), std::path::Path::new("/tmp"), None)
         .await;
     assert!(result.is_err());
 }
@@ -96,7 +96,7 @@ async fn test_dynamic_nodes_not_supported() {
     let dir = create_test_tree();
     let persistence = HostmountPersistence::new(dir.path().to_path_buf()).unwrap();
     let result = persistence
-        .create_dynamic_node(FileID::root(), "test", vec![])
+        .create_dynamic_node(FileID::root(), "test", vec![], None)
         .await;
     assert!(result.is_err());
 }

--- a/crates/tinyfs/src/memory/persistence.rs
+++ b/crates/tinyfs/src/memory/persistence.rs
@@ -100,7 +100,12 @@ impl PersistenceLayer for MemoryPersistence {
         self.state.lock().await.create_directory_node(id).await
     }
 
-    async fn create_symlink_node(&self, id: FileID, target: &std::path::Path) -> Result<Node> {
+    async fn create_symlink_node(
+        &self,
+        id: FileID,
+        target: &std::path::Path,
+        _mtime: Option<i64>,
+    ) -> Result<Node> {
         self.state
             .lock()
             .await
@@ -113,6 +118,7 @@ impl PersistenceLayer for MemoryPersistence {
         id: FileID,
         factory_type: &str,
         config_content: Vec<u8>,
+        _mtime: Option<i64>,
     ) -> Result<Node> {
         // Store the config content as a file version
         self.state

--- a/crates/tinyfs/src/persistence.rs
+++ b/crates/tinyfs/src/persistence.rs
@@ -62,13 +62,30 @@ pub trait PersistenceLayer: Send + Sync {
         Ok(())
     }
 
-    async fn create_symlink_node(&self, id: FileID, target: &Path) -> Result<Node>;
+    /// Create a symlink node pointing at `target`.
+    ///
+    /// `mtime` sets the node's timestamp explicitly, in microseconds since the
+    /// Unix epoch; `None` means now.  Replication passes the source's value so
+    /// a mirrored node keeps the time it was originally written rather than
+    /// claiming to have been modified at pull time.
+    async fn create_symlink_node(
+        &self,
+        id: FileID,
+        target: &Path,
+        mtime: Option<i64>,
+    ) -> Result<Node>;
 
+    /// Create a dynamic node from its factory type and config.
+    ///
+    /// `mtime` behaves as in [`create_symlink_node`].
+    ///
+    /// [`create_symlink_node`]: PersistenceLayer::create_symlink_node
     async fn create_dynamic_node(
         &self,
         id: FileID,
         factory_type: &str,
         config_content: Vec<u8>,
+        mtime: Option<i64>,
     ) -> Result<Node>;
 
     async fn get_dynamic_node_config(&self, id: FileID) -> Result<Option<(String, Vec<u8>)>>; // (factory_type, config)

--- a/crates/tinyfs/src/wd.rs
+++ b/crates/tinyfs/src/wd.rs
@@ -437,11 +437,16 @@ impl WD {
     /// Adopt a symlink child under `name` with an explicit `node_id`, pointing
     /// at `target`.  `name` must be a direct child of this directory and must
     /// not already exist.
+    ///
+    /// `mtime` sets the node's timestamp explicitly (microseconds since the
+    /// Unix epoch); `None` means now.  Replication passes the source's mtime so
+    /// the mirrored node keeps it.
     pub async fn insert_symlink_with_id(
         &self,
         name: &str,
         node_id: NodeID,
         target: &str,
+        mtime: Option<i64>,
     ) -> Result<()> {
         self.check_writable()?;
         if self.dref.get(name).await?.is_some() {
@@ -451,7 +456,7 @@ impl WD {
         let node = self
             .fs
             .persistence
-            .create_symlink_node(id, Path::new(target))
+            .create_symlink_node(id, Path::new(target), mtime)
             .await?;
         self.fs.persistence.store_node(&node).await?;
         self.dref.insert(name.to_string(), node).await?;
@@ -461,12 +466,17 @@ impl WD {
     /// Adopt a dynamic child under `name` with an explicit `node_id`, from its
     /// factory type and config.  `name` must be a direct child of this
     /// directory and must not already exist.
+    ///
+    /// `mtime` behaves as in [`insert_symlink_with_id`].
+    ///
+    /// [`insert_symlink_with_id`]: WD::insert_symlink_with_id
     pub async fn insert_dynamic_with_id(
         &self,
         name: &str,
         node_id: NodeID,
         factory_type: &str,
         config_content: Vec<u8>,
+        mtime: Option<i64>,
     ) -> Result<()> {
         self.check_writable()?;
         if self.dref.get(name).await?.is_some() {
@@ -475,7 +485,7 @@ impl WD {
         let id = self.id().child_id(node_id);
         let node = self
             .fs
-            .create_dynamic_node(id, factory_type, config_content)
+            .create_dynamic_node(id, factory_type, config_content, mtime)
             .await?;
         self.dref.insert(name.to_string(), node).await?;
         Ok(())
@@ -1387,7 +1397,7 @@ impl WD {
                         let id = wd.id().new_child_id(entry_type);
                         let node = wd
                             .fs
-                            .create_dynamic_node(id, factory_type, config_content)
+                            .create_dynamic_node(id, factory_type, config_content, None)
                             .await?;
 
                         // Insert into parent directory with the given name

--- a/crates/tlogfs/src/factories/logfile_ingest.rs
+++ b/crates/tlogfs/src/factories/logfile_ingest.rs
@@ -23,6 +23,8 @@ mod tests {
             archived_pattern: "/var/log/test-*.json".to_string(),
             active_pattern: "/var/log/test.json".to_string(),
             pond_path: "logs/test".to_string(),
+            timestamp_field: None,
+            timestamp_unit: Default::default(),
         };
 
         assert!(config.validate().is_ok());
@@ -34,6 +36,8 @@ mod tests {
             archived_pattern: "/var/log/test-*.json".to_string(),
             active_pattern: "/var/log/test.json".to_string(),
             pond_path: "".to_string(),
+            timestamp_field: None,
+            timestamp_unit: Default::default(),
         };
 
         assert!(config.validate().is_err());
@@ -343,6 +347,8 @@ mod integration_tests {
             active_pattern: logfile.path().to_string_lossy().to_string(),
             archived_pattern: "".to_string(), // No archived files for this test
             pond_path: "logs/test_app".to_string(),
+            timestamp_field: None,
+            timestamp_unit: Default::default(),
         };
 
         // Create pond with the config (creates real config file with FileID)
@@ -480,6 +486,8 @@ mod integration_tests {
             active_pattern: logfile.path().to_string_lossy().to_string(),
             archived_pattern: "".to_string(),
             pond_path: "logs/test_app".to_string(),
+            timestamp_field: None,
+            timestamp_unit: Default::default(),
         };
 
         // Create pond with config (gets real FileID)
@@ -552,6 +560,8 @@ mod integration_tests {
             active_pattern: active_path.to_string_lossy().to_string(),
             archived_pattern: archived_pattern.clone(),
             pond_path: "logs/test_app".to_string(),
+            timestamp_field: None,
+            timestamp_unit: Default::default(),
         };
 
         // Create pond
@@ -899,6 +909,8 @@ mod integration_tests {
             active_pattern: active_path.to_string_lossy().to_string(),
             archived_pattern: archived_pattern.clone(),
             pond_path: "logs/blake3_test".to_string(),
+            timestamp_field: None,
+            timestamp_unit: Default::default(),
         };
 
         let pond = PondSimulator::new(&config).await.unwrap();
@@ -1061,6 +1073,8 @@ mod integration_tests {
             active_pattern: active_path.to_string_lossy().to_string(),
             archived_pattern: archived_pattern.clone(),
             pond_path: "logs/large_test".to_string(),
+            timestamp_field: None,
+            timestamp_unit: Default::default(),
         };
 
         let pond = PondSimulator::new(&config).await.unwrap();
@@ -1151,6 +1165,8 @@ mod integration_tests {
             active_pattern: active_path.to_string_lossy().to_string(),
             archived_pattern: "".to_string(),
             pond_path: "logs/boundary_test".to_string(),
+            timestamp_field: None,
+            timestamp_unit: Default::default(),
         };
 
         let pond = PondSimulator::new(&config).await.unwrap();
@@ -1262,6 +1278,8 @@ mod integration_tests {
                 active_pattern: active_path.to_string_lossy().to_string(),
                 archived_pattern: archived_pattern.clone(),
                 pond_path: format!("logs/{}", test_name),
+                timestamp_field: None,
+                timestamp_unit: Default::default(),
             };
 
             let pond = PondSimulator::new(&config).await?;

--- a/crates/tlogfs/src/file.rs
+++ b/crates/tlogfs/src/file.rs
@@ -330,6 +330,9 @@ pub struct OpLogFileWriter {
     completion_future: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
     entry_type: tinyfs::EntryType,
     precomputed_metadata: Option<crate::file_writer::FileMetadata>,
+    /// An explicit mtime to persist instead of the current wall clock, set by
+    /// replication so a mirrored version keeps the source's timestamp.
+    precomputed_mtime: Option<i64>,
     /// Pre-allocated version number for this write (allocated at writer creation)
     allocated_version: i64,
     /// When set, the persisted row carries a `collapsed_through` sentinel equal
@@ -360,6 +363,7 @@ impl OpLogFileWriter {
             completion_future: None,
             entry_type,
             precomputed_metadata: None,
+            precomputed_mtime: None,
             allocated_version,
             collapse_prior,
         }
@@ -374,6 +378,10 @@ impl FileMetadataWriter for OpLogFileWriter {
             max_timestamp: max,
             timestamp_column,
         });
+    }
+
+    fn set_mtime(&mut self, timestamp: i64) {
+        self.precomputed_mtime = Some(timestamp);
     }
 
     async fn infer_temporal_bounds(&mut self) -> tinyfs::Result<(i64, i64, String)> {
@@ -516,6 +524,7 @@ impl AsyncWrite for OpLogFileWriter {
             let transaction_state = this.transaction_state.clone();
             let entry_type = this.entry_type;
             let precomputed_metadata = this.precomputed_metadata.clone();
+            let precomputed_mtime = this.precomputed_mtime;
             let allocated_version = this.allocated_version;
             let collapse_prior = this.collapse_prior;
 
@@ -660,7 +669,7 @@ impl AsyncWrite for OpLogFileWriter {
                     // version as superseding every earlier one it wrote.
                     let collapsed_through = collapse_prior.then(|| allocated_version - 1);
 
-                    state.store_file_content_ref(file_id, content_ref, metadata, Some(allocated_version), bao_outboard, collapsed_through).await
+                    state.store_file_content_ref(file_id, content_ref, metadata, Some(allocated_version), bao_outboard, collapsed_through, precomputed_mtime).await
                         .map_other_context("Failed to store file")
                 }.await;
 

--- a/crates/tlogfs/src/file.rs
+++ b/crates/tlogfs/src/file.rs
@@ -333,6 +333,11 @@ pub struct OpLogFileWriter {
     /// An explicit mtime to persist instead of the current wall clock, set by
     /// replication so a mirrored version keeps the source's timestamp.
     precomputed_mtime: Option<i64>,
+    /// Names the timestamp field the caller expects to find, set by
+    /// [`FileMetadataWriter::require_temporal_metadata`]. When present,
+    /// finalizing a non-empty `FilePhysicalSeries` without temporal bounds is
+    /// an error rather than a silent downgrade to `FileMetadata::Data`.
+    required_timestamp_column: Option<String>,
     /// Pre-allocated version number for this write (allocated at writer creation)
     allocated_version: i64,
     /// When set, the persisted row carries a `collapsed_through` sentinel equal
@@ -364,6 +369,7 @@ impl OpLogFileWriter {
             entry_type,
             precomputed_metadata: None,
             precomputed_mtime: None,
+            required_timestamp_column: None,
             allocated_version,
             collapse_prior,
         }
@@ -382,6 +388,10 @@ impl FileMetadataWriter for OpLogFileWriter {
 
     fn set_mtime(&mut self, timestamp: i64) {
         self.precomputed_mtime = Some(timestamp);
+    }
+
+    fn require_temporal_metadata(&mut self, timestamp_column: String) {
+        self.required_timestamp_column = Some(timestamp_column);
     }
 
     async fn infer_temporal_bounds(&mut self) -> tinyfs::Result<(i64, i64, String)> {
@@ -525,6 +535,7 @@ impl AsyncWrite for OpLogFileWriter {
             let entry_type = this.entry_type;
             let precomputed_metadata = this.precomputed_metadata.clone();
             let precomputed_mtime = this.precomputed_mtime;
+            let required_timestamp_column = this.required_timestamp_column.clone();
             let allocated_version = this.allocated_version;
             let collapse_prior = this.collapse_prior;
 
@@ -636,6 +647,22 @@ impl AsyncWrite for OpLogFileWriter {
                             // tracking), otherwise fall through to Data.
                             if let Some(precomputed) = precomputed_metadata {
                                 precomputed
+                            } else if let Some(column) = required_timestamp_column
+                                .filter(|_| !content.is_empty() || content_len > 0)
+                            {
+                                // The caller declared this version carries
+                                // event-timestamped records, so storing it
+                                // unbounded is not a safe degradation: every
+                                // downstream temporal-reduce would treat it as
+                                // spanning all time and rebuild its whole cache.
+                                // Symmetric with TablePhysicalSeries above.
+                                return Err(tinyfs::Error::Other(format!(
+                                    "FilePhysicalSeries declared temporal via \
+                                     FileMetadataWriter::require_temporal_metadata('{column}') but \
+                                     was finalized without bounds: no usable '{column}' timestamp \
+                                     was found in {content_len} bytes. Check that the configured \
+                                     timestamp field matches the records being ingested."
+                                )));
                             } else {
                                 crate::file_writer::FileMetadata::Data
                             }

--- a/crates/tlogfs/src/file.rs
+++ b/crates/tlogfs/src/file.rs
@@ -664,6 +664,22 @@ impl AsyncWrite for OpLogFileWriter {
                                      timestamp field matches the records being ingested."
                                 )));
                             } else {
+                                // No extractor: nothing declared this series
+                                // temporal and no bounds were supplied, so the
+                                // version is stored with a null range. That is
+                                // correct for an opaque byte stream, but it is
+                                // also what a downstream temporal-reduce must
+                                // read as "spans all time", so say so rather
+                                // than letting it vanish -- an unbounded
+                                // version is otherwise visible only as a slow,
+                                // memory-hungry rollup much later.
+                                debug!(
+                                    "OpLogFileWriter::poll_shutdown() - FilePhysicalSeries {file_id} \
+                                     version {allocated_version} stored with null temporal bounds \
+                                     ({content_len} bytes): no timestamp extractor was provided. \
+                                     Callers carrying logs or metrics should declare one with \
+                                     FileMetadataWriter::require_temporal_metadata()."
+                                );
                                 crate::file_writer::FileMetadata::Data
                             }
                         }

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -104,8 +104,11 @@ pub struct InnerState {
     pending_mtimes: HashMap<FileID, i64>,
     /// Track pre-allocated version numbers for async writes in progress
     allocated_versions: HashMap<FileID, Vec<i64>>,
-    /// Transaction poisoned flag - if true, commit must fail
-    poisoned: bool,
+    /// Reason the transaction was poisoned by a failed write, if any. Commit
+    /// must fail while this is set, and it carries the originating message so
+    /// the commit error can say what actually went wrong rather than only that
+    /// something did.
+    poisoned: Option<String>,
     session_context: Arc<SessionContext>,
     txn_seq: i64,
     /// Options for large file storage (compression, etc.)
@@ -2450,7 +2453,7 @@ impl InnerState {
             pending_files: HashMap::new(),
             pending_mtimes: HashMap::new(),
             allocated_versions: HashMap::new(),
-            poisoned: false,
+            poisoned: None,
             session_context: ctx,
             txn_seq,
             large_file_options,
@@ -2794,9 +2797,9 @@ impl InnerState {
 
     /// Poison the transaction due to write failure
     async fn poison_transaction(&mut self, reason: String) {
-        if !self.poisoned {
+        if self.poisoned.is_none() {
             warn!("[TEST] TRANSACTION POISONED: {reason}");
-            self.poisoned = true;
+            self.poisoned = Some(reason);
         }
     }
 
@@ -3046,10 +3049,11 @@ impl InnerState {
         pond_id: String,
     ) -> Result<Option<deltalake::kernel::transaction::FinalizedCommit>, TLogFSError> {
         // Check if transaction is poisoned (failed write)
-        if self.poisoned {
+        if let Some(reason) = &self.poisoned {
             return Err(TLogFSError::Transaction {
-                message: "Cannot commit poisoned transaction - a write operation failed"
-                    .to_string(),
+                message: format!(
+                    "Cannot commit poisoned transaction - a write operation failed: {reason}"
+                ),
             });
         }
 

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -96,6 +96,12 @@ pub struct InnerState {
     directories: HashMap<FileID, DirectoryState>,
     /// Track files that exist in directories but haven't been written yet (pending write)
     pending_files: HashMap<FileID, EntryType>,
+    /// Explicit mtimes to adopt for nodes created but not yet persisted.
+    ///
+    /// A symlink is built in memory by `create_symlink_node` and written by a
+    /// later `store_node`, so a replicated mtime has to survive the gap; it is
+    /// consumed when the row is written.
+    pending_mtimes: HashMap<FileID, i64>,
     /// Track pre-allocated version numbers for async writes in progress
     allocated_versions: HashMap<FileID, Vec<i64>>,
     /// Transaction poisoned flag - if true, commit must fail
@@ -2041,11 +2047,16 @@ impl PersistenceLayer for State {
             .map_err(error_utils::to_tinyfs_error)
     }
 
-    async fn create_symlink_node(&self, id: FileID, target: &Path) -> TinyFSResult<Node> {
+    async fn create_symlink_node(
+        &self,
+        id: FileID,
+        target: &Path,
+        mtime: Option<i64>,
+    ) -> TinyFSResult<Node> {
         self.inner
             .lock()
             .await
-            .create_symlink_node(id, target, self.clone())
+            .create_symlink_node(id, target, self.clone(), mtime)
             .await
     }
 
@@ -2054,11 +2065,12 @@ impl PersistenceLayer for State {
         id: FileID,
         factory_type: &str,
         config_content: Vec<u8>,
+        mtime: Option<i64>,
     ) -> TinyFSResult<Node> {
         self.inner
             .lock()
             .await
-            .create_dynamic_node(id, factory_type, config_content, self.clone())
+            .create_dynamic_node(id, factory_type, config_content, self.clone(), mtime)
             .await
             .map_err(error_utils::to_tinyfs_error)
     }
@@ -2188,6 +2200,7 @@ impl State {
         pre_allocated_version: Option<i64>,
         bao_outboard: Option<Vec<u8>>,
         collapsed_through: Option<i64>,
+        mtime: Option<i64>,
     ) -> Result<(), TLogFSError> {
         self.inner
             .lock()
@@ -2199,6 +2212,7 @@ impl State {
                 pre_allocated_version,
                 bao_outboard,
                 collapsed_through,
+                mtime,
             )
             .await
     }
@@ -2434,6 +2448,7 @@ impl InnerState {
             records: Vec::new(),
             directories: HashMap::new(),
             pending_files: HashMap::new(),
+            pending_mtimes: HashMap::new(),
             allocated_versions: HashMap::new(),
             poisoned: false,
             session_context: ctx,
@@ -3273,11 +3288,14 @@ impl InnerState {
         pre_allocated_version: Option<i64>,
         bao_outboard: Option<Vec<u8>>,
         collapsed_through: Option<i64>,
+        mtime: Option<i64>,
     ) -> Result<(), TLogFSError> {
         debug!("store_file_content_ref_transactional called for node_id={id}");
 
-        // Create OplogEntry from content reference
-        let now = Utc::now().timestamp_micros();
+        // Create OplogEntry from content reference.  Replication supplies the
+        // source's mtime so a mirrored version keeps the timestamp it was
+        // originally written with; a local write stamps the wall clock.
+        let now = mtime.unwrap_or_else(|| Utc::now().timestamp_micros());
 
         // Use pre-allocated version if provided, otherwise calculate next version
         let version = if let Some(allocated) = pre_allocated_version {
@@ -3654,6 +3672,7 @@ impl InnerState {
         factory_type: &str,
         config_content: Vec<u8>,
         state: State,
+        mtime: Option<i64>,
     ) -> Result<Node, TLogFSError> {
         debug!(
             "create_dynamic_node: id={}, entry_type={:?}, factory_type='{}', txn_seq={}",
@@ -3663,7 +3682,7 @@ impl InnerState {
             self.txn_seq
         );
 
-        let now = Utc::now().timestamp_micros();
+        let now = mtime.unwrap_or_else(|| Utc::now().timestamp_micros());
         let next_version = self.get_next_version_for_node(id).await?;
 
         // Create dynamic node OplogEntry with factory field
@@ -4146,7 +4165,10 @@ impl InnerState {
             }
         };
 
-        let now = Utc::now().timestamp_micros();
+        let now = self
+            .pending_mtimes
+            .remove(&id)
+            .unwrap_or_else(|| Utc::now().timestamp_micros());
 
         let next_version = self
             .get_next_version_for_node(id)
@@ -4218,8 +4240,13 @@ impl InnerState {
         id: FileID,
         target: &Path,
         state: State,
+        mtime: Option<i64>,
     ) -> TinyFSResult<Node> {
-        // Create symlink node in memory only - store_node will persist it
+        // Create symlink node in memory only - store_node will persist it,
+        // consuming any explicit mtime recorded here.
+        if let Some(mtime) = mtime {
+            _ = self.pending_mtimes.insert(id, mtime);
+        }
         node_factory::create_symlink_node(id, target, state)
     }
 

--- a/crates/tlogfs/src/tests/mod.rs
+++ b/crates/tlogfs/src/tests/mod.rs
@@ -3882,3 +3882,87 @@ async fn test_corruption_read_pending_bytes_walks_range_order() {
     }
     tx.commit_test().await.expect("commit read");
 }
+
+/// A caller that declares a FilePhysicalSeries temporal must supply bounds.
+///
+/// This is the byte-oriented counterpart of the TablePhysicalSeries rule.
+/// A parquet series gets its bounds from the footer, so one without them is
+/// already rejected; a byte series has no footer, and the storage layer cannot
+/// tell a timestamped log from an opaque blob. Ingest factories say so
+/// explicitly whenever their config names a timestamp field, and this test
+/// pins the resulting guarantee: declaring the requirement and then failing to
+/// set bounds fails the write instead of silently storing an unbounded version
+/// that would force every downstream rollup to recompute all history.
+#[tokio::test]
+async fn declared_temporal_file_series_without_bounds_is_rejected() {
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+
+    let tx = persistence
+        .begin_test()
+        .await
+        .expect("Failed to begin transaction");
+    let wd = tx.root().await.expect("Failed to get root");
+
+    use tokio::io::AsyncWriteExt;
+    let mut writer = wd
+        .async_writer_path_with_type("logs.jsonl", tinyfs::EntryType::FilePhysicalSeries)
+        .await
+        .expect("Failed to create writer");
+    writer
+        .write_all(b"{\"msg\":\"no timestamp here\"}\n")
+        .await
+        .expect("Failed to write");
+    writer.require_temporal_metadata("timeUnixNano".to_string());
+
+    // A failed write poisons the transaction rather than surfacing at
+    // shutdown, so the rejection is observed at commit -- the same path that
+    // reports a TablePhysicalSeries written without bounds.
+    let _ = writer.shutdown().await;
+
+    let err = tx
+        .commit_test()
+        .await
+        .expect_err("commit must reject a declared-temporal series lacking bounds");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("timeUnixNano"),
+        "error should name the field that was looked for, got: {msg}"
+    );
+}
+
+/// The same write succeeds, and stays unbounded, when nothing declared it
+/// temporal -- FilePhysicalSeries remains usable for opaque byte streams.
+#[tokio::test]
+async fn undeclared_file_series_without_bounds_is_still_allowed() {
+    let store_path = test_dir();
+    let mut persistence = OpLogPersistence::create_test(&store_path)
+        .await
+        .expect("Failed to create persistence");
+
+    let tx = persistence
+        .begin_test()
+        .await
+        .expect("Failed to begin transaction");
+    let wd = tx.root().await.expect("Failed to get root");
+
+    use tokio::io::AsyncWriteExt;
+    let mut writer = wd
+        .async_writer_path_with_type("blob.bin", tinyfs::EntryType::FilePhysicalSeries)
+        .await
+        .expect("Failed to create writer");
+    writer
+        .write_all(b"opaque bytes\n")
+        .await
+        .expect("Failed to write");
+    writer
+        .shutdown()
+        .await
+        .expect("an undeclared byte series must still be storable without bounds");
+
+    tx.commit_test()
+        .await
+        .expect("an undeclared byte series must commit without bounds");
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1775,6 +1775,13 @@ archived_pattern: /var/log/app/app.log.*
 active_pattern: /var/log/app/app.log
 # Destination path within the pond
 pond_path: /logs/app
+# Optional: JSON field holding each record's event time. Setting it declares
+# that this node carries logs or metrics, which makes ingest record per-version
+# event-time bounds. Omit it for opaque byte streams.
+timestamp_field: timeUnixNano
+# Unit of that field: seconds | milliseconds | microseconds | nanoseconds
+# (default: microseconds)
+timestamp_unit: nanoseconds
 ```
 
 **Usage:**
@@ -1794,6 +1801,18 @@ pond run 10-ingest b3sum
 - **Archived files** (matching `archived_pattern`): Immutable - ingested once, verified unchanged
 - **Active file** (matching `active_pattern`): Append-only - detects new bytes via cumulative bao-tree hash
 - **Rotation detection**: When active file shrinks or content prefix changes, searches for matching archived file
+
+**Event-time bounds (`timestamp_field`):**
+
+`temporal-reduce` keys its partial-aggregate cache on each source version's event-time range. A version stored without one is taken to span *all* of time, so every sealed segment is dropped and the rollup recomputes its whole history on every build — visible only as a slow, memory-hungry build.
+
+Setting `timestamp_field` declares the node temporal and changes three things:
+
+- Each written version records the min/max of that field across its records.
+- Slices taken from the **active** file are cut at the last newline, so a version never contains a half-written record. The withheld bytes are stored on the next run, once the writer has finished the line; appends are detected by size, so nothing is lost. Archived and rotated files are final and are always stored whole.
+- A version whose bounds cannot be determined **fails the write** rather than being stored unbounded. Reaching that point means the configured field or unit does not match the records.
+
+Leaving `timestamp_field` unset keeps the file an opaque byte stream: no bounds, no alignment, stored byte-for-byte. Use that for anything without one record per line.
 
 **Important:** Files >64KB are stored externally in parquet (not inline in oplog). See `docs/large-file-storage-implementation.md`.
 

--- a/testsuite/tests/054-logfile-ingest-event-time-bounds.sh
+++ b/testsuite/tests/054-logfile-ingest-event-time-bounds.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+# EXPERIMENT: logfile-ingest records event-time bounds, so temporal-reduce can
+#   prune its cache instead of rebuilding it.
+# DESCRIPTION: temporal-reduce keys its partial-aggregate cache on the event-time
+#   range of each source version (watertown #123). It reads that range from the
+#   min/max_event_time tlogfs records on the version; a version without them is
+#   taken to span ALL of time (`SourceRange::UNKNOWN` = i64::MIN..i64::MAX).
+#
+#   logfile-ingest never recorded those bounds. Every version it wrote was
+#   therefore unbounded, so on every build the dirty range reached the beginning
+#   of time, `unseal_from(None)` dropped every sealed segment, `sealed_hi_secs`
+#   reset to null, and the rollup recomputed the entire history from source.
+#   In production (watershop site-staging) that turned a ~450 MB incremental
+#   site build into a pinned ~2.05 GB full rebuild on every single run -- the
+#   cost of a cold cache, paid three times an hour, forever.
+#
+#   The fix is the optional `timestamp_field` config below, which makes
+#   logfile-ingest record each version's real bounds the way journal-ingest
+#   already did.
+#
+# EXPECTED: With `timestamp_field` set, the ingested versions carry a time range
+#   and the rollup manifest records real per-source ranges; an incremental
+#   append leaves the sealed segments standing. Without it (the control), the
+#   manifest is full of the i64::MIN sentinel and the append unseals everything.
+set -e
+source check.sh
+
+echo "=== Experiment: logfile-ingest event-time bounds bound the rollup ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+# ---- Source: 48 hourly samples, then one more recent sample as the append ---
+# Every sample is 1.0, so SUM over the rollup equals the sample COUNT and any
+# deviation is a miscount rather than a rounding difference.
+mkdir -p /var/log/well
+awk 'BEGIN {
+    start = 1784073600;
+    for (i = 0; i < 48; i++) {
+        e = start + i * 3600;
+        printf "{\"resourceMetrics\":[{\"resource\":{},\"scopeMetrics\":[{\"scope\":{\"name\":\"water\"},\"metrics\":[{\"name\":\"well_depth_value\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"%d000000000\",\"asDouble\":1.0}]}}]}]}]}\n", e;
+    }
+}' > /tmp/054-all.jsonl
+
+# The append: one sample AFTER the newest, i.e. ordinary forward progress. This
+# is the case that must stay incremental.
+awk 'BEGIN {
+    e = 1784073600 + 48 * 3600;
+    printf "{\"resourceMetrics\":[{\"resource\":{},\"scopeMetrics\":[{\"scope\":{\"name\":\"water\"},\"metrics\":[{\"name\":\"well_depth_value\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"%d000000000\",\"asDouble\":1.0}]}}]}]}]}\n", e;
+}' > /tmp/054-next.jsonl
+
+cat > /tmp/054-reduce.yaml << 'YAML'
+in_pattern: "oteljson:///ingest/well.json"
+out_pattern: "data"
+time_column: "timestamp"
+resolutions: ["1h"]
+seal_target_bytes: 0
+aggregations:
+  - type: "sum"
+    columns: ["well_depth_value"]
+  - type: "count"
+    columns: ["well_depth_value"]
+YAML
+
+# `seal_target_bytes: 0` seals on every build, so segments exist to be dropped.
+# Without it the size gate would leave everything hot and the two arms below
+# would be indistinguishable.
+
+# Count the unbounded sentinel across every manifest in a pond. This is the
+# exact quantity measured on the production pond, where it was 7526 of 7526.
+count_unbounded() {
+    find "$1/cache" -name manifest.json -exec cat {} + 2>/dev/null \
+        | grep -o -- '-9223372036854775808' | wc -l | tr -d ' '
+}
+
+# Is any resolution still sealed?  `unseal_from(None)` resets sealed_hi_secs to
+# null, so a null everywhere means the whole cache was thrown away.
+count_sealed() {
+    find "$1/cache" -name manifest.json -exec cat {} + 2>/dev/null \
+        | grep -oE '"sealed_hi_secs":[[:space:]]*[0-9]' | wc -l | tr -d ' '
+}
+
+# Guard against a vacuous pass: "no sentinels" means nothing if no manifest was
+# ever written.
+count_manifests() {
+    find "$1/cache" -name manifest.json 2>/dev/null | wc -l | tr -d ' '
+}
+
+manifests() {
+    find "$1/cache" -name manifest.json -exec cat {} + 2>/dev/null
+}
+
+# The sealed segments' digests. `sealed_hi_secs` cannot distinguish the two arms
+# because a build always re-seals before writing the manifest, so the end state
+# looks sealed either way. What differs is whether the segments that existed
+# before an append SURVIVE it: pruning preserves them, while unsealing destroys
+# and recomputes them. That survival is precisely the work the fix avoids.
+seg_digests() {
+    manifests "$1" | grep -oE '"digest":[[:space:]]*"[0-9a-f]{64}"' \
+        | grep -oE '[0-9a-f]{64}' | sort -u
+}
+
+# How many of the digests in $1 are still present in $2.
+survivors() {
+    comm -12 <(printf '%s\n' "$1" | sort -u) <(printf '%s\n' "$2" | sort -u) \
+        | grep -c . || true
+}
+
+# ---- Arm A: bounds recorded (the fix) --------------------------------------
+cat > /tmp/054-ingest-bounded.yaml << 'EOF'
+archived_pattern: /var/log/well/well.json.*
+active_pattern: /var/log/well/well.json
+pond_path: /ingest
+timestamp_field: timeUnixNano
+timestamp_unit: nanoseconds
+EOF
+
+pond mkdir -p /system/run >/dev/null
+pond mkdir -p /ingest >/dev/null
+pond mknod logfile-ingest /system/run/10-well --config-path /tmp/054-ingest-bounded.yaml >/dev/null
+
+: > /var/log/well/well.json
+split -l 12 /tmp/054-all.jsonl /tmp/054-chunk.
+for c in /tmp/054-chunk.*; do
+    cat "$c" >> /var/log/well/well.json
+    pond run /system/run/10-well >/dev/null 2>&1
+done
+
+pond mknod temporal-reduce /reduced --config-path /tmp/054-reduce.yaml >/dev/null
+
+echo ""
+echo "--- Build the rollup ---"
+SUM_BEFORE=$(pond cat /reduced/data/res=1h.series --format=table \
+  --sql "SELECT CAST(SUM(\"well_depth_value.count\") AS BIGINT) AS n FROM source" 2>&1 \
+  | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+
+UNBOUNDED_FIXED=$(count_unbounded "$POND")
+SEALED_FIXED=$(count_sealed "$POND")
+MANIFESTS_FIXED=$(count_manifests "$POND")
+
+echo ""
+echo "--- Manifest after the initial build ---"
+manifests "$POND"
+
+# The four ingest runs each wrote 12 hourly samples, so the recorded ranges must
+# tile the source exactly: the earliest is the first sample and the latest is
+# the 48th.  Checking the values, not merely their presence, is what
+# distinguishes a correct conversion from a plausible-looking wrong one --
+# nanoseconds read as microseconds would still be non-sentinel.
+FIRST_US=1784073600000000
+LAST_US=1784242800000000
+MIN_SEEN=$(manifests "$POND" | grep -oE '"min_us":[[:space:]]*-?[0-9]+' \
+    | grep -oE '\-?[0-9]+$' | sort -n | head -1)
+MAX_SEEN=$(manifests "$POND" | grep -oE '"max_us":[[:space:]]*-?[0-9]+' \
+    | grep -oE '\-?[0-9]+$' | sort -n | tail -1)
+
+SEG_FIXED_BEFORE=$(seg_digests "$POND")
+
+# The incremental append.
+cat /tmp/054-next.jsonl >> /var/log/well/well.json
+pond run /system/run/10-well >/dev/null 2>&1
+
+SUM_AFTER=$(pond cat /reduced/data/res=1h.series --format=table \
+  --sql "SELECT CAST(SUM(\"well_depth_value.count\") AS BIGINT) AS n FROM source" 2>&1 \
+  | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1)
+
+SEALED_FIXED_AFTER=$(count_sealed "$POND")
+SEG_FIXED_AFTER=$(seg_digests "$POND")
+SURVIVED_FIXED=$(survivors "$SEG_FIXED_BEFORE" "$SEG_FIXED_AFTER")
+SEG_FIXED_BEFORE_N=$(printf '%s\n' "$SEG_FIXED_BEFORE" | grep -c . || true)
+
+# ---- Arm B: control, no timestamp_field (today's behaviour) -----------------
+export POND=/pond-control
+pond init --birthplace test-host >/dev/null
+
+cat > /tmp/054-ingest-plain.yaml << 'EOF'
+archived_pattern: /var/log/well2/well.json.*
+active_pattern: /var/log/well2/well.json
+pond_path: /ingest
+EOF
+
+mkdir -p /var/log/well2
+pond mkdir -p /system/run >/dev/null
+pond mkdir -p /ingest >/dev/null
+pond mknod logfile-ingest /system/run/10-well --config-path /tmp/054-ingest-plain.yaml >/dev/null
+
+: > /var/log/well2/well.json
+for c in /tmp/054-chunk.*; do
+    cat "$c" >> /var/log/well2/well.json
+    pond run /system/run/10-well >/dev/null 2>&1
+done
+
+pond mknod temporal-reduce /reduced --config-path /tmp/054-reduce.yaml >/dev/null
+
+pond cat /reduced/data/res=1h.series --format=table \
+  --sql "SELECT COUNT(*) FROM source" >/dev/null 2>&1 || true
+
+UNBOUNDED_CONTROL=$(count_unbounded "$POND")
+SEALED_CONTROL=$(count_sealed "$POND")
+SEG_CONTROL_BEFORE=$(seg_digests "$POND")
+
+cat /tmp/054-next.jsonl >> /var/log/well2/well.json
+pond run /system/run/10-well >/dev/null 2>&1
+
+pond cat /reduced/data/res=1h.series --format=table \
+  --sql "SELECT COUNT(*) FROM source" >/dev/null 2>&1 || true
+
+SEALED_CONTROL_AFTER=$(count_sealed "$POND")
+SEG_CONTROL_AFTER=$(seg_digests "$POND")
+SURVIVED_CONTROL=$(survivors "$SEG_CONTROL_BEFORE" "$SEG_CONTROL_AFTER")
+SEG_CONTROL_BEFORE_N=$(printf '%s\n' "$SEG_CONTROL_BEFORE" | grep -c . || true)
+
+export POND=/pond
+
+# ---- Verify ----------------------------------------------------------------
+echo ""
+echo "--- Verification ---"
+echo "fixed:   manifests=${MANIFESTS_FIXED} unbounded=${UNBOUNDED_FIXED} sealed=${SEALED_FIXED} -> ${SEALED_FIXED_AFTER}"
+echo "fixed:   min_us=${MIN_SEEN} max_us=${MAX_SEEN}"
+echo "fixed:   segments ${SEG_FIXED_BEFORE_N}, surviving the append ${SURVIVED_FIXED}"
+echo "control: unbounded=${UNBOUNDED_CONTROL} sealed=${SEALED_CONTROL} -> ${SEALED_CONTROL_AFTER}"
+echo "control: segments ${SEG_CONTROL_BEFORE_N}, surviving the append ${SURVIVED_CONTROL}"
+
+check '[ "${MANIFESTS_FIXED}" -gt 0 ]' \
+  "the rollup wrote a manifest, so the counts below are not vacuous"
+
+check '[ "${UNBOUNDED_FIXED}" = "0" ]' \
+  "no source range is the unbounded sentinel, got ${UNBOUNDED_FIXED}"
+
+check '[ "${MIN_SEEN}" = "${FIRST_US}" ]' \
+  "earliest recorded bound is the first sample, got ${MIN_SEEN}"
+
+check '[ "${MAX_SEEN}" = "${LAST_US}" ]' \
+  "latest recorded bound is the last sample, got ${MAX_SEEN}"
+
+check '[ "${SEALED_FIXED}" -gt 0 ]' \
+  "the rollup sealed at least one resolution, got ${SEALED_FIXED}"
+
+check '[ "${SEG_FIXED_BEFORE_N}" -gt 0 ] && [ "${SURVIVED_FIXED}" = "${SEG_FIXED_BEFORE_N}" ]' \
+  "every sealed segment survives an in-order append, ${SURVIVED_FIXED}/${SEG_FIXED_BEFORE_N}"
+
+check '[ "${SUM_BEFORE}" = "48" ]' \
+  "all 48 samples counted exactly once before the append, got ${SUM_BEFORE}"
+
+check '[ "${SUM_AFTER}" = "49" ]' \
+  "the appended sample is counted, and none double-counted, got ${SUM_AFTER}"
+
+# The control documents what the fix is worth: without bounds every source looks
+# unbounded, so the append recomputes the segments rather than keeping them.
+check '[ "${UNBOUNDED_CONTROL}" -gt 0 ]' \
+  "control (no timestamp_field) records unbounded ranges, got ${UNBOUNDED_CONTROL}"
+
+check '[ "${SEG_CONTROL_BEFORE_N}" -gt 0 ] && [ "${SURVIVED_CONTROL}" = "0" ]' \
+  "control recomputes every segment on append, ${SURVIVED_CONTROL}/${SEG_CONTROL_BEFORE_N} survived"
+
+check_finish

--- a/testsuite/tests/055-replication-preserves-node-metadata.sh
+++ b/testsuite/tests/055-replication-preserves-node-metadata.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# EXPERIMENT: replication carries node metadata, so a consumer that rolls up
+#   REPLICATED data stays incremental.
+# DESCRIPTION: Test 054 fixed the producer: logfile-ingest now records each
+#   version's event-time bounds. That is only half the path actually used in
+#   production. watershop's site pond does not roll up its own ingest; it rolls
+#   up copies pulled from other ponds (config/scripts/attach-remotes.sh). So the
+#   bounds have to survive replication too.
+#
+#   They did not. Before the content-addressed rewrite, replication shipped
+#   whole OplogEntry rows and min/max_event_time rode along for free. The
+#   rewrite reduced each node to a child_hash and let the consumer re-mint the
+#   rest locally -- which silently dropped every column that is not a function
+#   of the bytes. A consumer therefore saw NULL bounds on every replicated
+#   version, read them back as SourceRange::UNKNOWN (i64::MIN..i64::MAX), and
+#   rebuilt its entire rollup from source on every single build. That is the
+#   ~2.05 GB pinned build measured on site-staging, reproduced here.
+#
+#   The fix puts node metadata back on the wire, on the DIRECTORY ENTRY: a
+#   directory holds names that refer to nodes, and the metadata belongs beside
+#   the name. Metadata is content, so the entry's hash commits to it -- which
+#   also means a successful cross-pond import is itself a proof of fidelity,
+#   since the import re-folds the mirrored tree and rejects any mismatch
+#   against the source's root hash.
+#
+# EXPECTED: The consumer's rollup over replicated data records real per-source
+#   ranges (no i64::MIN sentinel), the replicated node keeps the producer's own
+#   mtime, and an in-order append leaves the consumer's sealed segments standing
+#   instead of recomputing them.
+set -e
+source check.sh
+
+echo "=== Experiment: replication preserves node metadata ==="
+
+P1=/tmp/055-producer
+P2=/tmp/055-consumer
+REMOTE=/tmp/055-remote
+rm -rf "$P1" "$P2" "$REMOTE"
+mkdir -p "$REMOTE"
+
+# ---- Source data: 48 hourly samples, then one later sample as the append ----
+# Every sample is 1.0, so SUM over the rollup equals the sample COUNT and any
+# deviation is a miscount rather than a rounding difference.
+mkdir -p /var/log/well
+awk 'BEGIN {
+    start = 1784073600;
+    for (i = 0; i < 48; i++) {
+        e = start + i * 3600;
+        printf "{\"resourceMetrics\":[{\"resource\":{},\"scopeMetrics\":[{\"scope\":{\"name\":\"water\"},\"metrics\":[{\"name\":\"well_depth_value\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"%d000000000\",\"asDouble\":1.0}]}}]}]}]}\n", e;
+    }
+}' > /tmp/055-all.jsonl
+
+awk 'BEGIN {
+    e = 1784073600 + 48 * 3600;
+    printf "{\"resourceMetrics\":[{\"resource\":{},\"scopeMetrics\":[{\"scope\":{\"name\":\"water\"},\"metrics\":[{\"name\":\"well_depth_value\",\"gauge\":{\"dataPoints\":[{\"timeUnixNano\":\"%d000000000\",\"asDouble\":1.0}]}}]}]}]}\n", e;
+}' > /tmp/055-next.jsonl
+
+cat > /tmp/055-ingest.yaml << 'EOF'
+archived_pattern: /var/log/well/well.json.*
+active_pattern: /var/log/well/well.json
+pond_path: /ingest
+timestamp_field: timeUnixNano
+timestamp_unit: nanoseconds
+EOF
+
+# The consumer rolls up the REPLICATED copy, exactly as the site pond does.
+cat > /tmp/055-reduce.yaml << 'YAML'
+in_pattern: "oteljson:///imports/up/ingest/well.json"
+out_pattern: "data"
+time_column: "timestamp"
+resolutions: ["1h"]
+seal_target_bytes: 0
+aggregations:
+  - type: "sum"
+    columns: ["well_depth_value"]
+  - type: "count"
+    columns: ["well_depth_value"]
+YAML
+
+# `seal_target_bytes: 0` seals on every build, so segments exist to survive (or
+# not) the append; the default size gate would leave everything hot and make the
+# two outcomes indistinguishable.
+
+count_unbounded() {
+    find "$1/cache" -name manifest.json -exec cat {} + 2>/dev/null \
+        | grep -o -- '-9223372036854775808' | wc -l | tr -d ' '
+}
+
+count_manifests() {
+    find "$1/cache" -name manifest.json 2>/dev/null | wc -l | tr -d ' '
+}
+
+manifests() {
+    find "$1/cache" -name manifest.json -exec cat {} + 2>/dev/null
+}
+
+# The sealed segments' digests. What distinguishes an incremental build from a
+# full rebuild is whether the segments that existed before an append SURVIVE it:
+# pruning preserves them, unsealing destroys and recomputes them.
+seg_digests() {
+    manifests "$1" | grep -oE '"digest":[[:space:]]*"[0-9a-f]{64}"' \
+        | grep -oE '[0-9a-f]{64}' | sort -u
+}
+
+survivors() {
+    comm -12 <(printf '%s\n' "$1" | sort -u) <(printf '%s\n' "$2" | sort -u) \
+        | grep -c . || true
+}
+
+rollup_sum() {
+    pond cat /reduced/data/res=1h.series --format=table \
+        --sql "SELECT CAST(SUM(\"well_depth_value.count\") AS BIGINT) AS n FROM source" 2>&1 \
+        | grep -E '^\| *[0-9]' | head -1 | grep -oE '[0-9]+' | head -1
+}
+
+echo ""
+echo "--- Step 1: producer ingests with event-time bounds ---"
+export POND="$P1"
+pond init --birthplace test-host >/dev/null
+pond mkdir -p /system/run >/dev/null
+pond mkdir -p /ingest >/dev/null
+pond mknod logfile-ingest /system/run/10-well --config-path /tmp/055-ingest.yaml >/dev/null
+
+: > /var/log/well/well.json
+split -l 12 /tmp/055-all.jsonl /tmp/055-chunk.
+for c in /tmp/055-chunk.*; do
+    cat "$c" >> /var/log/well/well.json
+    pond run /system/run/10-well >/dev/null 2>&1
+done
+
+# `pond list -l` renders each node's mtime, which is the plainest observable
+# form of replicated node metadata.
+pond list -l /ingest/well.json > /tmp/055-p1-list.txt 2>&1
+P1_MTIME=$(grep 'well.json' /tmp/055-p1-list.txt \
+    | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}' | head -1)
+
+echo ""
+echo "--- Step 2: publish to a file:// remote ---"
+pond backup add origin "file://${REMOTE}" > /tmp/055-backup.log 2>&1
+check 'grep -q "added remote origin" /tmp/055-backup.log' "backup add origin succeeded"
+
+echo ""
+echo "--- Step 3: consumer imports the producer's pond ---"
+export POND="$P2"
+pond init --birthplace test-host >/dev/null
+pond remote add upstream "file://${REMOTE}" /imports/up >/dev/null 2>&1
+# Pull well after the producer wrote, so a consumer that re-minted the mtime
+# locally would record a visibly different one.
+sleep 2
+pond pull upstream > /tmp/055-pull.log 2>&1
+check 'grep -q "pull upstream complete" /tmp/055-pull.log' "consumer completed cross-pond import"
+
+# The import re-folds the mirrored tree and compares it to the source's root
+# hash. Because metadata is part of the entry, that fold only matches if every
+# replicated version's metadata matches too -- so a clean pull is itself the
+# fidelity check. (When the consumer re-minted metadata locally, this is exactly
+# where the mismatch surfaced.)
+check '! grep -qi "folds to" /tmp/055-pull.log' \
+    "mirrored tree folds to the source root (metadata replicated exactly)"
+
+# The replica must report the producer's own mtime, not the time of the pull --
+# the same thing `rsync -t` and `cp -p` do.
+pond list -l /imports/up/ingest/well.json > /tmp/055-p2-list.txt 2>&1
+P2_MTIME=$(grep 'well.json' /tmp/055-p2-list.txt \
+    | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}' | head -1)
+
+echo ""
+echo "--- Step 4: consumer rolls up the REPLICATED copy ---"
+pond mknod temporal-reduce /reduced --config-path /tmp/055-reduce.yaml >/dev/null
+SUM_BEFORE=$(rollup_sum)
+
+UNBOUNDED=$(count_unbounded "$POND")
+MANIFESTS=$(count_manifests "$POND")
+SEG_BEFORE=$(seg_digests "$POND")
+SEG_BEFORE_N=$(printf '%s\n' "$SEG_BEFORE" | grep -c . || true)
+
+echo ""
+echo "--- Consumer rollup manifest ---"
+manifests "$POND"
+
+echo ""
+echo "--- Step 5: producer appends, consumer re-pulls and rebuilds ---"
+export POND="$P1"
+cat /tmp/055-next.jsonl >> /var/log/well/well.json
+pond run /system/run/10-well >/dev/null 2>&1
+
+export POND="$P2"
+pond pull upstream > /tmp/055-pull2.log 2>&1
+check 'grep -q "pull upstream complete" /tmp/055-pull2.log' "consumer pulled the append"
+
+SUM_AFTER=$(rollup_sum)
+SEG_AFTER=$(seg_digests "$POND")
+SURVIVED=$(survivors "$SEG_BEFORE" "$SEG_AFTER")
+UNBOUNDED_AFTER=$(count_unbounded "$POND")
+
+echo ""
+echo "--- Verification ---"
+echo "producer mtime: ${P1_MTIME}"
+echo "consumer mtime: ${P2_MTIME}"
+echo "consumer: manifests=${MANIFESTS} unbounded=${UNBOUNDED} -> ${UNBOUNDED_AFTER}"
+echo "consumer: segments ${SEG_BEFORE_N}, surviving the append ${SURVIVED}"
+echo "consumer: rollup sum ${SUM_BEFORE} -> ${SUM_AFTER}"
+
+check '[ "${MANIFESTS}" -gt 0 ]' \
+    "the consumer's rollup wrote a manifest, so the counts below are not vacuous"
+
+check '[ -n "${P1_MTIME}" ]' \
+    "the producer's series reports an mtime"
+
+check '[ "${P1_MTIME}" = "${P2_MTIME}" ]' \
+    "the replica keeps the producer's mtime rather than the time of the pull"
+
+check '[ "${UNBOUNDED}" = "0" ]' \
+    "no replicated source is the unbounded sentinel, got ${UNBOUNDED}"
+
+check '[ "${SUM_BEFORE}" = "48" ]' \
+    "all 48 replicated samples counted exactly once, got ${SUM_BEFORE}"
+
+check '[ "${SUM_AFTER}" = "49" ]' \
+    "the appended sample is counted, and none double-counted, got ${SUM_AFTER}"
+
+check '[ "${UNBOUNDED_AFTER}" = "0" ]' \
+    "the append introduces no unbounded source, got ${UNBOUNDED_AFTER}"
+
+# The payoff: with bounds carried across the wire, the consumer prunes its cache
+# instead of discarding it. Without them every replicated source spanned all of
+# time, so this number was 0 and the whole rollup was recomputed every build.
+check '[ "${SEG_BEFORE_N}" -gt 0 ] && [ "${SURVIVED}" = "${SEG_BEFORE_N}" ]' \
+    "every sealed segment survives the replicated append, ${SURVIVED}/${SEG_BEFORE_N}"
+
+check_finish

--- a/testsuite/tests/056-logfile-ingest-record-alignment.sh
+++ b/testsuite/tests/056-logfile-ingest-record-alignment.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# EXPERIMENT: a log declared to carry timestamps always ends up with event-time
+#   bounds -- a partially-written record can no longer strand a version without
+#   them, and a field that does not match the data fails loudly.
+# DESCRIPTION: test 054 made logfile-ingest RECORD bounds; this one makes that
+#   recording total.
+#
+#   logfile-ingest tails an actively-written file by byte offset, so a slice
+#   routinely ends mid-record: the station is still writing that line. Stored
+#   verbatim, one record straddles two versions and NEITHER can read its own
+#   timestamps -- the first cannot parse its trailing fragment, the second
+#   cannot parse its leading one. The scan then abandons (correctly: bounds
+#   covering only the lines that parsed would leave the rest of the slice
+#   outside its own range) and the version was written unbounded. One unbounded
+#   version is all it takes: temporal-reduce treats it as spanning all of time
+#   and rebuilds its entire cache, which is the ~2.05 GB failure of 054
+#   reappearing through a different door.
+#
+#   Two changes close it. Slices from an active file are cut at the last
+#   newline, so every stored version holds a whole number of records and the
+#   next one starts at a record boundary; the withheld bytes are picked up on
+#   the next tick, since appends are detected by size. And naming a
+#   timestamp_field now declares the node temporal, so a version that still
+#   cannot produce bounds fails the write instead of being silently stored
+#   unbounded.
+#
+#   Both are gated on timestamp_field being set. Without it the file is an
+#   opaque byte stream that may contain no newline at all, and withholding
+#   would strand it forever rather than merely until the next tick.
+#
+# EXPECTED: ingesting a torn tail withholds the partial record and yields zero
+#   unbounded versions; the withheld bytes arrive once complete, byte-exact; a
+#   mismatched timestamp_field fails the run and names the field; and a node
+#   without timestamp_field still ingests a torn tail verbatim.
+set -e
+source check.sh
+
+echo "=== Experiment: record alignment makes temporal bounds total ==="
+
+export POND=/pond
+pond init --birthplace test-host >/dev/null
+
+mkdir -p /var/log/torn
+
+# One OTLP record per line, same shape the stations emit.
+record() {
+    printf '{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metrics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"%d000000000","asDouble":1.0}]}}]}]}]}\n' "$1"
+}
+
+# The unbounded sentinel (i64::MIN) as it appears in a manifest or listing.
+count_unbounded() {
+    find "$1" -name '*.json' -exec cat {} + 2>/dev/null \
+        | grep -o -- '-9223372036854775808' | wc -l | tr -d ' '
+}
+
+cat > /tmp/056-ingest.yaml << 'EOF'
+archived_pattern: /var/log/torn/well.json.*
+active_pattern: /var/log/torn/well.json
+pond_path: /ingest
+timestamp_field: timeUnixNano
+timestamp_unit: nanoseconds
+EOF
+
+pond mkdir -p /system/run >/dev/null
+pond mkdir -p /ingest >/dev/null
+pond mknod logfile-ingest /system/run/10-well --config-path /tmp/056-ingest.yaml >/dev/null
+
+# ---- A torn tail: two whole records plus a half-written third --------------
+: > /var/log/torn/well.json
+record 1784073600 >> /var/log/torn/well.json
+record 1784077200 >> /var/log/torn/well.json
+COMPLETE_BYTES=$(wc -c < /var/log/torn/well.json | tr -d ' ')
+
+# The station is mid-write: a record with no terminating newline.
+printf '{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"water"},"metr' \
+    >> /var/log/torn/well.json
+TORN_BYTES=$(wc -c < /var/log/torn/well.json | tr -d ' ')
+
+echo ""
+echo "--- Ingest with a half-written record at the tail ---"
+pond run /system/run/10-well >/dev/null 2>&1
+
+pond cat /ingest/well.json > /tmp/056-after-torn.txt 2>/dev/null || true
+STORED=$(wc -c < /tmp/056-after-torn.txt | tr -d ' ')
+
+check "[ '$STORED' -eq '$COMPLETE_BYTES' ]" \
+  "stores only the $COMPLETE_BYTES complete bytes, not the $TORN_BYTES on disk"
+check "[ \"\$(tail -c 1 /tmp/056-after-torn.txt)\" = '' ]" \
+  "stored content ends on a record boundary"
+check "[ \"\$(grep -c timeUnixNano /tmp/056-after-torn.txt)\" -eq 2 ]" \
+  "exactly the 2 complete records are stored, not the half-written third"
+
+UNBOUNDED_TORN=$(count_unbounded "$POND")
+check "[ '$UNBOUNDED_TORN' -eq 0 ]" \
+  "no unbounded version after a torn tail (found $UNBOUNDED_TORN sentinels)"
+
+# The version must actually carry a range -- "no sentinel" is vacuous if no
+# version was written at all.
+pond list -l /ingest/well.json > /tmp/056-list.txt 2>&1 || true
+check "grep -qE '[0-9]{4}-[0-9]{2}-[0-9]{2}' /tmp/056-list.txt" \
+  "the stored version reports a real time range"
+
+# ---- The withheld bytes arrive once the record is finished -----------------
+echo ""
+echo "--- Complete the record and re-run ---"
+printf 'ics":[{"name":"well_depth_value","gauge":{"dataPoints":[{"timeUnixNano":"1784080800000000000","asDouble":1.0}]}}]}]}]}\n' \
+    >> /var/log/torn/well.json
+FULL_BYTES=$(wc -c < /var/log/torn/well.json | tr -d ' ')
+
+pond run /system/run/10-well >/dev/null 2>&1
+
+pond cat /ingest/well.json > /tmp/056-after-complete.txt 2>/dev/null || true
+STORED_FULL=$(wc -c < /tmp/056-after-complete.txt | tr -d ' ')
+
+check "[ '$STORED_FULL' -eq '$FULL_BYTES' ]" \
+  "withheld bytes are picked up on the next tick ($STORED_FULL of $FULL_BYTES)"
+check "diff -q /tmp/056-after-complete.txt /var/log/torn/well.json" \
+  "pond content is byte-identical to the host file"
+check "[ \"\$(grep -c timeUnixNano /tmp/056-after-complete.txt)\" -eq 3 ]" \
+  "all three records are present exactly once"
+
+UNBOUNDED_FULL=$(count_unbounded "$POND")
+check "[ '$UNBOUNDED_FULL' -eq 0 ]" \
+  "still no unbounded version after the append (found $UNBOUNDED_FULL sentinels)"
+
+# ---- A field that does not match the data must fail loudly -----------------
+echo ""
+echo "--- A mismatched timestamp_field fails the run ---"
+mkdir -p /var/log/wrong
+record 1784073600 > /var/log/wrong/other.json
+
+cat > /tmp/056-wrong.yaml << 'EOF'
+archived_pattern: /var/log/wrong/other.json.*
+active_pattern: /var/log/wrong/other.json
+pond_path: /wrongfield
+timestamp_field: notATimestampField
+timestamp_unit: nanoseconds
+EOF
+
+pond mkdir -p /wrongfield >/dev/null
+pond mknod logfile-ingest /system/run/20-wrong --config-path /tmp/056-wrong.yaml >/dev/null
+
+RUN_RC=0
+pond run /system/run/20-wrong > /tmp/056-wrong-out.txt 2>&1 || RUN_RC=$?
+
+check "[ '$RUN_RC' -ne 0 ]" \
+  "declaring a field the records lack fails the run (rc=$RUN_RC)"
+check_contains /tmp/056-wrong-out.txt \
+  "the failure names the field it looked for" 'notATimestampField'
+
+# The silent alternative is the whole point: an unbounded version stored here
+# would surface only as a slow, memory-hungry rollup weeks later.
+UNBOUNDED_WRONG=$(count_unbounded "$POND")
+check "[ '$UNBOUNDED_WRONG' -eq 0 ]" \
+  "the rejected write left no unbounded version behind"
+
+# ---- Without timestamp_field, a byte stream is still stored verbatim -------
+echo ""
+echo "--- An opaque stream is not withheld ---"
+mkdir -p /var/log/opaque
+# No newline anywhere: aligning this would withhold it forever.
+printf 'no-newline-anywhere-at-all' > /var/log/opaque/blob.log
+
+cat > /tmp/056-opaque.yaml << 'EOF'
+archived_pattern: /var/log/opaque/blob.log.*
+active_pattern: /var/log/opaque/blob.log
+pond_path: /opaque
+EOF
+
+pond mkdir -p /opaque >/dev/null
+pond mknod logfile-ingest /system/run/30-opaque --config-path /tmp/056-opaque.yaml >/dev/null
+pond run /system/run/30-opaque >/dev/null 2>&1
+
+pond cat /opaque/blob.log > /tmp/056-opaque.txt 2>/dev/null || true
+check "diff -q /tmp/056-opaque.txt /var/log/opaque/blob.log" \
+  "a stream with no newline and no timestamp_field is stored byte-exact"
+
+check_finish

--- a/testsuite/tests/056-logfile-ingest-record-alignment.sh
+++ b/testsuite/tests/056-logfile-ingest-record-alignment.sh
@@ -158,8 +158,6 @@ check "[ '$UNBOUNDED_WRONG' -eq 0 ]" \
 echo ""
 echo "--- An opaque stream is not withheld ---"
 mkdir -p /var/log/opaque
-# No newline anywhere: aligning this would withhold it forever.
-printf 'no-newline-anywhere-at-all' > /var/log/opaque/blob.log
 
 cat > /tmp/056-opaque.yaml << 'EOF'
 archived_pattern: /var/log/opaque/blob.log.*
@@ -168,11 +166,24 @@ pond_path: /opaque
 EOF
 
 pond mkdir -p /opaque >/dev/null
+# mknod runs the factory as a post-commit hook, so the file is created after
+# the node: otherwise the ingest happens during mknod and the run below has
+# nothing left to write.
 pond mknod logfile-ingest /system/run/30-opaque --config-path /tmp/056-opaque.yaml >/dev/null
-pond run /system/run/30-opaque >/dev/null 2>&1
+
+# No newline anywhere: aligning this would withhold it forever.
+printf 'no-newline-anywhere-at-all' > /var/log/opaque/blob.log
+RUST_LOG=debug pond run /system/run/30-opaque > /tmp/056-opaque-log.txt 2>&1
 
 pond cat /opaque/blob.log > /tmp/056-opaque.txt 2>/dev/null || true
 check "diff -q /tmp/056-opaque.txt /var/log/opaque/blob.log" \
   "a stream with no newline and no timestamp_field is stored byte-exact"
+
+# Storing a null range is correct here, but it is the same state a downstream
+# temporal-reduce reads as "spans all time", so it must not be silent: an
+# unbounded version is otherwise visible only as a slow rollup much later.
+check_contains /tmp/056-opaque-log.txt \
+  "storing null bounds without an extractor is logged, not silent" \
+  'null event-time bounds'
 
 check_finish


### PR DESCRIPTION
watershop's site-staging pond had been rebuilding its entire rollup on every
build — a pinned ~2.05 GB peak where ~450 MB of incremental work was needed,
paid three times an hour. This is the fix, in two independent parts. The goal
is running the pond on a 2 GB machine.

## 1. logfile-ingest never recorded event-time bounds (`0bf7303`)

`temporal-reduce` keys its partial-aggregate cache on each source version's
event-time range (#123). A version without one is taken to span all of time
(`SourceRange::UNKNOWN` = `i64::MIN..i64::MAX`), so the dirty range reaches the
beginning of time, `unseal_from(None)` drops every sealed segment, and the
rollup recomputes all history from source.

`logfile-ingest` never recorded those bounds, so **every** version it wrote was
unbounded — 7526 of 7526 source entries in site-staging's manifests carried the
sentinel. `journal-ingest` already did this correctly; the new optional
`timestamp_field` / `timestamp_unit` config brings `logfile-ingest` in line.

## 2. Replication silently dropped node metadata (`f21ab9b`)

Fixing the producer only covers half the path actually used in production: the
site pond doesn't roll up its own ingest, it rolls up copies pulled from other
ponds (`attach-remotes.sh`). So the bounds have to survive replication too.

They didn't. Before the content-addressed rewrite (#99) replication shipped
whole `OplogEntry` rows and these columns rode along for free. The rewrite
reduced each node to a `child_hash` and let the consumer re-mint the rest
locally, which dropped every column that isn't a function of the bytes: the
mtime, and the event-time range of a raw JSON-lines version — which depends on
the ingest configuration of the pond that created it (which key holds the event
time, in which unit) and so cannot be recovered from the bytes at all.

Node metadata now travels on the **directory entry**. A filesystem's directory
holds names that refer to nodes, and the metadata belongs beside the name.
Because the entry is a content object it flows into cross-pond imports along
with the data, while blobs and series objects stay purely byte-addressed, so
identical bytes still transfer and store once. `VersionMeta` is the replicable
part of the node's row — mtime, event-time bounds, extended attributes — carried
for every node kind except directories, whose state is the subtree their hash
already commits to (mirroring tlogfs partitioning, where a partition holds
entries plus all node metadata for non-directory nodes).

### Metadata is content

The entry's hash commits to the metadata. Two consequences, both intended:

- A cross-pond import re-folds the mirrored tree and rejects a mismatch against
  the source's root hash, so **fidelity is now verified for free** on every
  pull. This is what caught the symlink/dynamic-node gap during development.
- Two ponds written independently from the same bytes are no longer equal,
  because their versions were created at different times. The tests that
  asserted otherwise now compare a pond against a genuine **replica**, which is
  the only construction that really does have identical content.

The tree diff descends on metadata too — pruning on `child_hash` alone let the
roots differ while the diff reported nothing at all.

### Convergence is not assumed

`extended_attributes` is re-encoded through a `BTreeMap` before hashing, since
its stored form comes from a `HashMap` with nondeterministic key order; two
ponds that disagreed would never converge and every pull would rewrite
everything, forever. Unknown metadata flags are rejected rather than skipped:
their width is unknown, and silently dropping node state is precisely the
failure this encoding exists to prevent.

## Compatibility

`dp.tree.2` and `dp.manifest.2` are encoding bumps (Decision D2). **Ponds that
sync must be reset together.** A full reset of the maintained instances is
planned as part of this rollout.

## Deployment ordering

`LogfileIngestConfig` is `#[serde(deny_unknown_fields)]`, so the caspar.water
config change adding `timestamp_field` must land **after** an image containing
this PR. Order: merge → image → configs → reset/redeploy.

## Testing

- New `testsuite/055-replication-preserves-node-metadata.sh` (12/12): a consumer
  rolling up *replicated* data records real ranges, keeps the producer's mtime
  across a deliberate 2 s gap, and keeps every sealed segment across an append.
- New `testsuite/054-logfile-ingest-event-time-bounds.sh` (10/10): differential,
  with a no-`timestamp_field` control that recomputes every segment.
- Wire-format unit tests: `VersionMeta` round-trips over all 16 flag
  combinations, unknown flags are rejected, and a metadata-only change moves the
  tree hash.
- `cargo test --workspace` green; CI clippy clean; testsuite 048, 051, 722–727
  pass.
