### PR TITLE
logfile-ingest: skip corrupt lines when scanning event-time bounds

### DIFF
--- a/crates/provider/src/factory/logfile_ingest.rs
+++ b/crates/provider/src/factory/logfile_ingest.rs
@@ -191,29 +191,64 @@ impl LogfileIngestConfig {
 /// Event-time bounds of one version's content, in microseconds, `max`
 /// inclusive -- the shape `set_temporal_metadata` wants.
 ///
-/// Returns `None` when bounds cannot be established for the whole slice, and
-/// the caller then writes the version without them. That is the safe
-/// direction: a missing bound makes the downstream rollup pessimistic (it
-/// recomputes everything), whereas a bound that is too narrow would let it
-/// skip buckets this content belongs to and silently keep stale aggregates.
-/// So every uncertainty here -- an unparseable line, a timestamp that is not
-/// an integer, an overflowing conversion -- abandons the scan rather than
-/// guessing.
+/// Returns `None` only when *no* line yielded a usable timestamp, and the
+/// caller then writes the version without them (or fails, if the node declared
+/// itself temporal).
+///
+/// The correctness condition is that the bounds cover every record the reader
+/// will actually produce from this content -- not every byte. Bounds that are
+/// too narrow would let the rollup skip buckets this content belongs to and
+/// silently keep stale aggregates, so this scan must not be *looser* than the
+/// reader. But it must not be *stricter* either: a line the reader discards
+/// contributes to no bucket, so excluding its unknown timestamp cannot narrow
+/// the bounds below the data that exists.
+///
+/// So this mirrors `format::batch::read_clean_lines` exactly -- same NUL
+/// stripping, same trim, same per-line skip -- and a corrupt line is dropped
+/// from the scan rather than abandoning it. That matters on real data: a
+/// single torn record in a 100 MB rotation (NUL padding from a crashed write,
+/// which the reader strips and recovers) would otherwise discard the event
+/// times of every other record in the file.
 ///
 /// Cost is proportional to the bytes being written, not to the file: the
 /// append path passes only the new tail.
 fn scan_temporal_bounds(content: &[u8], field: &str, unit: TimestampUnit) -> Option<(i64, i64)> {
-    let text = std::str::from_utf8(content).ok()?;
+    // Lossy rather than strict: invalid UTF-8 is corruption of the same kind
+    // as a torn line, and borrows without copying in the common valid case.
+    let text = String::from_utf8_lossy(content);
     let mut acc: Option<(i64, i64)> = None;
+    let mut skipped: u64 = 0;
 
     for line in text.lines() {
-        if line.trim().is_empty() {
+        // Strip NUL bytes (flash-storage corruption), as the reader does.
+        let cleaned: String = line.chars().filter(|c| *c != '\0').collect();
+        let trimmed = cleaned.trim();
+        if trimmed.is_empty() {
             continue;
         }
-        let value: Value = serde_json::from_str(line).ok()?;
-        if !fold_timestamps(&value, field, &mut acc) {
-            return None;
+
+        // Fold into a per-line accumulator so a line carrying a malformed
+        // timestamp contributes nothing rather than a partial range.
+        let mut line_acc: Option<(i64, i64)> = None;
+        let parsed = serde_json::from_str::<Value>(trimmed)
+            .ok()
+            .filter(|value| fold_timestamps(value, field, &mut line_acc));
+
+        match parsed.and(line_acc) {
+            Some((lo, hi)) => {
+                acc = Some(match acc {
+                    Some((alo, ahi)) => (alo.min(lo), ahi.max(hi)),
+                    None => (lo, hi),
+                });
+            }
+            None => skipped += 1,
         }
+    }
+
+    if skipped > 0 {
+        log::warn!(
+            "logfile-ingest: skipped {skipped} corrupt or timestamp-less line(s) while scanning event-time bounds for '{field}'"
+        );
     }
 
     let (min_raw, max_raw) = acc?;
@@ -226,9 +261,9 @@ fn scan_temporal_bounds(content: &[u8], field: &str, unit: TimestampUnit) -> Opt
 /// Fold every value stored under `field`, at any depth of `value`, into `acc`
 /// as a running (min, max).
 ///
-/// Returns false if a value under that key is not an integer, which abandons
-/// the scan -- see `scan_temporal_bounds` for why that is preferred to
-/// skipping it.
+/// Returns false if a value under that key is not an integer, which drops the
+/// line from the scan -- see `scan_temporal_bounds` for why that is preferred
+/// to guessing.
 fn fold_timestamps(value: &Value, field: &str, acc: &mut Option<(i64, i64)>) -> bool {
     match value {
         Value::Object(map) => {
@@ -1478,11 +1513,14 @@ mod tests {
     }
 
     #[test]
-    fn an_unparseable_line_abandons_the_scan() {
-        // Bounds covering only the lines that parsed would leave the rest of
-        // the slice outside its own range. Since slices are line-aligned before
-        // they are written, reaching this case means genuinely corrupt input,
-        // and the declared temporal requirement turns it into a failed write.
+    fn an_unparseable_line_is_skipped_not_fatal() {
+        // The reader (format::batch::read_clean_lines) skips corrupt lines and
+        // warns, so a corrupt line contributes to no bucket and dropping it
+        // here cannot narrow the bounds below the data that exists. Abandoning
+        // the whole scan instead would discard the event times of every good
+        // record in the slice -- on a 100 MB rotation, tens of thousands of
+        // them -- and, for a node that declared itself temporal, turn routine
+        // corruption into a failed write.
         let content = format!("{}\n{{\"resourceMetrics\":\n", otlp_line(&["1000000000"]));
         assert_eq!(
             scan_temporal_bounds(
@@ -1490,12 +1528,30 @@ mod tests {
                 "timeUnixNano",
                 TimestampUnit::Nanoseconds
             ),
-            None
+            Some((1_000_000, 1_000_000))
         );
     }
 
     #[test]
-    fn a_non_integer_timestamp_abandons_the_scan() {
+    fn nul_padding_is_stripped_as_the_reader_does() {
+        // Observed in production: a crashed write left a run of NUL bytes in
+        // front of an otherwise-complete record in a 2022 rotation. The reader
+        // strips NULs and recovers that record, so the scan must see it too.
+        let mut content = "\0".repeat(2048);
+        content.push_str(&otlp_line(&["1661233155151580973"]));
+        content.push('\n');
+        assert_eq!(
+            scan_temporal_bounds(
+                content.as_bytes(),
+                "timeUnixNano",
+                TimestampUnit::Nanoseconds
+            ),
+            Some((1_661_233_155_151_580, 1_661_233_155_151_581))
+        );
+    }
+
+    #[test]
+    fn a_non_integer_timestamp_drops_the_line() {
         let content =
             r#"{"resourceMetrics":[{"gauge":{"dataPoints":[{"timeUnixNano":"not-a-number"}]}}]}"#;
         assert_eq!(

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1808,9 +1808,9 @@ pond run 10-ingest b3sum
 
 Setting `timestamp_field` declares the node temporal and changes three things:
 
-- Each written version records the min/max of that field across its records.
+- Each written version records the min/max of that field across its records. Corrupt lines are skipped and counted, matching what the reader does with them (NUL padding is stripped, unparseable lines are dropped), so one torn record in a large rotation does not discard the event times of every other record in it.
 - Slices taken from the **active** file are cut at the last newline, so a version never contains a half-written record. The withheld bytes are stored on the next run, once the writer has finished the line; appends are detected by size, so nothing is lost. Archived and rotated files are final and are always stored whole.
-- A version whose bounds cannot be determined **fails the write** rather than being stored unbounded. Reaching that point means the configured field or unit does not match the records.
+- A version in which *no* record yields a usable timestamp **fails the write** rather than being stored unbounded. Reaching that point means the configured field or unit does not match the records.
 
 Leaving `timestamp_field` unset keeps the file an opaque byte stream: no bounds, no alignment, stored byte-for-byte. Use that for anything without one record per line.
 


### PR DESCRIPTION
Follow-up to #127, found by deploying it.

## What happened

The staging deploy stopped water/noyo/septic ingest outright:

```
FilePhysicalSeries declared temporal via require_temporal_metadata('timeUnixNano')
but was finalized without bounds: no usable 'timeUnixNano' timestamp was found
in 104856988 bytes.
```

The configured field was not wrong. That file carries ~448,868 `timeUnixNano`
values. **One** corrupt line — 28851 of 65061, a run of NUL padding left by a
write that crashed in 2022 — tripped `scan_temporal_bounds`' "any uncertainty
abandons the scan" rule, discarding the event times of every other record in the
rotation. #127's declared-temporal requirement then turned that into a poisoned
transaction rather than an unbounded version.

## Why the old rule was wrong

The reader already handles precisely this case. `format::batch::read_clean_lines`
strips NUL bytes (commented "flash-storage corruption"), drops unparseable lines,
and `oteljson` warns `skipped N corrupt line(s) during read`. The scan was
therefore **stricter than the reader** — failing on input the pipeline is
explicitly designed to tolerate, and which the reader recovers intact (after NUL
stripping, line 28851 is a complete record).

The correctness condition is that bounds cover the records *the reader produces*,
not every byte. A line the reader discards contributes to no bucket, so excluding
its unknown timestamp cannot narrow the bounds below the data that exists. The
scan must not be looser than the reader — but it must not be stricter either.

## The change

`scan_temporal_bounds` now mirrors `read_clean_lines` exactly: same NUL stripping,
same trim, same per-line skip, with a warn count. Timestamps fold into a per-line
accumulator, so a malformed value drops only its own line instead of contributing
a partial range.

A version in which *no* record yields a usable timestamp is still a hard error —
a configured field matching nothing remains a misconfiguration.

## Verification

- Replayed the new rule over the production archive on watershop: **109 water +
  2 septic files, 0 lines skipped**, including the file that failed, recovering
  `1660364645989110397..1664960003502943014` from it. Every file yields a usable
  timestamp, so the hard error cannot re-fire on this data.
- New unit test `nul_padding_is_stripped_as_the_reader_does`; the two
  `*_abandons_the_scan` tests renamed and rewritten to the corrected semantics.
- `cargo fmt --check`, `cargo clippy --workspace --all-features -- -D warnings`,
  `cargo test --workspace` (**42 targets, 0 failures**), testsuite 054 (10/10),
  055 (12/12), 056 (14/14).
- `docs/cli-reference.md` updated.

Staging ingest is stalled until an image with this lands.