### PR TITLE
export: bound full-rewrite peak memory by chunking partition writers

### DIFF
--- a/crates/provider/src/export.rs
+++ b/crates/provider/src/export.rs
@@ -82,6 +82,28 @@ pub struct SeriesExportManifest {
 /// File name of the per-series export manifest inside a series export dir.
 pub const MANIFEST_FILE: &str = ".export-manifest.json";
 
+/// Maximum number of Hive partitions written by a single `COPY ... PARTITIONED
+/// BY` statement.
+///
+/// DataFusion's partitioned write holds one open Parquet writer per partition
+/// for the whole statement and never closes one early, even though our source
+/// query is `ORDER BY` the timestamp and therefore visits partitions in order.
+/// Each open writer costs on the order of a megabyte of column and page
+/// buffers, so peak memory tracks *partition count*, not data volume. Measured
+/// on a 1-minute series whose partitioned form is ~100 MB of data:
+///
+/// | partitioning        | partitions | peak     |
+/// |---------------------|-----------:|---------:|
+/// | `year`              |          4 |    50 MB |
+/// | `year,month`        |         48 |   185 MB |
+/// | `year,month,day`    |       1412 |  2042 MB |
+///
+/// Chunking the rewrite bounds that cost, at the price of one enumeration pass
+/// over the timestamp column plus one source scan per chunk. The budget is
+/// deliberately conservative: wider schemas hold more per-writer buffers, and
+/// the export runs alongside the rest of a site build.
+const MAX_OPEN_PARTITIONS: usize = 128;
+
 /// Hierarchical metadata structure for export results
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
@@ -698,16 +720,21 @@ async fn export_one_partition(
     Ok(crate::version_cache::file_blake3(abs_file)?)
 }
 
-/// Full-rewrite export via a single `COPY ... PARTITIONED BY` (one source scan).
+/// Full-rewrite export via `COPY ... PARTITIONED BY` (one source scan per chunk).
 ///
 /// This is the fast path taken when no prior output can be reused (first build,
-/// missing seed manifest, or an unbounded `changed_since`). It writes every
-/// partition in one DataFusion pass -- as opposed to `export_one_partition`,
-/// which rescans the source once per partition and is only appropriate for the
-/// small changed-partition tail of an incremental reconcile. DataFusion emits
-/// one UUID-named parquet per Hive partition; each is renamed to the
-/// deterministic `data.parquet` so a later build can reuse it by path, and its
-/// blake3 digest is recorded in the returned manifest.
+/// missing seed manifest, or an unbounded `changed_since`). It writes the
+/// partitions in as few DataFusion passes as the [`MAX_OPEN_PARTITIONS`] writer
+/// budget allows -- as opposed to `export_one_partition`, which rescans the
+/// source once per partition and is only appropriate for the small
+/// changed-partition tail of an incremental reconcile. DataFusion emits one
+/// UUID-named parquet per Hive partition; each is renamed to the deterministic
+/// `data.parquet` so a later build can reuse it by path, and its blake3 digest
+/// is recorded in the returned manifest.
+///
+/// Chunking does not change the output: each chunk selects a disjoint set of
+/// partitions, so every partition is written exactly once, by exactly one
+/// statement, from the same rows it would have received from a single COPY.
 async fn full_rewrite_partitioned(
     ctx: &datafusion::prelude::SessionContext,
     table: &str,
@@ -719,37 +746,58 @@ async fn full_rewrite_partitioned(
     source_label: &str,
     hint: Option<&tinyfs::ExportHint>,
 ) -> Result<(Vec<(Vec<String>, ExportOutput)>, SeriesExportManifest)> {
-    let temporal_columns = temporal_parts
-        .iter()
-        .map(|p| {
-            format!(
-                "CAST(date_part('{}', \"{}\") AS BIGINT) AS {}",
-                p, timestamp_column, p
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
-    let select = if temporal_parts.is_empty() {
-        format!("SELECT * FROM \"{table}\" ORDER BY \"{timestamp_column}\"")
+    // Enumerate the partitions up front so the rewrite can be split when there
+    // are more of them than one statement should hold writers for.
+    let partitions = if temporal_parts.is_empty() {
+        Vec::new()
     } else {
-        format!("SELECT *, {temporal_columns} FROM \"{table}\" ORDER BY \"{timestamp_column}\"")
+        distinct_partitions(ctx, table, temporal_parts, timestamp_column, source_label).await?
     };
-    let mut copy_sql = format!(
-        "COPY ({select}) TO '{}' STORED AS PARQUET",
-        export_dir.to_string_lossy()
-    );
-    if !temporal_parts.is_empty() {
-        copy_sql.push_str(&format!(" PARTITIONED BY ({})", temporal_parts.join(", ")));
+
+    if partitions.len() > MAX_OPEN_PARTITIONS {
+        let chunks: Vec<&[Vec<(String, i64)>]> = partitions.chunks(MAX_OPEN_PARTITIONS).collect();
+        log::debug!(
+            "full-rewrite export: {} partitions for '{}' exceed the {}-writer budget; \
+             rewriting in {} chunks",
+            partitions.len(),
+            source_label,
+            MAX_OPEN_PARTITIONS,
+            chunks.len()
+        );
+        for (i, chunk) in chunks.iter().enumerate() {
+            // Each chunk writes to its own directory and is then moved into
+            // place. Writing every chunk straight into `export_dir` would rely
+            // on DataFusion appending rather than replacing the directory
+            // contents; staging keeps the result independent of that.
+            let chunk_dir = export_dir.join(format!(".chunk-{i}"));
+            if chunk_dir.exists() {
+                std::fs::remove_dir_all(&chunk_dir)?;
+            }
+            std::fs::create_dir_all(&chunk_dir)?;
+            run_partitioned_copy(
+                ctx,
+                table,
+                temporal_parts,
+                timestamp_column,
+                &chunk_dir,
+                Some(chunk),
+                source_label,
+            )
+            .await?;
+            merge_chunk_dir(&chunk_dir, export_dir, source_label)?;
+        }
+    } else {
+        run_partitioned_copy(
+            ctx,
+            table,
+            temporal_parts,
+            timestamp_column,
+            export_dir,
+            None,
+            source_label,
+        )
+        .await?;
     }
-    log::debug!("full-rewrite export SQL: {}", copy_sql);
-    let df = ctx
-        .sql(&copy_sql)
-        .await
-        .map_err(|e| anyhow::anyhow!("COPY failed for '{}': {}", source_label, e))?;
-    _ = df
-        .collect()
-        .await
-        .map_err(|e| anyhow::anyhow!("COPY stream failed for '{}': {}", source_label, e))?;
 
     // DataFusion wrote one UUID-named parquet per Hive partition. Rename each to
     // the deterministic `data.parquet` and record its digest + temporal bounds.
@@ -803,6 +851,128 @@ async fn full_rewrite_partitioned(
     results.sort_by(|a, b| a.1.file.cmp(&b.1.file));
     manifest.partitions.sort_by(|a, b| a.file.cmp(&b.file));
     Ok((results, manifest))
+}
+
+/// Build the predicate selecting exactly the partitions in `chunk`.
+///
+/// Each partition contributes one conjunction of `date_part(...) = value`
+/// equalities -- the same form `export_one_partition` uses for a single
+/// partition -- and the chunk is their disjunction. Chunks partition the
+/// enumerated tuples, so the predicates are mutually exclusive and jointly
+/// cover every partition.
+fn partition_chunk_predicate(chunk: &[Vec<(String, i64)>], timestamp_column: &str) -> String {
+    chunk
+        .iter()
+        .map(|part| {
+            let conj = part
+                .iter()
+                .map(|(name, value)| {
+                    format!(
+                        "CAST(date_part('{}', \"{}\") AS BIGINT) = {}",
+                        name, timestamp_column, value
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            format!("({conj})")
+        })
+        .collect::<Vec<_>>()
+        .join(" OR ")
+}
+
+/// Run one `COPY ... PARTITIONED BY` into `target_dir`.
+///
+/// `chunk` restricts the statement to a subset of partitions; `None` writes the
+/// whole source in one pass.
+async fn run_partitioned_copy(
+    ctx: &datafusion::prelude::SessionContext,
+    table: &str,
+    temporal_parts: &[String],
+    timestamp_column: &str,
+    target_dir: &Path,
+    chunk: Option<&[Vec<(String, i64)>]>,
+    source_label: &str,
+) -> Result<()> {
+    let temporal_columns = temporal_parts
+        .iter()
+        .map(|p| {
+            format!(
+                "CAST(date_part('{}', \"{}\") AS BIGINT) AS {}",
+                p, timestamp_column, p
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let where_sql = match chunk {
+        Some(c) => format!(" WHERE {}", partition_chunk_predicate(c, timestamp_column)),
+        None => String::new(),
+    };
+    let select = if temporal_parts.is_empty() {
+        format!("SELECT * FROM \"{table}\"{where_sql} ORDER BY \"{timestamp_column}\"")
+    } else {
+        format!(
+            "SELECT *, {temporal_columns} FROM \"{table}\"{where_sql} ORDER BY \"{timestamp_column}\""
+        )
+    };
+    let mut copy_sql = format!(
+        "COPY ({select}) TO '{}' STORED AS PARQUET",
+        target_dir.to_string_lossy()
+    );
+    if !temporal_parts.is_empty() {
+        copy_sql.push_str(&format!(" PARTITIONED BY ({})", temporal_parts.join(", ")));
+    }
+    log::debug!("full-rewrite export SQL: {}", copy_sql);
+    let df = ctx
+        .sql(&copy_sql)
+        .await
+        .map_err(|e| anyhow::anyhow!("COPY failed for '{}': {}", source_label, e))?;
+    _ = df
+        .collect()
+        .await
+        .map_err(|e| anyhow::anyhow!("COPY stream failed for '{}': {}", source_label, e))?;
+    Ok(())
+}
+
+/// Move a chunk's partition tree into the export directory and remove the
+/// staging directory.
+///
+/// Chunks write disjoint partitions, so no destination file can already exist.
+/// A collision means two chunks claimed the same partition -- a correctness bug
+/// in the chunking, not a condition to resolve by overwriting -- so it is a hard
+/// failure.
+fn merge_chunk_dir(chunk_dir: &Path, export_dir: &Path, source_label: &str) -> Result<()> {
+    fn move_tree(dir: &Path, chunk_root: &Path, export_dir: &Path, label: &str) -> Result<()> {
+        for entry in std::fs::read_dir(dir)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                move_tree(&path, chunk_root, export_dir, label)?;
+                continue;
+            }
+            let rel = path
+                .strip_prefix(chunk_root)
+                .map_err(|e| anyhow::anyhow!("chunk path outside its staging dir: {}", e))?;
+            let dst = export_dir.join(rel);
+            if dst.exists() {
+                return Err(anyhow::anyhow!(
+                    "Chunked export produced partition '{}' twice for '{}'; \
+                     chunks must cover disjoint partitions.",
+                    rel.display(),
+                    label
+                ));
+            }
+            if let Some(parent) = dst.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::rename(&path, &dst).map_err(|e| {
+                anyhow::anyhow!("Failed to publish chunk file '{}': {}", dst.display(), e)
+            })?;
+        }
+        Ok(())
+    }
+
+    move_tree(chunk_dir, chunk_dir, export_dir, source_label)?;
+    std::fs::remove_dir_all(chunk_dir)?;
+    Ok(())
 }
 
 /// Verify a partition file's bytes match a recorded digest, hard-failing on a
@@ -1520,6 +1690,98 @@ mod tests {
             assert_eq!(
                 p.digest,
                 crate::version_cache::file_blake3(&base.join(&p.file)).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn partition_chunk_predicate_is_a_disjunction_of_partition_equalities() {
+        let chunk = vec![
+            vec![("year".to_string(), 2025), ("month".to_string(), 6)],
+            vec![("year".to_string(), 2025), ("month".to_string(), 7)],
+        ];
+        let sql = partition_chunk_predicate(&chunk, "timestamp");
+        assert_eq!(
+            sql,
+            "(CAST(date_part('year', \"timestamp\") AS BIGINT) = 2025 AND \
+             CAST(date_part('month', \"timestamp\") AS BIGINT) = 6) OR \
+             (CAST(date_part('year', \"timestamp\") AS BIGINT) = 2025 AND \
+             CAST(date_part('month', \"timestamp\") AS BIGINT) = 7)"
+        );
+    }
+
+    /// A full rewrite whose partition count exceeds the writer budget is split
+    /// into several `COPY` statements. The split must be invisible: every
+    /// partition still appears exactly once, holding exactly its own rows, and
+    /// no staging directory survives to confuse partition discovery.
+    #[tokio::test]
+    async fn test_export_chunks_large_partition_counts_without_changing_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        let export_dir = base.join("WellDepth/res=1m");
+        let ctx = create_provider_context();
+        let parts = vec!["year".to_string(), "month".to_string(), "day".to_string()];
+
+        // One row per day, over enough days to force multiple chunks.
+        let days = MAX_OPEN_PARTITIONS * 2 + 5;
+        let start = ts(2024, 1, 1);
+        let rows: Vec<(i64, f64)> = (0..days)
+            .map(|i| (start + (i as i64) * 86_400, i as f64))
+            .collect();
+
+        let (results, _schema) = export_table_provider_to_parquet(
+            mem_table(&rows),
+            "welldepth",
+            &export_dir,
+            &parts,
+            &["x".into()],
+            base,
+            &ctx,
+            "timestamp",
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(results.len(), days, "every day must yield one partition");
+
+        // No staging directory may remain: discovery walks the whole tree and
+        // would otherwise pick up chunk files under a bogus partition path.
+        for entry in std::fs::read_dir(&export_dir).unwrap() {
+            let name = entry.unwrap().file_name();
+            assert!(
+                !name.to_string_lossy().starts_with(".chunk-"),
+                "chunk staging dir left behind: {:?}",
+                name
+            );
+        }
+
+        // Each partition holds exactly the single row belonging to that day,
+        // which is only true if the chunk predicates were disjoint and total.
+        let manifest = read_series_manifest(&export_dir.join(MANIFEST_FILE))
+            .unwrap()
+            .unwrap();
+        assert_eq!(manifest.partitions.len(), days);
+        for (i, row) in rows.iter().enumerate() {
+            let date = chrono::DateTime::from_timestamp(row.0, 0)
+                .unwrap()
+                .date_naive();
+            use chrono::Datelike;
+            let file = export_dir
+                .join(format!("year={}", date.format("%Y")))
+                .join(format!("month={}", date.month()))
+                .join(format!("day={}", date.day()))
+                .join("data.parquet");
+            assert!(file.exists(), "missing partition for day {i}: {file:?}");
+
+            let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+                std::fs::File::open(&file).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(
+                reader.metadata().file_metadata().num_rows(),
+                1,
+                "partition {file:?} should hold exactly its own row"
             );
         }
     }

--- a/docs/archive/sitegen-export-memory.md
+++ b/docs/archive/sitegen-export-memory.md
@@ -4,6 +4,21 @@ Status: analysis. Code-grounded as of 2026-07-01. Measurements taken on
 watershop against a copy of the prod site pond (pond 0.52.0). Citations use
 `crate/file.rs:line`. Nothing here is implemented yet.
 
+Update 2026-08-03: two of the items below have since landed, and the §1
+measurements no longer describe current behaviour.
+
+- Incremental export landed: deterministic per-partition `data.parquet` names
+  plus an `.export-manifest.json` of digests let a build reuse unchanged
+  partitions. Warm site builds now peak at ~405 MB rather than ~2.1 GB.
+- The full-rewrite fan-out is now bounded. `full_rewrite_partitioned` splits the
+  rewrite into chunks of at most `MAX_OPEN_PARTITIONS` partitions, so a cold
+  build no longer holds ~1400 partition writers open at once. Re-measured on
+  prod data, peak scales as ~50 MB + ~1.4 MB per open writer, which matches the
+  2148 MB / 1381 writers recorded in §1.
+- P0 (allocator tuning, `MALLOC_ARENA_MAX`) is still NOT implemented, and the
+  `analysis` stage's O(history) recompute (P1/P5) is still unmeasured. Those
+  remain the open levers on peak RSS.
+
 Goal: run the whole Caspar Water site build (sitegen exporting from the site
 pond, which imports the water/septic/noyo subponds) on a low-memory machine.
 This document captures what was measured, how to reproduce the sampling, the

--- a/docs/archive/sitegen-export-memory.md
+++ b/docs/archive/sitegen-export-memory.md
@@ -1,11 +1,13 @@
 # Sitegen full-site build: memory profile and incremental-export plan
 
-Status: analysis. Code-grounded as of 2026-07-01. Measurements taken on
-watershop against a copy of the prod site pond (pond 0.52.0). Citations use
-`crate/file.rs:line`. Nothing here is implemented yet.
+Status: partly implemented; see the 2026-08-03 update below for what has landed
+and what these measurements no longer describe. Code-grounded as of 2026-07-01.
+Measurements taken on watershop against a copy of the prod site pond
+(pond 0.52.0). Citations use `crate/file.rs:line`.
 
-Update 2026-08-03: two of the items below have since landed, and the §1
-measurements no longer describe current behaviour.
+Update 2026-08-03: the plan in §5 has been worked through -- two items landed,
+one was measured and rejected, and the remaining one is characterized in §6.
+The §1 measurements no longer describe current behaviour.
 
 - Incremental export landed: deterministic per-partition `data.parquet` names
   plus an `.export-manifest.json` of digests let a build reuse unchanged
@@ -15,9 +17,25 @@ measurements no longer describe current behaviour.
   build no longer holds ~1400 partition writers open at once. Re-measured on
   prod data, peak scales as ~50 MB + ~1.4 MB per open writer, which matches the
   2148 MB / 1381 writers recorded in §1.
-- P0 (allocator tuning, `MALLOC_ARENA_MAX`) is still NOT implemented, and the
-  `analysis` stage's O(history) recompute (P1/P5) is still unmeasured. Those
-  remain the open levers on peak RSS.
+- P0 (allocator tuning, `MALLOC_ARENA_MAX`) was implemented and measured, and
+  **did not reproduce the predicted win, so it was not adopted.** Running the
+  same 1412-partition single-series export with and without
+  `MALLOC_ARENA_MAX=2` / `MALLOC_TRIM_THRESHOLD_=131072` /
+  `MALLOC_MMAP_THRESHOLD_=131072` gave peak RSS of 431 MB both times. The
+  variables were confirmed present in the container's environment, and the
+  runtime is glibc 2.36 with `PanicOnLargeAlloc` wrapping the system allocator,
+  so the tunables were genuinely active and genuinely inert.
+- That experiment also showed **tracked heap badly overstates RSS on the export
+  path**: the same run reported 2016 MB of PEAK_ALLOC heap but only 431 MB of
+  peak RSS (cgroup `memory.peak`). The per-partition parquet writer buffers are
+  largely allocated-but-untouched pages. So on this workload the ~2 GB figure
+  was never resident memory, and the effective ceiling was the
+  `PanicOnLargeAlloc::new(3000)` accounting guard rather than RAM.
+- Caveat: the §1 "~2629 MB RSS" was a *full* site build across all series with
+  ~60 threads, not the single-series export measured above. Full-build RSS has
+  not been re-measured, so §1's RSS-above-heap relationship may still hold there.
+- P1 (the `analysis` stage) is now measured, and it is the remaining peak once
+  exports are bounded -- see §6.
 
 Goal: run the whole Caspar Water site build (sitegen exporting from the site
 pond, which imports the water/septic/noyo subponds) on a low-memory machine.
@@ -189,3 +207,61 @@ still hold the peak after export and merge are fixed -- confirm its share first.
 Note: the noyo subsite recomputes cold every build (~15 s/series, ~340 s of wall
 time) -- a TIME cost, not a memory-peak cost. Separate optimization (a subsite
 export cache).
+
+---
+
+## 6. The analysis stage (measured 2026-08-03)
+
+With exports bounded, the `analysis` stage sets the peak for a warm build.
+Measured on prod/staging data via `pond cat` on each series (each `pond run`
+step is its own process, so `Peak memory usage` attributes per step):
+
+| Query | Tracked heap peak |
+| --- | --- |
+| `COUNT(*)` over the same source | 9.16 MB |
+| one `SUM(...) OVER (ORDER BY timestamp ROWS UNBOUNDED PRECEDING)` | 83.57 MB |
+| `horner-by-month` | 402.05 MB |
+| `drawdown-by-month` | 442.55 MB (staging) / 482.41 MB (prod) |
+
+Reading: the source scan streams (9 MB), and the sort plus a single unbounded
+window costs ~75 MB more. Neither explains 442 MB. The cost is the *shape* of
+`drawdown-by-month`: a `with_meta` CTE (itself three unbounded windows) is
+referenced five times -- by four filter CTEs that are then joined back
+pairwise. DataFusion does not materialize CTEs, so that window pipeline is
+re-evaluated per reference and each join builds a hash table over the full
+event history.
+
+### What was tried and rejected
+
+Bounding the windows with `PARTITION BY month` (adding a `month_start` column
+and partitioning the three full-history windows) measured **475.07 MB against a
+442.55 MB baseline -- slightly worse.** DataFusion does not infer that
+`date_trunc('month', timestamp)` is monotone in `timestamp`, so it sorts on
+`[month_start, timestamp]` and still materializes, now with a wider sort key.
+
+That rewrite is also non-trivial to make *correct*: `pump_event_id` is a running
+`SUM` over all history, so partitioning it by month restarts the counter and
+makes January's event 1 collide with February's event 1 in every downstream
+`PARTITION BY pump_event_id`. A correct version needs a composite key such as
+`epoch(month_start) * 1000000 + pump_seq`, and `WHERE pump_event_id > 0` must
+become `WHERE pump_seq > 0` once the key is unconditionally positive.
+
+### Open lead
+
+Nothing in the chain advertises its output ordering:
+`NullPaddingExec::compute_properties` (`transform/null_padding.rs`) and
+`ColumnRenameExec` (`transform/column_rename.rs`) both build
+`EquivalenceProperties::new(schema)` -- empty -- explicitly preserving
+partitioning, emission type and boundedness while discarding any child
+ordering. Both operators are row-preserving (null padding only adds columns;
+rename only renames them), so propagating the child's ordering through them,
+mapped across the schema change, should be sound and would let the windows'
+required `ORDER BY timestamp` stream. `factory/temporal_reduce.rs` already
+treats declared `output_ordering` as the mechanism for streaming a
+full-history `ORDER BY`, and `partial_aggregate_cache.rs` already uses
+`with_file_sort_order`.
+
+**Prerequisite before acting on this:** declaring an ordering that does not
+hold silently corrupts results. Series versions are appended in time order, but
+whether a concatenated multi-version series is *globally* sorted by timestamp
+(no cross-version overlap) has not been established. Settle that first.

--- a/docs/archive/sitegen-export-memory.md
+++ b/docs/archive/sitegen-export-memory.md
@@ -231,13 +231,43 @@ pairwise. DataFusion does not materialize CTEs, so that window pipeline is
 re-evaluated per reference and each join builds a hash table over the full
 event history.
 
+### Measurement noise: read this before trusting any number here
+
+Peak heap on the analysis stage varies **±30% run to run for a byte-identical
+query**. Six interleaved repetitions of `drawdown-by-month` on unchanged
+staging data gave 390, 398, 400, 401, 474 and 515 MB (median 400.6).
+
+Consequently **single-shot A/B comparisons of this stage are meaningless**, and
+several earlier entries in this document that were taken as single samples
+should be read as "no measured difference" rather than as the small deltas they
+report. Always interleave at least six repetitions and compare medians.
+
 ### What was tried and rejected
 
-Bounding the windows with `PARTITION BY month` (adding a `month_start` column
-and partitioning the three full-history windows) measured **475.07 MB against a
-442.55 MB baseline -- slightly worse.** DataFusion does not infer that
-`date_trunc('month', timestamp)` is monotone in `timestamp`, so it sorts on
-`[month_start, timestamp]` and still materializes, now with a wider sort key.
+**Fusing the four qualifier CTEs (rejected).** `long_enough`, `clean_start`,
+`real_drawdown` and `not_stale` are all
+`SELECT pump_event_id FROM with_meta GROUP BY pump_event_id HAVING <pred>`,
+each joined back to `with_meta` on that same key. They collapse into a single
+grouped aggregate with the four predicates ANDed (using
+`MIN/MAX/SUM(CASE WHEN ... END)` so no `FILTER` support is required), taking
+`with_meta` from five scans to two and from four hash joins to one.
+
+Output equivalence was verified exactly: wrapping both variants in an
+order-independent integer digest (`COUNT(*)`, summed `elapsed_s`, summed `n`,
+and the three percentile columns summed as `CAST(ROUND(x*1e6) AS BIGINT)`)
+produced identical values on all eight columns over 5924 output rows.
+
+Despite doing strictly less relational work, its peak heap measured **higher**:
+median 467.5 MB against a 400.6 MB baseline over six interleaved repetitions.
+Peak heap on this stage is evidently not proportional to the amount of
+relational work, so the rewrite was not adopted.
+
+**Bounding the windows with `PARTITION BY month` (rejected).** Measured 475 MB
+against a 442 MB baseline -- but as a single sample, i.e. inside the noise band,
+so the honest reading is "no improvement demonstrated". DataFusion does not
+infer that `date_trunc('month', timestamp)` is monotone in `timestamp`, so it
+sorts on `[month_start, timestamp]` and still materializes, now with a wider
+sort key.
 
 That rewrite is also non-trivial to make *correct*: `pump_event_id` is a running
 `SUM` over all history, so partitioning it by month restarts the counter and
@@ -246,22 +276,33 @@ makes January's event 1 collide with February's event 1 in every downstream
 `epoch(month_start) * 1000000 + pump_seq`, and `WHERE pump_event_id > 0` must
 become `WHERE pump_seq > 0` once the key is unconditionally positive.
 
-### Open lead
+### Declaring a source ordering: ruled out
 
-Nothing in the chain advertises its output ordering:
-`NullPaddingExec::compute_properties` (`transform/null_padding.rs`) and
-`ColumnRenameExec` (`transform/column_rename.rs`) both build
-`EquivalenceProperties::new(schema)` -- empty -- explicitly preserving
-partitioning, emission type and boundedness while discarding any child
-ordering. Both operators are row-preserving (null padding only adds columns;
-rename only renames them), so propagating the child's ordering through them,
-mapped across the schema change, should be sound and would let the windows'
-required `ORDER BY timestamp` stream. `factory/temporal_reduce.rs` already
-treats declared `output_ordering` as the mechanism for streaming a
-full-history `ORDER BY`, and `partial_aggregate_cache.rs` already uses
-`with_file_sort_order`.
+It looked promising to propagate output ordering through the row-preserving
+`NullPaddingExec` and `ColumnRenameExec` (both build an empty
+`EquivalenceProperties::new(schema)`, discarding any child ordering) so the
+windows' `ORDER BY timestamp` could stream instead of sorting.
 
-**Prerequisite before acting on this:** declaring an ordering that does not
-hold silently corrupts results. Series versions are appended in time order, but
-whether a concatenated multi-version series is *globally* sorted by timestamp
-(no cross-version overlap) has not been established. Settle that first.
+**This is unsound for these sources.** The concatenated multi-version ingest
+series are only *mostly* timestamp-sorted; there are genuinely out-of-order
+sections, which is why the rollups carry a max-late-arrival setting.
+`allowed_lateness` cannot be borrowed as a disorder bound either: it is a
+cache-freezing policy that explicitly tolerates being violated -- "Data
+arriving older than the sealed watermark is not an error: the segments covering
+it are unsealed and recomputed from source" (`factory/temporal_reduce.rs`).
+Declaring an ordering that does not actually hold would silently corrupt window
+results.
+
+It would also not be worth much: the sort is not the expensive part. The source
+scan streams at 9 MB and adding one unbounded window costs only 84 MB, against
+a ~400 MB total.
+
+### Where this leaves the analysis stage
+
+No query-shape change tried so far moves the peak outside the noise band, and
+peak RSS for pond runs is well under the tracked-heap figure anyway (§ the
+2026-08-03 update). The analysis stage sits at roughly 400-500 MB tracked heap
+and is not currently the thing preventing a 1-2 GB machine from working.
+Further effort here should start by establishing a *repeatable* measurement
+(medians over interleaved repetitions, ideally with `target_partitions` pinned
+so scheduling variance is removed) before any more rewrites are attempted.


### PR DESCRIPTION
Bounds the cold site build's peak memory, which was pinned at ~2 GB and blocks running the pond on a 1–2 GB machine.

## Root cause

A full-rewrite export issued one `COPY ... PARTITIONED BY` covering every partition. DataFusion holds one open Parquet writer per partition for the whole statement and never closes one early — even though the source query is `ORDER BY` the timestamp and therefore visits partitions in order. Peak memory tracks **partition count**, not data volume.

Measured on prod water data, re-exporting the *same* 1-minute series at different partition depths:

| partitioning | partitions | peak |
|---|---:|---:|
| `year` | 4 | 50 MB |
| `year,month` | 48 | 185 MB |
| `year,month,day` | 1412 | **2042 MB** |

The last row is the cold site build: the `1m` resolution auto-partitions by day, so ~1400 writers stay open to write ~100 MB of data (1440 rows per file). Roughly `50 MB + 1.4 MB × writers`.

`docs/archive/sitegen-export-memory.md` recorded the same fan-out in July (2148 MB for 1381 writers), but only the *incremental* half of that plan was implemented — which is why warm builds are ~405 MB while a cold build still hit ~2 GB.

## Change

Enumerate partitions first and, above `MAX_OPEN_PARTITIONS` (128), rewrite them in chunks.

Output is unchanged: each chunk selects a **disjoint** set of partitions by predicate, so every partition is written exactly once from the same rows a single COPY would have given it — same file names, same digests, so manifest reuse is unaffected. Chunks stage into their own directory and are moved into place, so correctness does not depend on whether DataFusion appends to or replaces a non-empty target directory.

Expected effect: cold build peak ~2042 MB → ~230 MB, and now bounded independently of how much history accumulates. Cost is one enumeration pass plus one source scan per chunk, on the cold path only.

## Verification

- `cargo test --workspace` — 0 failures
- `cargo clippy -p provider --all-targets -- -D warnings` — clean
- testsuite `045`, `049`, `052`, `208` — pass
- New `test_export_chunks_large_partition_counts_without_changing_output` forces 261 partitions across 3 chunks and asserts every day-partition exists exactly once holding exactly its own row (proving the chunk predicates are disjoint and total), and that no staging directory survives.
- New unit test pins the predicate form.

Directly measured on prod: restricting the same export to a single year (365 day-partitions) peaked at 530 MB, interpolating the model correctly.