### PR TITLE
Answer remote blob presence with one listing, not a probe per blob

### DIFF
--- a/crates/steward/src/content_pull.rs
+++ b/crates/steward/src/content_pull.rs
@@ -168,7 +168,10 @@ async fn descend_from_tip(
     if let Some((_, tip_commit)) = graph.commits.first() {
         let root = tip_commit.root_tree_hash;
         let manifest_hash = tip_commit.node_manifest_hash;
-        fetch_tree(remote, root, &mut graph).await?;
+        // Populated on first use by `fetch_blob`, so a closure with no external
+        // blobs never spends a request asking about them.
+        let mut blob_index: Option<std::collections::HashSet<ObjectHash>> = None;
+        fetch_tree(remote, root, &mut graph, &mut blob_index).await?;
         graph.manifest = fetch_manifest(remote, manifest_hash).await?;
     }
 
@@ -190,6 +193,7 @@ async fn fetch_tree(
     remote: &dyn ContentSource,
     tree_hash: ObjectHash,
     graph: &mut FetchedGraph,
+    blob_index: &mut Option<std::collections::HashSet<ObjectHash>>,
 ) -> Result<(), StewardError> {
     // Iterative worklist to avoid async recursion on the directory tree.
     let mut stack = vec![tree_hash];
@@ -209,7 +213,7 @@ async fn fetch_tree(
             match entry.entry_type {
                 EntryType::DirectoryPhysical => stack.push(entry.child_hash),
                 EntryType::FilePhysicalSeries | EntryType::TablePhysicalSeries => {
-                    fetch_series(remote, entry.child_hash, graph).await?;
+                    fetch_series(remote, entry.child_hash, graph, blob_index).await?;
                 }
                 EntryType::FilePhysicalVersion
                 | EntryType::TablePhysicalVersion
@@ -217,7 +221,7 @@ async fn fetch_tree(
                 | EntryType::DirectoryDynamic
                 | EntryType::FileDynamic
                 | EntryType::TableDynamic => {
-                    fetch_blob(remote, entry.child_hash, graph).await?;
+                    fetch_blob(remote, entry.child_hash, graph, blob_index).await?;
                 }
             }
         }
@@ -230,6 +234,7 @@ async fn fetch_series(
     remote: &dyn ContentSource,
     series_hash: ObjectHash,
     graph: &mut FetchedGraph,
+    blob_index: &mut Option<std::collections::HashSet<ObjectHash>>,
 ) -> Result<(), StewardError> {
     if graph.objects.contains_key(&series_hash) {
         return Ok(());
@@ -242,7 +247,7 @@ async fn fetch_series(
         .insert(series_hash, FetchedObject::Series(versions.clone()));
     let _ = graph.bytes.insert(series_hash, bytes);
     for version in versions {
-        fetch_blob(remote, version, graph).await?;
+        fetch_blob(remote, version, graph, blob_index).await?;
     }
     Ok(())
 }
@@ -256,6 +261,7 @@ async fn fetch_blob(
     remote: &dyn ContentSource,
     hash: ObjectHash,
     graph: &mut FetchedGraph,
+    blob_index: &mut Option<std::collections::HashSet<ObjectHash>>,
 ) -> Result<(), StewardError> {
     if graph.objects.contains_key(&hash) {
         return Ok(());
@@ -275,11 +281,21 @@ async fn fetch_blob(
     // Not an inline row: it must be a large external blob in the remote blob
     // store.  Confirm its presence now so a missing object still fails the fetch
     // early, but do not download it -- its bytes stream at rebuild time.
-    if !remote
-        .has_blob(hash)
-        .await
-        .map_err(|e| StewardError::Content(e.to_string()))?
-    {
+    //
+    // Presence comes from a single listing taken on first use, not a probe per
+    // blob: probing costs a request for every blob in the closure, which is a
+    // cost proportional to the pond's history rather than to what the pull
+    // actually transfers.
+    let index = match blob_index {
+        Some(index) => index,
+        none => none.insert(
+            remote
+                .list_blobs()
+                .await
+                .map_err(|e| StewardError::Content(e.to_string()))?,
+        ),
+    };
+    if !index.contains(&hash) {
         return Err(StewardError::Content(format!(
             "object {} is absent from the remote (inline and blob store)",
             hash.to_hex()

--- a/crates/steward/src/content_push.rs
+++ b/crates/steward/src/content_push.rs
@@ -151,14 +151,29 @@ pub async fn push_content_to_remote_limited(
     // streamed local->remote into the remote's content-addressed blob store,
     // keyed by its content hash, never loading the whole blob into memory.  Skip
     // blobs the remote already holds so re-pushes stay cheap.
-    for hash in &materialized.external_blobs {
+    // Ask which blobs the remote already holds ONCE, as a listing, rather than
+    // with a HEAD per blob.  Per-blob probing costs a billed request for every
+    // blob in the pond's accumulated history on every push, including pushes
+    // that upload nothing -- measured at ~180 requests per push on a staging
+    // pond, or ~4300 a day at an hourly cadence, to re-confirm blobs that had
+    // not changed.  That is a cost proportional to history rather than to work,
+    // and it is exactly the kind of quiet spending the budgets exist to catch.
+    // (It was in fact the budget that caught it.)
+    let present_blobs = if materialized.external_blobs.is_empty() {
+        // Nothing to ask about, so do not spend a request asking.
+        std::collections::HashSet::new()
+    } else {
         limits.check(LimitUnit::Ops, 1)?;
-        let present = remote
-            .has_blob(*hash)
+        let listed = remote
+            .list_blobs()
             .await
             .map_err(|e| StewardError::Content(e.to_string()))?;
         limits.record(LimitUnit::Ops, 1);
-        if present {
+        listed
+    };
+
+    for hash in &materialized.external_blobs {
+        if present_blobs.contains(hash) {
             continue;
         }
         // Opening the reader is local and free, and it yields the exact number

--- a/crates/steward/src/content_source.rs
+++ b/crates/steward/src/content_source.rs
@@ -47,7 +47,19 @@ pub trait ContentSource: Send + Sync {
     async fn get_object(&self, hash: ObjectHash) -> Result<Option<Vec<u8>>, StewardError>;
 
     /// True if the source holds the external blob with `hash`.
+    ///
+    /// Prefer [`Self::list_blobs`] when asking about more than a couple of
+    /// blobs: against a remote store this is one billed request per call.
     async fn has_blob(&self, hash: ObjectHash) -> Result<bool, StewardError>;
+
+    /// Every external blob the source holds, as one listing.
+    ///
+    /// Presence is asked about in bulk -- once per blob in a content closure --
+    /// and answering it per blob costs a request proportional to the pond's
+    /// accumulated history rather than to the work being done.  One listing
+    /// answers the whole question, and reads live state exactly as the
+    /// per-blob probes did.
+    async fn list_blobs(&self) -> Result<std::collections::HashSet<ObjectHash>, StewardError>;
 
     /// A bounded streaming reader over the external blob with `hash`, or `None`
     /// if the source does not hold it.
@@ -83,6 +95,12 @@ impl ContentSource for ContentRemote {
 
     async fn has_blob(&self, hash: ObjectHash) -> Result<bool, StewardError> {
         ContentRemote::has_blob(self, hash)
+            .await
+            .map_err(|e| StewardError::Content(e.to_string()))
+    }
+
+    async fn list_blobs(&self) -> Result<std::collections::HashSet<ObjectHash>, StewardError> {
+        ContentRemote::list_blobs(self)
             .await
             .map_err(|e| StewardError::Content(e.to_string()))
     }
@@ -218,6 +236,11 @@ impl ContentSource for LocalPondSource {
 
     async fn has_blob(&self, hash: ObjectHash) -> Result<bool, StewardError> {
         Ok(self.external_blobs.contains(&hash))
+    }
+
+    async fn list_blobs(&self) -> Result<std::collections::HashSet<ObjectHash>, StewardError> {
+        // Already resolved in memory when the producer clone was opened.
+        Ok(self.external_blobs.iter().copied().collect())
     }
 
     async fn get_blob_reader(&self, hash: ObjectHash) -> Result<Option<BlobReader>, StewardError> {

--- a/crates/steward/src/governed_source.rs
+++ b/crates/steward/src/governed_source.rs
@@ -167,6 +167,12 @@ impl ContentSource for GovernedSource<'_> {
         self.inner.has_blob(hash).await
     }
 
+    async fn list_blobs(&self) -> Result<std::collections::HashSet<ObjectHash>, StewardError> {
+        // One listing, one charge -- the point of asking this way.
+        self.begin_op()?;
+        self.inner.list_blobs().await
+    }
+
     async fn get_blob_reader(&self, hash: ObjectHash) -> Result<Option<BlobReader>, StewardError> {
         self.begin_op()?;
         self.check_any_left(LimitUnit::Bytes)?;

--- a/crates/steward/tests/limiter_test.rs
+++ b/crates/steward/tests/limiter_test.rs
@@ -292,3 +292,69 @@ async fn each_dimension_reports_separately() {
     assert_eq!(rows[1].unit, "ops");
     assert_eq!(rows[1].amount, 3);
 }
+
+/// A re-push must not cost a request per blob the pond has ever retained.
+///
+/// Confirming blob presence with a probe per blob makes every push cost a
+/// billed request for each blob in the accumulated history, even when the push
+/// uploads nothing at all -- a bill proportional to how long the pond has
+/// existed rather than to what it just did.  A single listing answers the same
+/// question, so a no-op re-push spends a small constant regardless of how many
+/// blobs are retained.  This is the finding the ops budget surfaced in staging;
+/// the test exists so it cannot come back unnoticed.
+#[tokio::test]
+async fn a_re_push_does_not_pay_per_retained_blob() {
+    const BLOBS: usize = 8;
+
+    let (_t, mut ship) = new_pond("limiter-push-listing").await;
+    // Generous enough that nothing is refused: the point here is what is
+    // *spent*, not what is denied.
+    write_limiter(&mut ship, "/ops", "ops/day", 100_000.0, None).await;
+
+    // Each file must exceed the 64 KB inline threshold to become an external
+    // blob (Decision D7); distinct contents keep their hashes distinct.
+    for i in 0..BLOBS {
+        let body = vec![b'a' + u8::try_from(i).expect("small index"); 100 * 1024];
+        write_file(&mut ship, &format!("/big{i}.bin"), &body).await;
+    }
+
+    let pond_id = uuid::Uuid::parse_str(ship.data_persistence().pond_id()).expect("pond id");
+    let remote_dir = tempdir().expect("remote dir");
+    let mut remote = ContentRemote::create_at(remote_dir.path().join("remote"), pond_id)
+        .await
+        .expect("create remote");
+
+    // First push: uploads are genuine work and are expected to cost per blob.
+    let mut limits = LimiterSet::open(&mut ship, &[(LimitUnit::Ops, "/ops".to_string())])
+        .await
+        .expect("bind");
+    let _ = push_content_to_remote_limited(&ship, &mut remote, "main", &mut limits)
+        .await
+        .expect("first push");
+    let after_first = limits.states()[0].used;
+    assert!(
+        after_first >= BLOBS as u64,
+        "the first push should have uploaded {BLOBS} blobs, spent {after_first}"
+    );
+    limits
+        .commit(ship.control_table_mut())
+        .await
+        .expect("commit");
+
+    // Second push: the remote already holds every blob, so nothing is
+    // transferred and the cost must not scale with how many are held.
+    let mut limits = LimiterSet::open(&mut ship, &[(LimitUnit::Ops, "/ops".to_string())])
+        .await
+        .expect("rebind");
+    let before_second = limits.states()[0].used;
+    let _ = push_content_to_remote_limited(&ship, &mut remote, "main", &mut limits)
+        .await
+        .expect("second push");
+    let spent = limits.states()[0].used - before_second;
+
+    assert!(
+        spent < BLOBS as u64,
+        "a no-op re-push spent {spent} ops across {BLOBS} retained blobs, \
+         which is the per-blob probing this listing replaced"
+    );
+}

--- a/crates/sync-store/src/content_remote.rs
+++ b/crates/sync-store/src/content_remote.rs
@@ -275,8 +275,50 @@ impl ContentRemote {
         object_store::path::Path::from(format!("_blobs/blob={}", hash.to_hex()))
     }
 
+    /// Every external blob the remote holds, as one listing of the `_blobs/`
+    /// prefix.
+    ///
+    /// This exists because presence is asked about in bulk.  A push must know,
+    /// for each blob its content closure references, whether the remote already
+    /// holds it -- and [`Self::has_blob`] answers that with one `HEAD` per
+    /// blob.  That cost is proportional to the pond's accumulated history
+    /// rather than to the work being done: a pond holding 180 blobs pays 180
+    /// billed requests on every push, including a push that transfers nothing.
+    /// Measured on a staging pond, hourly pushes came to ~4300 requests a day
+    /// purely to re-confirm blobs that had not changed.
+    ///
+    /// One listing answers the same question. `object_store` paginates
+    /// internally at 1000 keys per request, so this is a single request for any
+    /// realistic blob count, and it reads live remote state exactly as the
+    /// per-blob `HEAD`s did -- it is not a cache.
+    pub async fn list_blobs(&self) -> Result<std::collections::HashSet<ObjectHash>> {
+        use futures::StreamExt;
+
+        let prefix = object_store::path::Path::from("_blobs");
+        let mut stream = self.store.object_store().list(Some(&prefix));
+        let mut out = std::collections::HashSet::new();
+        while let Some(meta) = stream.next().await {
+            let meta = meta.map_err(|e| StoreError::Invariant(format!("list blobs: {e}")))?;
+            // Keys are `_blobs/blob=<hex>`; anything else under the prefix is
+            // not ours and is skipped rather than guessed at.
+            let Some(name) = meta.location.filename() else {
+                continue;
+            };
+            let Some(hex) = name.strip_prefix("blob=") else {
+                continue;
+            };
+            if let Ok(hash) = ObjectHash::from_hex(hex) {
+                let _ = out.insert(hash);
+            }
+        }
+        Ok(out)
+    }
+
     /// True if the external blob `hash` is already present in the remote blob
     /// store, so a producer can skip re-uploading it.
+    ///
+    /// Prefer [`Self::list_blobs`] when asking about more than a couple of
+    /// blobs: this is one billed request per call.
     pub async fn has_blob(&self, hash: ObjectHash) -> Result<bool> {
         match self.store.object_store().head(&Self::blob_path(hash)).await {
             Ok(_) => Ok(true),

--- a/docs/rate-limiter-design.md
+++ b/docs/rate-limiter-design.md
@@ -1014,6 +1014,52 @@ that forgets failed attempts is one a retry loop can spend without bound.
 
 ---
 
+## 8c. The first thing the budget caught was not a runaway (Decision L15)
+
+The budgets went out to watershop staging expecting to sit idle -- they were set
+generously, to observe rather than to bite. The first push after the deploy was
+refused:
+
+```
+rate limit /sys/limits/backup-ops exceeded: 200/200 ops used in the last 8640s
+```
+
+That is the `burst` constraint, not the daily one: with `limit: 2000/day` and
+`burst: 200`, the burst window is `200/2000 x 86400 = 8640s`, exactly as
+reported. The instructive part is what it had spent 200 operations *on*. The
+pond held 180 external blobs, and `push_content_to_remote` confirmed each one's
+presence with its own `has_blob` HEAD request before deciding it had nothing to
+upload. The push transferred **86.5 KiB and spent 200 requests doing it**, and
+would have spent the same 200 again an hour later having changed nothing.
+
+The shape of the cost is the real problem. It was proportional to the pond's
+accumulated *history* rather than to the work in front of it, so it grew forever
+and was worst precisely on the quiet ponds that transfer nothing. At the hourly
+timer cadence that is ~4300 billed requests a day against a 2000/day budget, for
+no data movement at all. Nothing was broken; nothing looked wrong in any log;
+the only symptom was a bill.
+
+The fix is that all blob keys share the `_blobs/` prefix, so one listing answers
+the same question the 180 probes answered. `ContentRemote::list_blobs` returns
+the set once; presence is then an in-memory lookup. `object_store` paginates
+internally at 1000 keys, so 180 blobs cost one request. The same probe-per-blob
+loop existed on the pull side in `fetch_blob`, where the listing is taken
+lazily, so a closure with no external blobs still spends nothing asking about
+them.
+
+Two things worth keeping:
+
+- **This is not caching.** The listing reads live remote state in the same
+  round-trip the HEADs would have; it is not a local record of what we believe
+  the remote holds. A budget must never be satisfied by a stale belief.
+- **A budget is a measurement instrument before it is a control.** We installed
+  these limits to stop a runaway, and their first real catch was an inefficiency
+  that had been quietly running the whole time. That is an argument for setting
+  limits early and generously rather than waiting until they can be tuned
+  precisely: an unenforced number nobody is measuring against teaches nothing.
+
+---
+
 ## 9. Summary of decisions
 
 | ID | Decision |
@@ -1033,3 +1079,4 @@ that forgets failed attempts is one a retry loop can spend without bound.
 | L12 | Spending is *also* emitted into the pond as a durable metric series at `/sys/limits/usage`, flushed at the start of the next write transaction. |
 | L13 | `POND_IGNORE_LIMITS` suspends enforcement (not binding) for a seeding import; it logs loudly and discards rather than records what it spent, so an exceptional transfer cannot exhaust the window that governs ordinary traffic. |
 | L14 | Pulls are governed by decorating `ContentSource` (`GovernedSource`), so every ingress path is charged at the remote boundary; a pull refuses to *begin* a transfer on a spent budget rather than checking an unknowable size in advance. |
+| L15 | Remote blob presence is answered by one listing of the `_blobs/` prefix, not a probe per blob: probing costs a billed request for every blob in the pond's history on every push or pull, including ones that transfer nothing. |


### PR DESCRIPTION
## What happened

The ops budget from #130 went out to watershop staging set generously, expected to observe rather than bite. The first push after the deploy was refused:

```
rate limit /sys/limits/backup-ops exceeded: 200/200 ops used in the last 8640s
```

The budget was right. That is the `burst` constraint (`limit: 2000/day`, `burst: 200` gives a `200/2000 x 86400 = 8640s` window, matching the message exactly). The instructive part is what those 200 operations bought: **86.5 KiB transferred**.

The pond holds 180 external blobs. Both `content_push` and `content_pull` confirmed each blob's presence with its own `has_blob` HEAD request, unconditionally, before deciding there was nothing to upload. The next hourly push would have spent the same 200 requests having changed nothing.

The shape of the cost is the actual bug. It was proportional to the pond's accumulated **history** rather than to the work in front of it, so it grew without bound and was worst precisely on the quiet ponds that transfer nothing -- ~4300 billed requests a day at the timer cadence, against a 2000/day budget, for no data movement. Nothing was broken, nothing looked wrong in any log; the only symptom would have been a bill.

## The fix

All blob keys share the `_blobs/` prefix, so a single listing answers the question 180 probes were answering.

- `ContentRemote::list_blobs()` returns the present set; `object_store` paginates internally at 1000 keys, so 180 blobs cost **one** request.
- **Push** takes the listing once (1 op) and does in-memory membership; it skips the listing entirely when there are no external blobs, so a pond with none pays nothing.
- **Pull** threads a lazily-populated index through `descend_from_tip` / `fetch_tree` / `fetch_series` / `fetch_blob` -- lazy for the same reason, and kept private rather than polluting `FetchedGraph`.
- `list_blobs` joins the `ContentSource` trait **with no default implementation**, so every implementation has to answer rather than silently fall back to probing. `GovernedSource` charges it as the single operation it is.

### This is not caching

The listing reads live remote state in the same round-trip the HEADs would have. It is not a local record of what we believe the remote holds. A budget must never be satisfied by a stale belief.

## Test

`a_re_push_does_not_pay_per_retained_blob` pushes twice over 8 retained blobs and asserts the second push -- which transfers nothing -- spends fewer ops than there are blobs. The old loop violated that by construction.

## Documentation

Design doc section 8c and Decision L15, with the measurement.

The wider point recorded there: **a budget is a measurement instrument before it is a control.** We installed these limits to stop a runaway, and their first real catch was an inefficiency that had been running quietly all along. That argues for setting limits early and generously rather than waiting until they can be tuned precisely -- an unenforced number nobody measures against teaches nothing.

## Expected effect, and a follow-up

water-staging's push should drop from ~180 ops to ~2. That will also make the current 2000/day budget look very slack, and it should be re-tuned downward from the new measurements once this is deployed -- a budget nothing ever approaches measures nothing.

## Verification

Run locally, exactly as CI runs them:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test -p steward -p sync-store -p cmd`
- `make check-headers` (REUSE compliant, 709/709)
