### PR TITLE
Inspect maintenance before performing it, reach Azure Blob Storage, and replicate version metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ humantime = "2.1"
 linkme = "0.3"
 log = "0.4.17"
 oauth2 = { version = "5.0", default-features = false, features = ["reqwest", "rustls-tls"] }
-object_store = { version = "0.12", features = ["aws"] }
+object_store = { version = "0.12", features = ["aws", "azure"] }
 opentelemetry-proto = { version = "0.27.0", features = ["gen-tonic-messages", "metrics", "with-serde"] }
 parquet = { version = "57", features = ["async", "arrow"] }
 parse_duration = "2.1.1"

--- a/crates/cmd/src/commands/maintain.rs
+++ b/crates/cmd/src/commands/maintain.rs
@@ -17,6 +17,10 @@ use log::info;
 /// vacuum reclaims it in the SAME pass (no extra ship open / read txn).
 /// Collapse likewise runs before the checkpoint + vacuum, since its
 /// reclamation phase deletes the rows that collapse superseded.
+///
+/// When `dry_run` is true nothing is modified: the command reports what
+/// collapse and prune *would* do and returns.
+#[allow(clippy::fn_params_excessive_bools)]
 pub async fn maintain_command(
     ship_context: &ShipContext,
     compact: bool,
@@ -24,6 +28,7 @@ pub async fn maintain_command(
     prune: bool,
     keep_txns: i64,
     allow_no_remote: bool,
+    dry_run: bool,
 ) -> Result<()> {
     let pond_path = ship_context.resolve_pond_path()?;
     info!("Running maintenance on pond: {}", pond_path.display());
@@ -32,6 +37,17 @@ pub async fn maintain_command(
         .open_pond()
         .await
         .map_err(|e| anyhow!("Failed to open pond: {}", e))?;
+
+    if dry_run {
+        return report_dry_run(
+            &mut ship,
+            collapse_versions,
+            prune,
+            keep_txns,
+            allow_no_remote,
+        )
+        .await;
+    }
 
     // Prune BEFORE maintain so the deletion's tombstones are reclaimed by
     // the checkpoint + vacuum below, in the same maintenance pass.
@@ -93,4 +109,110 @@ pub async fn maintain_command(
 
     info!("[OK] Maintenance completed");
     Ok(())
+}
+
+/// Report what maintenance would do, changing nothing.
+///
+/// Collapse is the operation worth previewing.  It rewrites every live version
+/// of a series into one merged run, and that merged run is new content: it
+/// replicates like any other write, so the next push carries the whole series
+/// again.  Nothing deletes the superseded blobs from the remote, so the space
+/// is spent permanently, and a series larger than the byte budget can reach a
+/// state the limiter will never admit.  Reporting the size beforehand is how
+/// that is caught while it is still a number rather than a bill.
+async fn report_dry_run(
+    ship: &mut steward::Steward,
+    collapse_versions: usize,
+    prune: bool,
+    keep_txns: i64,
+    allow_no_remote: bool,
+) -> Result<()> {
+    let horizon = if prune {
+        Some(
+            crate::commands::control::compute_prune_horizon(ship, keep_txns, allow_no_remote)
+                .await?,
+        )
+    } else {
+        None
+    };
+
+    // Resolve node identities to paths so the report names files rather than
+    // UUIDs.  Done only when there is something to name.
+    let candidates = if collapse_versions > 0 {
+        ship.survey_collapsible_series(collapse_versions).await?
+    } else {
+        Vec::new()
+    };
+    let paths = if candidates.is_empty() {
+        std::collections::HashMap::new()
+    } else {
+        ship.node_paths().await?
+    };
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("Dry run: nothing was modified.");
+
+        if let Some(h) = horizon {
+            if h.horizon < 1 {
+                println!("  control prune: nothing to prune (horizon < 1)");
+            } else {
+                println!(
+                    "  control prune: would delete rows at/below seq {} (last committed {})",
+                    h.horizon, h.last_committed
+                );
+            }
+        }
+
+        if collapse_versions == 0 {
+            println!("  collapse: not requested (pass --collapse-versions N)");
+        } else if candidates.is_empty() {
+            println!("  collapse: no series exceeds {collapse_versions} live versions");
+        } else {
+            let total: u64 = candidates.iter().map(|c| c.total_bytes).sum();
+            println!(
+                "  collapse: {} series exceed {} live versions",
+                candidates.len(),
+                collapse_versions
+            );
+            let mut rows: Vec<_> = candidates.iter().collect();
+            rows.sort_by_key(|c| std::cmp::Reverse(c.total_bytes));
+            for c in rows {
+                let name = paths
+                    .get(&c.file_id)
+                    .map_or_else(|| c.file_id.node_id().to_string(), |p| p.clone());
+                println!(
+                    "    {name}: {} versions -> 1, {}",
+                    c.live_versions,
+                    human_bytes(c.total_bytes)
+                );
+            }
+            println!(
+                "  collapse would rewrite {} as new content, which the next push \n  \
+                 must carry and the remote keeps permanently",
+                human_bytes(total)
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Render a byte count the way the limiter reports its budgets, so a dry-run
+/// figure can be compared against `pond status` without arithmetic.
+fn human_bytes(n: u64) -> String {
+    #[allow(clippy::cast_precision_loss)]
+    let bytes = n as f64;
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes / GIB)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes / KIB)
+    } else {
+        format!("{n} B")
+    }
 }

--- a/crates/cmd/src/commands/status.rs
+++ b/crates/cmd/src/commands/status.rs
@@ -310,8 +310,12 @@ mod tests {
     #[test]
     fn the_storage_line_names_the_profile_and_no_credential() {
         let doc = b"endpoint: http://watershop:9000\naccess_key_id: ${env:S3_KEY}\nsecret_access_key: ${env:S3_SECRET}\n";
-        let profile =
-            steward::ResolvedStorage::from_bytes("/sys/storage/minio", doc).expect("parse");
+        let profile = steward::ResolvedStorage::from_bytes(
+            "/sys/storage/minio",
+            provider::factory::storage_minio::FACTORY_NAME,
+            doc,
+        )
+        .expect("parse");
         let line = format_storage_line("/sys/storage/minio", &Ok(profile.describe()));
 
         assert!(line.contains("/sys/storage/minio"), "{line}");

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -240,6 +240,11 @@ enum Commands {
         /// (retention-only; pruned history is then unrecoverable).
         #[arg(long)]
         allow_no_remote: bool,
+        /// Report what maintenance would do -- which series collapse would
+        /// merge and how many bytes that would push -- without changing
+        /// anything.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Show pond contents
     Show {
@@ -566,6 +571,7 @@ async fn main() -> Result<()> {
             prune,
             keep_txns,
             allow_no_remote,
+            dry_run,
         } => {
             commands::maintain_command(
                 &ship_context,
@@ -574,6 +580,7 @@ async fn main() -> Result<()> {
                 prune,
                 keep_txns,
                 allow_no_remote,
+                dry_run,
             )
             .await
         }

--- a/crates/cmd/tests/control.rs
+++ b/crates/cmd/tests/control.rs
@@ -1703,7 +1703,7 @@ async fn test_maintain_prune_shrinks_in_one_pass() {
     assert!(below_before > 0);
 
     // compact=false, collapse=0, prune=true, keep_txns, allow_no_remote=true.
-    maintain_command(&setup.ship_context, false, 0, true, keep_txns, true)
+    maintain_command(&setup.ship_context, false, 0, true, keep_txns, true, false)
         .await
         .expect("maintain --prune");
 

--- a/crates/cmd/tests/test_apply_remote.rs
+++ b/crates/cmd/tests/test_apply_remote.rs
@@ -704,3 +704,112 @@ async fn an_applied_pull_remote_is_actually_governed() {
         "expected a rate-limit refusal, got: {msg}"
     );
 }
+
+/// Phase A3, end to end: an Azure profile survives `pond apply` and reads back
+/// as an Azure profile.
+///
+/// The round trip is the point.  Dispatch keys off the factory recorded on the
+/// node (Decision A9), so this is what proves the name is actually stored and
+/// returned -- a unit test can only assert that a name it supplied is honoured.
+#[tokio::test]
+async fn an_azure_profile_applies_and_reads_back_as_azure() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let pond = tmp.path().join("pond");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "test-host").await.expect("init");
+
+    apply_yaml(
+        &ctx,
+        tmp.path(),
+        "version: v1\nkind: mknod\nmetadata:\n  path: /sys/storage/azure\nspec:\n  factory: storage-azure\n  config:\n    account_name: casparwater\n    account_key: ${env:PATH}\n",
+    )
+    .await
+    .expect("apply azure profile");
+
+    let mut ship = ctx.open_pond().await.expect("open");
+    let pond = ship.as_pond_mut().expect("pond steward");
+    let profile = steward::ResolvedStorage::open(pond, "/sys/storage/azure")
+        .await
+        .expect("read profile back");
+
+    assert_eq!(profile.kind(), "storage-azure");
+    assert!(profile.serves_scheme("az://container/prefix"));
+    assert!(
+        !profile.serves_scheme("s3://bucket"),
+        "an azure profile must not claim an s3 URL"
+    );
+
+    // The reference survived as text and resolves here, not at apply time
+    // (Decision A6).
+    let opts = profile.to_storage_options().expect("resolve");
+    let path = std::env::var("PATH").expect("PATH is set");
+    assert_eq!(
+        opts.get("account_key").map(String::as_str),
+        Some(path.as_str())
+    );
+    assert_eq!(
+        opts.get("account_name").map(String::as_str),
+        Some("casparwater")
+    );
+}
+
+/// An Azure profile with two credential shapes is refused at `pond apply`,
+/// not stored and left to fail on first push (Decision A4).
+#[tokio::test]
+async fn an_ambiguous_azure_profile_is_refused_at_apply() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let pond = tmp.path().join("pond");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "test-host").await.expect("init");
+
+    let err = apply_yaml(
+        &ctx,
+        tmp.path(),
+        "version: v1\nkind: mknod\nmetadata:\n  path: /sys/storage/azure\nspec:\n  factory: storage-azure\n  config:\n    account_name: casparwater\n    account_key: ${env:PATH}\n    sas_token: ${env:PATH}\n",
+    )
+    .await
+    .expect_err("two credentials must be refused");
+    assert!(format!("{err:#}").contains("exactly one"), "{err:#}");
+}
+
+/// An Azure profile with no credential is refused at apply too: authenticating
+/// with nothing is an outage deferred to first push.
+#[tokio::test]
+async fn an_azure_profile_without_a_credential_is_refused_at_apply() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let pond = tmp.path().join("pond");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "test-host").await.expect("init");
+
+    let err = apply_yaml(
+        &ctx,
+        tmp.path(),
+        "version: v1\nkind: mknod\nmetadata:\n  path: /sys/storage/azure\nspec:\n  factory: storage-azure\n  config:\n    account_name: casparwater\n",
+    )
+    .await
+    .expect_err("no credential must be refused");
+    assert!(format!("{err:#}").contains("exactly one"), "{err:#}");
+}
+
+/// A literal Azure credential must be refused at apply, exactly as a literal
+/// S3 secret is: the node replicates to every backup.
+#[tokio::test]
+async fn a_literal_azure_credential_is_refused_at_apply() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let pond = tmp.path().join("pond");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "test-host").await.expect("init");
+
+    let err = apply_yaml(
+        &ctx,
+        tmp.path(),
+        "version: v1\nkind: mknod\nmetadata:\n  path: /sys/storage/azure\nspec:\n  factory: storage-azure\n  config:\n    account_name: casparwater\n    account_key: hunter2\n",
+    )
+    .await
+    .expect_err("a literal secret must be refused");
+    assert!(format!("{err:#}").contains("account_key"), "{err:#}");
+}

--- a/crates/provider/src/factory/mod.rs
+++ b/crates/provider/src/factory/mod.rs
@@ -11,6 +11,7 @@ pub mod logfile_ingest;
 pub mod materialize_series;
 pub mod rate_limit;
 pub mod sql_derived;
+pub mod storage_azure;
 pub mod storage_minio;
 pub mod synthetic_timeseries;
 pub mod temporal_reduce;

--- a/crates/provider/src/factory/storage_azure.rs
+++ b/crates/provider/src/factory/storage_azure.rs
@@ -1,0 +1,638 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! `storage-azure` factory: declares how to reach an Azure Blob Storage
+//! account.
+//!
+//! See `docs/storage-profile-design.md` §3.2.  Like [`super::storage_minio`],
+//! a storage profile is a **leaf config node**: nothing to compute, nothing to
+//! execute.  It exists so that "this is our Azure account" is stated once, in
+//! the pond, and referenced by path from every remote that talks to it.
+//!
+//! ```yaml
+//! kind: mknod
+//! metadata:
+//!   path: /sys/storage/azure
+//! spec:
+//!   factory: storage-azure
+//!   config:
+//!     account_name: ${env:AZURE_STORAGE_ACCOUNT}
+//!     account_key: ${env:AZURE_STORAGE_KEY}
+//! ```
+//!
+//! # Exactly one credential shape (Decision A4)
+//!
+//! Azure accepts an account key, a SAS token, or a service principal, and this
+//! kind requires **exactly one**.  Zero is an error because a profile that
+//! authenticates with nothing is a failure deferred to first push.  Two is an
+//! error because a profile holding both a key and a SAS token has no
+//! unambiguous intent, and silently preferring one would be the precedence
+//! rule Decision A4 exists to forbid -- an operator who rotated the key and
+//! left the token behind would keep authenticating with the stale one and have
+//! no way to see it.
+//!
+//! This is also the concrete reason `storage-azure` is its own factory rather
+//! than optional fields on a shared struct (Decision A3): "exactly one of three
+//! groups" is not something a flat field set shared with MinIO can state.
+//!
+//! [`StorageAzureConfig::credential`] is the only way to read the credential,
+//! so the exactly-one rule is enforced wherever it is used rather than
+//! remembered at each site.
+//!
+//! # Credentials are references, never values (Decision A1)
+//!
+//! Every credential field MUST be an `${env:...}` reference, rejected at
+//! `pond apply` time otherwise.  A profile node replicates to every backup, so
+//! a literal would be exposed on all of them -- and an Azure account key grants
+//! full control of the account.  `account_name` is exempt: it is an identifier
+//! that appears in every URL, not a secret, and requiring it to be indirect
+//! would obscure which account a profile names without protecting anything.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt;
+use tinyfs::FileHandle;
+use tinyfs::Result as TinyFSResult;
+use tinyfs::ResultExt;
+
+/// The factory name this kind registers under.  Named once here so consumers
+/// that dispatch on it (`steward::storage_profile`) cannot drift from the
+/// registration below.
+pub const FACTORY_NAME: &str = "storage-azure";
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/// An Azure AD service principal: the credential shape used when a pond
+/// authenticates as an application rather than with a shared secret.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServicePrincipal {
+    /// Application (client) id.  Must be an `${env:...}` reference.
+    pub client_id: String,
+    /// Client secret.  Must be an `${env:...}` reference.
+    pub client_secret: String,
+    /// Directory (tenant) id.  Must be an `${env:...}` reference.
+    pub tenant_id: String,
+}
+
+/// On-disk config for a `storage-azure` node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StorageAzureConfig {
+    /// Storage account name, e.g. `casparwater`.  Required: an Azure profile
+    /// without an account names nothing.  Not a credential (see module docs).
+    pub account_name: String,
+
+    /// Shared account key.  Must be an `${env:...}` reference (Decision A1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_key: Option<String>,
+
+    /// Shared access signature token.  Must be an `${env:...}` reference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sas_token: Option<String>,
+
+    /// Azure AD application credentials.  Each field must be an `${env:...}`
+    /// reference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_principal: Option<ServicePrincipal>,
+}
+
+/// The credential a profile authenticates with, once the exactly-one rule has
+/// been applied.
+///
+/// Borrowed rather than owned so obtaining it copies no secret.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AzureCredential<'a> {
+    /// A shared account key.
+    AccountKey(&'a str),
+    /// A shared access signature token.
+    SasToken(&'a str),
+    /// An Azure AD application.
+    ServicePrincipal(&'a ServicePrincipal),
+}
+
+impl AzureCredential<'_> {
+    /// The shape's name, for operator-facing output.  Never the value.
+    #[must_use]
+    pub fn shape(&self) -> &'static str {
+        match self {
+            Self::AccountKey(_) => "account_key",
+            Self::SasToken(_) => "sas_token",
+            Self::ServicePrincipal(_) => "service_principal",
+        }
+    }
+}
+
+/// Why a `storage-azure` config was rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorageAzureError {
+    /// A required field was empty.
+    Missing { field: &'static str },
+    /// No credential shape was given.
+    NoCredential,
+    /// More than one credential shape was given.
+    AmbiguousCredential { shapes: Vec<&'static str> },
+    /// A credential field was a literal rather than an `${env:...}` reference.
+    LiteralCredential { field: &'static str },
+}
+
+impl fmt::Display for StorageAzureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing { field } => write!(f, "`{field}` is required and must not be empty"),
+            Self::NoCredential => write!(
+                f,
+                "exactly one credential is required: set one of `account_key`, `sas_token`, or \
+                 `service_principal`. A profile with none would authenticate with nothing and \
+                 fail on first push rather than at apply."
+            ),
+            Self::AmbiguousCredential { shapes } => write!(
+                f,
+                "exactly one credential is allowed, but {} were given: {}. Preferring one \
+                 silently would hide a stale credential -- remove the ones that should not be \
+                 used.",
+                shapes.len(),
+                shapes.join(", ")
+            ),
+            Self::LiteralCredential { field } => write!(
+                f,
+                "`{field}` must be an environment reference such as \
+                 ${{env:AZURE_STORAGE_KEY}}, not a literal: a storage profile is replicated to \
+                 every backup, so a literal credential would be exposed on all replicas. Set it \
+                 in the environment and reference it here."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StorageAzureError {}
+
+impl StorageAzureConfig {
+    /// The single credential this profile authenticates with.
+    ///
+    /// The only way to read a credential, so the exactly-one rule (Decision A4)
+    /// is enforced at every use rather than being a check someone has to
+    /// remember to have run.
+    pub fn credential(&self) -> Result<AzureCredential<'_>, StorageAzureError> {
+        let mut found: Vec<AzureCredential<'_>> = Vec::new();
+        if let Some(k) = self.account_key.as_deref().filter(|s| !s.trim().is_empty()) {
+            found.push(AzureCredential::AccountKey(k));
+        }
+        if let Some(t) = self.sas_token.as_deref().filter(|s| !s.trim().is_empty()) {
+            found.push(AzureCredential::SasToken(t));
+        }
+        if let Some(sp) = self.service_principal.as_ref() {
+            found.push(AzureCredential::ServicePrincipal(sp));
+        }
+
+        match found.len() {
+            1 => Ok(found[0]),
+            0 => Err(StorageAzureError::NoCredential),
+            _ => Err(StorageAzureError::AmbiguousCredential {
+                shapes: found.iter().map(AzureCredential::shape).collect(),
+            }),
+        }
+    }
+
+    /// Check every rule this kind enforces.
+    ///
+    /// Used on the config **as stored in the pond**, where both halves apply.
+    /// The two creation-time entry points each check one half, because neither
+    /// sees a document that satisfies both: see [`Self::validate_structure`]
+    /// and [`Self::validate_references`].
+    pub fn validate(&self) -> Result<(), StorageAzureError> {
+        self.validate_structure()?;
+        self.validate_references()
+    }
+
+    /// Check the rules that concern *values*: a named account, and exactly one
+    /// non-empty credential shape.
+    ///
+    /// This runs on the **env-expanded** config, which is the only form in
+    /// which emptiness is knowable -- a reference to an unset variable is not
+    /// distinguishable from a set one until it is expanded.
+    pub fn validate_structure(&self) -> Result<(), StorageAzureError> {
+        if self.account_name.trim().is_empty() {
+            return Err(StorageAzureError::Missing {
+                field: "account_name",
+            });
+        }
+        if let Some(sp) = self.service_principal.as_ref() {
+            for (field, value) in [
+                ("service_principal.client_id", &sp.client_id),
+                ("service_principal.client_secret", &sp.client_secret),
+                ("service_principal.tenant_id", &sp.tenant_id),
+            ] {
+                if value.trim().is_empty() {
+                    return Err(StorageAzureError::Missing { field });
+                }
+            }
+        }
+        let _ = self.credential()?;
+        Ok(())
+    }
+
+    /// Check that every credential is still an `${env:...}` reference
+    /// (Decision A1).
+    ///
+    /// This runs on the **raw** config, before expansion -- expansion is
+    /// precisely what turns a reference into a literal, so after it the
+    /// distinction this rule is about no longer exists.
+    ///
+    /// Each present field is checked independently of the exactly-one rule: a
+    /// document with two literal credentials should say both are literals, not
+    /// pick one complaint.  `account_name` is not checked; it is an identifier,
+    /// not a secret.
+    pub fn validate_references(&self) -> Result<(), StorageAzureError> {
+        let sp = self.service_principal.as_ref();
+        let fields: [(&'static str, Option<&str>); 5] = [
+            ("account_key", self.account_key.as_deref()),
+            ("sas_token", self.sas_token.as_deref()),
+            (
+                "service_principal.client_id",
+                sp.map(|s| s.client_id.as_str()),
+            ),
+            (
+                "service_principal.client_secret",
+                sp.map(|s| s.client_secret.as_str()),
+            ),
+            (
+                "service_principal.tenant_id",
+                sp.map(|s| s.tenant_id.as_str()),
+            ),
+        ];
+        for (field, value) in fields {
+            let Some(value) = value else { continue };
+            if value.trim().is_empty() {
+                continue;
+            }
+            if !utilities::env_substitution::has_env_refs(value) {
+                return Err(StorageAzureError::LiteralCredential { field });
+            }
+        }
+        Ok(())
+    }
+
+    /// The `object_store` options this profile implies, with `${env:...}`
+    /// references resolved.
+    ///
+    /// Resolution happens **here**, at use time, so each replica authenticates
+    /// as itself (Decision A6).  Only the keys belonging to the one credential
+    /// shape are emitted: handing `object_store` a key and a token together
+    /// would reintroduce, inside the builder, exactly the ambiguity
+    /// [`Self::credential`] refuses.
+    pub fn to_storage_options(&self) -> Result<HashMap<String, String>, String> {
+        let resolve = |v: &str| {
+            utilities::env_substitution::substitute_env_vars(v).map_err(|e| e.to_string())
+        };
+
+        let credential = self.credential().map_err(|e| e.to_string())?;
+
+        let mut out = HashMap::new();
+        let _ = out.insert("account_name".to_string(), resolve(&self.account_name)?);
+        match credential {
+            AzureCredential::AccountKey(k) => {
+                let _ = out.insert("account_key".to_string(), resolve(k)?);
+            }
+            AzureCredential::SasToken(t) => {
+                let _ = out.insert("sas_token".to_string(), resolve(t)?);
+            }
+            AzureCredential::ServicePrincipal(sp) => {
+                let _ = out.insert("client_id".to_string(), resolve(&sp.client_id)?);
+                let _ = out.insert("client_secret".to_string(), resolve(&sp.client_secret)?);
+                let _ = out.insert("tenant_id".to_string(), resolve(&sp.tenant_id)?);
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Parse a `storage-azure` node's stored config bytes.
+///
+/// Shared by the factory and by `steward::storage_profile`, so both agree on
+/// exactly one interpretation of a node's config -- the same discipline as
+/// [`super::storage_minio::config_from_bytes`].
+pub fn config_from_bytes(config: &[u8]) -> Result<StorageAzureConfig, String> {
+    let text = std::str::from_utf8(config).map_err(|e| format!("invalid UTF-8: {e}"))?;
+    let cfg: StorageAzureConfig =
+        serde_yaml::from_str(text).map_err(|e| format!("invalid storage-azure config: {e}"))?;
+    cfg.validate().map_err(|e| e.to_string())?;
+    Ok(cfg)
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/// The placeholder shown in place of a credential value.
+pub const REDACTED: &str = "<redacted>";
+
+/// Render the profile as the node's readable content: the account name and the
+/// credential *shape*, with every value replaced by [`REDACTED`].
+///
+/// Redaction is required, not cosmetic.  This runs on the **env-expanded**
+/// config -- `FactoryRegistry::create_file` expands before the factory is
+/// called -- so the values in hand are the resolved secrets.  Consumers do not
+/// read this text; they bind from the raw stored config
+/// (`steward::storage_profile`), which still holds the references.
+///
+/// The shape is named because which credential is in use is an operational
+/// fact worth seeing in `pond cat`: it is what an operator rotating a key needs
+/// to know, and it reveals nothing about the value.
+#[must_use]
+pub fn render(cfg: &StorageAzureConfig) -> Vec<u8> {
+    let shape = cfg.credential().map_or("none", |c| c.shape());
+    let normalized = StorageAzureConfig {
+        account_name: cfg.account_name.clone(),
+        account_key: cfg.account_key.as_ref().map(|_| REDACTED.to_string()),
+        sas_token: cfg.sas_token.as_ref().map(|_| REDACTED.to_string()),
+        service_principal: cfg.service_principal.as_ref().map(|_| ServicePrincipal {
+            client_id: REDACTED.to_string(),
+            client_secret: REDACTED.to_string(),
+            tenant_id: REDACTED.to_string(),
+        }),
+    };
+    let body = serde_yaml::to_string(&normalized)
+        .unwrap_or_else(|e| format!("# failed to render config: {e}\n"));
+    format!(
+        "# storage-azure: account {} (authenticating with {shape})\n{body}",
+        cfg.account_name
+    )
+    .into_bytes()
+}
+
+fn create_storage_azure_handle(
+    config: Value,
+    _context: crate::FactoryContext,
+) -> TinyFSResult<FileHandle> {
+    let cfg: StorageAzureConfig =
+        serde_json::from_value(config).map_other_context("Invalid storage-azure config")?;
+    // Structure only: `config` arrives expanded, so the reference rule is not
+    // checkable here.  It is enforced at creation time on the raw form.
+    cfg.validate_structure()
+        .map_err(|e| tinyfs::Error::Other(format!("Invalid storage-azure config: {e}")))?;
+    Ok(crate::ConfigFile::new(render(&cfg)).create_handle())
+}
+
+/// Validate the **env-expanded** config: structure only.
+///
+/// The credential-reference rule cannot be checked here, because expansion has
+/// already replaced every reference with its value.  It is checked instead by
+/// [`validate_storage_azure_raw_config`].
+fn validate_storage_azure_config(config: &[u8]) -> TinyFSResult<Value> {
+    let config_str = std::str::from_utf8(config).map_other_context("Invalid UTF-8")?;
+    let cfg: StorageAzureConfig =
+        serde_yaml::from_str(config_str).map_other_context("Invalid storage-azure config")?;
+    cfg.validate_structure()
+        .map_err(|e| tinyfs::Error::Other(format!("Invalid storage-azure config: {e}")))?;
+    serde_json::to_value(&cfg).map_other_context("Failed to serialize storage-azure config")
+}
+
+/// Validate the **raw** config, which is the form that gets stored: every
+/// credential must still be an `${env:...}` reference (Decision A1).
+///
+/// The exactly-one rule is checked here too.  It is a property of which fields
+/// are present, not of their values, so it is knowable before expansion -- and
+/// catching it here means `pond apply` refuses an ambiguous profile instead of
+/// storing one that only fails once something tries to use it.
+fn validate_storage_azure_raw_config(config: &[u8]) -> TinyFSResult<()> {
+    let config_str = std::str::from_utf8(config).map_other_context("Invalid UTF-8")?;
+    let cfg: StorageAzureConfig =
+        serde_yaml::from_str(config_str).map_other_context("Invalid storage-azure config")?;
+    cfg.validate_references()
+        .map_err(|e| tinyfs::Error::Other(format!("Invalid storage-azure config: {e}")))?;
+    let _ = cfg
+        .credential()
+        .map_err(|e| tinyfs::Error::Other(format!("Invalid storage-azure config: {e}")))?;
+    Ok(())
+}
+
+crate::register_dynamic_factory!(
+    name: FACTORY_NAME,
+    description: "Declare how to reach an Azure Blob Storage account (account + one credential shape), referenced by path from remotes",
+    file: create_storage_azure_handle,
+    validate: validate_storage_azure_config,
+    validate_raw: validate_storage_azure_raw_config
+);
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_key() -> StorageAzureConfig {
+        StorageAzureConfig {
+            account_name: "casparwater".to_string(),
+            account_key: Some("${env:AZURE_STORAGE_KEY}".to_string()),
+            sas_token: None,
+            service_principal: None,
+        }
+    }
+
+    fn principal() -> ServicePrincipal {
+        ServicePrincipal {
+            client_id: "${env:AZURE_CLIENT_ID}".to_string(),
+            client_secret: "${env:AZURE_CLIENT_SECRET}".to_string(),
+            tenant_id: "${env:AZURE_TENANT_ID}".to_string(),
+        }
+    }
+
+    #[test]
+    fn each_credential_shape_is_accepted_alone() {
+        assert_eq!(with_key().credential().expect("key").shape(), "account_key");
+
+        let sas = StorageAzureConfig {
+            account_key: None,
+            sas_token: Some("${env:AZURE_STORAGE_SAS}".to_string()),
+            ..with_key()
+        };
+        assert_eq!(sas.credential().expect("sas").shape(), "sas_token");
+
+        let sp = StorageAzureConfig {
+            account_key: None,
+            service_principal: Some(principal()),
+            ..with_key()
+        };
+        assert_eq!(sp.credential().expect("sp").shape(), "service_principal");
+    }
+
+    /// Zero credentials must fail at apply, not at first push: a profile that
+    /// authenticates with nothing is a deferred outage.
+    #[test]
+    fn no_credential_is_refused() {
+        let cfg = StorageAzureConfig {
+            account_key: None,
+            ..with_key()
+        };
+        assert_eq!(cfg.credential(), Err(StorageAzureError::NoCredential));
+        assert!(cfg.validate_structure().is_err());
+    }
+
+    /// Two credentials have no unambiguous intent.  Preferring one silently is
+    /// the precedence rule Decision A4 forbids -- and the error must name both,
+    /// so the operator can see which one they forgot to remove.
+    #[test]
+    fn two_credentials_are_refused_and_both_are_named() {
+        let cfg = StorageAzureConfig {
+            sas_token: Some("${env:AZURE_STORAGE_SAS}".to_string()),
+            ..with_key()
+        };
+        let err = cfg.credential().expect_err("ambiguous");
+        let msg = format!("{err}");
+        assert!(msg.contains("account_key"), "{msg}");
+        assert!(msg.contains("sas_token"), "{msg}");
+    }
+
+    #[test]
+    fn all_three_credentials_are_refused() {
+        let cfg = StorageAzureConfig {
+            sas_token: Some("${env:AZURE_STORAGE_SAS}".to_string()),
+            service_principal: Some(principal()),
+            ..with_key()
+        };
+        assert!(matches!(
+            cfg.credential(),
+            Err(StorageAzureError::AmbiguousCredential { .. })
+        ));
+    }
+
+    /// A literal credential must be refused on the way in.  A profile
+    /// replicates to every backup, so a literal cannot be withdrawn once
+    /// written.
+    #[test]
+    fn a_literal_credential_is_refused() {
+        let cfg = StorageAzureConfig {
+            account_key: Some("hunter2".to_string()),
+            ..with_key()
+        };
+        assert_eq!(
+            cfg.validate_references(),
+            Err(StorageAzureError::LiteralCredential {
+                field: "account_key"
+            })
+        );
+    }
+
+    /// Every field of a service principal is a credential, including the ones
+    /// that look like identifiers.
+    #[test]
+    fn a_literal_service_principal_field_is_refused() {
+        let cfg = StorageAzureConfig {
+            account_key: None,
+            service_principal: Some(ServicePrincipal {
+                client_secret: "hunter2".to_string(),
+                ..principal()
+            }),
+            ..with_key()
+        };
+        let err = cfg.validate_references().expect_err("literal");
+        assert!(format!("{err}").contains("client_secret"), "{err}");
+    }
+
+    /// `account_name` is an identifier, not a secret: requiring it to be
+    /// indirect would hide which account a profile names and protect nothing.
+    #[test]
+    fn a_literal_account_name_is_allowed() {
+        cfg_validate_ok(&with_key());
+    }
+
+    fn cfg_validate_ok(cfg: &StorageAzureConfig) {
+        cfg.validate_references().expect("references");
+    }
+
+    #[test]
+    fn options_carry_only_the_chosen_shape() {
+        // `PATH` stands in for a credential variable: the point is that the
+        // value arrives from the environment at use time, not which variable
+        // it came from.
+        let cfg = StorageAzureConfig {
+            account_key: Some("${env:PATH}".to_string()),
+            ..with_key()
+        };
+        let opts = cfg.to_storage_options().expect("resolve");
+        let path = std::env::var("PATH").expect("PATH is set");
+        assert_eq!(
+            opts.get("account_name").map(String::as_str),
+            Some("casparwater")
+        );
+        assert_eq!(
+            opts.get("account_key").map(String::as_str),
+            Some(path.as_str())
+        );
+        assert!(
+            !opts.contains_key("sas_token") && !opts.contains_key("client_id"),
+            "an unused shape must not reach the builder: {opts:?}"
+        );
+    }
+
+    /// Options resolve at use time so each replica authenticates as itself
+    /// (Decision A6).
+    #[test]
+    fn an_unresolvable_reference_fails_at_use_time() {
+        let cfg = StorageAzureConfig {
+            account_key: Some("${env:NOT_SET_XYZZY_AZ}".to_string()),
+            ..with_key()
+        };
+        assert!(cfg.to_storage_options().is_err());
+    }
+
+    /// The rendered node is what an operator will `pond cat`.  It must name the
+    /// shape in use and no value.
+    #[test]
+    fn render_names_the_shape_and_no_secret() {
+        // `render` runs on the expanded config, so the value in hand is the
+        // resolved secret -- which is exactly why it must be redacted.
+        let expanded = StorageAzureConfig {
+            account_key: Some("super-secret-value".to_string()),
+            ..with_key()
+        };
+        let text = String::from_utf8(render(&expanded)).expect("utf8");
+        assert!(text.contains("casparwater"), "{text}");
+        assert!(text.contains("account_key"), "{text}");
+        assert!(!text.contains("super-secret-value"), "{text}");
+        assert!(text.contains(REDACTED), "{text}");
+    }
+
+    #[test]
+    fn config_from_bytes_accepts_a_well_formed_profile() {
+        let cfg = config_from_bytes(
+            b"account_name: casparwater\naccount_key: ${env:AZURE_STORAGE_KEY}\n",
+        )
+        .expect("parse");
+        assert_eq!(cfg.account_name, "casparwater");
+    }
+
+    /// `deny_unknown_fields` is what makes each profile kind's parse strict;
+    /// a MinIO document must not be readable as an Azure one.
+    #[test]
+    fn a_minio_document_is_not_an_azure_profile() {
+        let err = config_from_bytes(
+            b"endpoint: http://watershop:9000\naccess_key_id: ${env:K}\nsecret_access_key: ${env:S}\n",
+        )
+        .expect_err("must refuse");
+        assert!(err.contains("storage-azure"), "{err}");
+    }
+
+    #[test]
+    fn raw_validation_refuses_an_ambiguous_profile_at_apply() {
+        let err = validate_storage_azure_raw_config(
+            b"account_name: casparwater\naccount_key: ${env:K}\nsas_token: ${env:T}\n",
+        )
+        .expect_err("must refuse");
+        assert!(format!("{err}").contains("exactly one"), "{err}");
+    }
+
+    #[test]
+    fn the_factory_is_registered_under_its_name() {
+        let f = crate::FactoryRegistry::get_factory(FACTORY_NAME)
+            .expect("storage-azure factory registered");
+        assert_eq!(f.name, FACTORY_NAME);
+    }
+}

--- a/crates/provider/src/factory/storage_minio.rs
+++ b/crates/provider/src/factory/storage_minio.rs
@@ -58,6 +58,11 @@ use tinyfs::FileHandle;
 use tinyfs::Result as TinyFSResult;
 use tinyfs::ResultExt;
 
+/// The factory name this kind registers under.  Named once here so consumers
+/// that dispatch on it (`steward::storage_profile`) cannot drift from the
+/// registration below.
+pub const FACTORY_NAME: &str = "storage-minio";
+
 /// MinIO's own default, and what `object_store` signs with when a region is
 /// not supplied.  MinIO ignores the region for placement but SigV4 requires
 /// one, so this is a genuine default rather than a guess.
@@ -309,7 +314,7 @@ fn validate_storage_minio_raw_config(config: &[u8]) -> TinyFSResult<()> {
 }
 
 crate::register_dynamic_factory!(
-    name: "storage-minio",
+    name: FACTORY_NAME,
     description: "Declare how to reach a MinIO deployment (endpoint + credentials), referenced by path from remotes",
     file: create_storage_minio_handle,
     validate: validate_storage_minio_config,

--- a/crates/steward/src/content_pull.rs
+++ b/crates/steward/src/content_pull.rs
@@ -982,6 +982,17 @@ fn plan_one(
 
     let content_changed = existing.is_none_or(|t| t.child_hash != entry.child_hash);
 
+    // The fold commits to each version's metadata -- mtime, event-time bounds,
+    // extended attributes -- alongside its bytes, so a source-side change to
+    // metadata alone still moves this entry's contribution to its parent's tree
+    // hash and every ancestor's.  Pruning on `child_hash` alone would plan no
+    // op at all, leave the replica holding stale metadata, and then fail the
+    // post-apply fold -- durably, because the commit lands before the fold runs,
+    // so every retry re-diffs against the same stale state and fails again.
+    // (`content_diff::diff_dir` prunes on both for the same reason.)
+    let meta_changed = existing.is_none_or(|t| t.versions != entry.versions);
+    let needs_write = create || content_changed || meta_changed;
+
     match entry.entry_type {
         EntryType::DirectoryPhysical => {
             if create {
@@ -998,7 +1009,7 @@ fn plan_one(
             if create {
                 outcome.files += 1;
             }
-            let versions = if content_changed {
+            let versions = if needs_write {
                 vec![planned_version(
                     graph,
                     entry.child_hash,
@@ -1037,7 +1048,7 @@ fn plan_one(
             if create {
                 outcome.symlinks += 1;
             }
-            if create || content_changed {
+            if needs_write {
                 let bytes = blob_bytes(graph, entry.child_hash)?;
                 let target = String::from_utf8(bytes).map_err(|e| {
                     StewardError::Content(format!("symlink target is not utf-8: {e}"))
@@ -1056,7 +1067,7 @@ fn plan_one(
             if create {
                 outcome.dynamic += 1;
             }
-            if create || content_changed {
+            if needs_write {
                 let bytes = blob_bytes(graph, entry.child_hash)?;
                 let (factory, config) = decode_recipe(&bytes).map_err(|e| {
                     StewardError::Content(format!("decode recipe for {}: {e}", entry.name))

--- a/crates/steward/src/dispatch.rs
+++ b/crates/steward/src/dispatch.rs
@@ -201,6 +201,38 @@ impl Steward {
         }
     }
 
+    /// Report which series collapse would merge at `threshold`, and what
+    /// merging them would cost, without merging anything.
+    ///
+    /// Returns an empty survey for Host stewards, which hold no series.
+    ///
+    /// # Errors
+    /// Returns an error if the read transaction or discovery query fails.
+    pub async fn survey_collapsible_series(
+        &mut self,
+        threshold: usize,
+    ) -> Result<Vec<tlogfs::CollapsibleSeries>, StewardError> {
+        match self {
+            Steward::Pond(ship) => ship.survey_collapsible_series(threshold).await,
+            Steward::Host(_) => Ok(Vec::new()),
+        }
+    }
+
+    /// Map every node in the pond to its path, from stored directory rows.
+    ///
+    /// Host stewards hold no pond tree, so they map nothing.
+    ///
+    /// # Errors
+    /// Returns an error if the read transaction or the directory scan fails.
+    pub async fn node_paths(
+        &mut self,
+    ) -> Result<std::collections::HashMap<tinyfs::FileID, String>, StewardError> {
+        match self {
+            Steward::Pond(ship) => ship.node_paths().await,
+            Steward::Host(_) => Ok(std::collections::HashMap::new()),
+        }
+    }
+
     /// Collapse multi-version `data:series` files whose live version count
     /// exceeds `threshold` into a single merged version.
     ///

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -858,6 +858,59 @@ impl Ship {
         report
     }
 
+    /// Report which series collapse would merge at `threshold`, and what
+    /// merging them would cost, without merging anything.
+    ///
+    /// Runs only phase 1 of [`Ship::collapse_versions`] -- the same discovery,
+    /// under a read transaction that takes no control-table records and
+    /// consumes no sequence number -- so asking is free and leaves no trace.
+    /// Sharing the discovery is the point: a preview that computed candidacy
+    /// its own way could disagree with the collapse it claims to predict.
+    ///
+    /// # Errors
+    /// Returns an error if the read transaction or the discovery query fails.
+    pub async fn survey_collapsible_series(
+        &mut self,
+        threshold: usize,
+    ) -> Result<Vec<tlogfs::CollapsibleSeries>, StewardError> {
+        let meta = PondUserMetadata::new(vec![
+            "pond".to_string(),
+            "maintain".to_string(),
+            "--dry-run".to_string(),
+        ]);
+        let tx = self.begin_read(&meta).await?;
+        let found = {
+            let state = tx.state()?;
+            state.survey_collapsible_series(threshold).await?
+        };
+        _ = tx.commit().await?;
+        Ok(found)
+    }
+
+    /// Map every node in the pond to its path, from stored directory rows.
+    ///
+    /// Reporting-only: it instantiates no node, so it cannot fail because some
+    /// unrelated dynamic node's config does not expand.
+    ///
+    /// # Errors
+    /// Returns an error if the read transaction or the directory scan fails.
+    pub async fn node_paths(
+        &mut self,
+    ) -> Result<std::collections::HashMap<tinyfs::FileID, String>, StewardError> {
+        let meta = PondUserMetadata::new(vec!["pond".to_string(), "node-paths".to_string()]);
+        let tx = self.begin_read(&meta).await?;
+        let result = async {
+            let state = tx.state()?;
+            Ok::<_, StewardError>(state.node_paths().await?)
+        }
+        .await;
+        // Close the read transaction on both paths: a preview that leaves an
+        // incomplete transaction behind has modified the pond it promised not
+        // to touch.
+        _ = tx.commit().await?;
+        result
+    }
+
     /// Collapse every `FilePhysicalSeries` node with more than `threshold` live
     /// versions into a single merged version, so subsequent reads are O(1)
     /// instead of O(versions).

--- a/crates/steward/src/storage_profile.rs
+++ b/crates/steward/src/storage_profile.rs
@@ -34,6 +34,7 @@
 
 use crate::PondUserMetadata;
 use crate::Ship;
+use provider::factory::storage_azure::StorageAzureConfig;
 use provider::factory::storage_minio::StorageMinioConfig;
 use std::collections::HashMap;
 use std::fmt;
@@ -97,42 +98,94 @@ pub enum ResolvedStorage {
         path: String,
         config: Box<StorageMinioConfig>,
     },
+    /// A `storage-azure` profile.
+    Azure {
+        path: String,
+        config: Box<StorageAzureConfig>,
+    },
 }
 
 impl ResolvedStorage {
     /// Read and parse the profile node at `path`.
     pub async fn open(ship: &mut Ship, path: &str) -> Result<Self, StorageProfileError> {
-        let bytes = read_node_bytes(ship, path).await?;
-        Self::from_bytes(path, &bytes)
+        let (factory, bytes) = read_node_bytes(ship, path).await?;
+        Self::from_bytes(path, &factory, &bytes)
     }
 
-    /// Parse an already-read profile document.
+    /// Parse an already-read profile document, given the factory that created
+    /// the node.
     ///
     /// Split out from [`Self::open`] so the parse and scheme rules can be
     /// exercised without a pond.
-    pub fn from_bytes(path: &str, bytes: &[u8]) -> Result<Self, StorageProfileError> {
-        // Only one kind exists today.  When `storage-azure` lands it is
-        // dispatched here, on the document's shape -- the node does not record
-        // which factory produced it, so each kind's parse must be strict
-        // enough to reject the others.  `deny_unknown_fields` on every config
-        // is what makes that safe.
-        match provider::factory::storage_minio::config_from_bytes(bytes) {
-            Ok(config) => Ok(Self::Minio {
+    ///
+    /// # Why the factory name and not the document's shape
+    ///
+    /// Dispatching on shape -- trying each kind's parser until one succeeds --
+    /// requires every profile kind to stay parse-disjoint from every other one
+    /// for good.  That holds today only because `storage-minio` requires an
+    /// `endpoint` that `storage-azure` does not have, and `storage-r2` (§3.3)
+    /// would immediately strain it by being MinIO-shaped without an endpoint.
+    /// Worse, the failure is silent misattribution rather than an error: a
+    /// document read as the wrong kind registers the wrong handlers and
+    /// surfaces as an opaque authentication failure on first push, which is
+    /// the class of bug profiles exist to remove.
+    ///
+    /// The node records the factory that created it -- `get_dynamic_node_config`
+    /// returns it, and this code previously discarded it -- so the kind is a
+    /// known fact rather than something to infer.  Knowing it also means a
+    /// malformed document reports *its own* kind's complaint.
+    pub fn from_bytes(
+        path: &str,
+        factory: &str,
+        bytes: &[u8],
+    ) -> Result<Self, StorageProfileError> {
+        match factory {
+            provider::factory::storage_azure::FACTORY_NAME => {
+                let config = provider::factory::storage_azure::config_from_bytes(bytes).map_err(
+                    |reason| StorageProfileError::NotAProfile {
+                        path: path.to_string(),
+                        reason,
+                    },
+                )?;
+                Ok(Self::Azure {
+                    path: path.to_string(),
+                    config: Box::new(config),
+                })
+            }
+            provider::factory::storage_minio::FACTORY_NAME => {
+                let config = provider::factory::storage_minio::config_from_bytes(bytes).map_err(
+                    |reason| StorageProfileError::NotAProfile {
+                        path: path.to_string(),
+                        reason,
+                    },
+                )?;
+                Ok(Self::Minio {
+                    path: path.to_string(),
+                    config: Box::new(config),
+                })
+            }
+            other => Err(StorageProfileError::NotAProfile {
                 path: path.to_string(),
-                config: Box::new(config),
-            }),
-            Err(reason) => Err(StorageProfileError::NotAProfile {
-                path: path.to_string(),
-                reason,
+                reason: format!(
+                    "`{other}` is not a storage profile factory; expected one of: {}",
+                    Self::KINDS.join(", ")
+                ),
             }),
         }
     }
+
+    /// Every factory name that names a storage profile, for error messages.
+    const KINDS: &'static [&'static str] = &[
+        provider::factory::storage_minio::FACTORY_NAME,
+        provider::factory::storage_azure::FACTORY_NAME,
+    ];
 
     /// The profile's kind, as written in `pond apply`.
     #[must_use]
     pub fn kind(&self) -> &'static str {
         match self {
-            Self::Minio { .. } => "storage-minio",
+            Self::Minio { .. } => provider::factory::storage_minio::FACTORY_NAME,
+            Self::Azure { .. } => provider::factory::storage_azure::FACTORY_NAME,
         }
     }
 
@@ -140,7 +193,7 @@ impl ResolvedStorage {
     #[must_use]
     pub fn path(&self) -> &str {
         match self {
-            Self::Minio { path, .. } => path,
+            Self::Minio { path, .. } | Self::Azure { path, .. } => path,
         }
     }
 
@@ -150,6 +203,13 @@ impl ResolvedStorage {
     pub fn describe(&self) -> String {
         match self {
             Self::Minio { config, .. } => format!("minio, {}", config.endpoint),
+            // The credential *shape* is named because it is what an operator
+            // rotating a key needs to see; the value never appears.
+            Self::Azure { config, .. } => format!(
+                "azure, account {} ({})",
+                config.account_name,
+                config.credential().map_or("no credential", |c| c.shape())
+            ),
         }
     }
 
@@ -161,6 +221,9 @@ impl ResolvedStorage {
     pub fn serves_scheme(&self, url: &str) -> bool {
         match self {
             Self::Minio { .. } => url.starts_with("s3://") || url.starts_with("s3a://"),
+            Self::Azure { .. } => sync_store::AZURE_SCHEMES
+                .iter()
+                .any(|s| url.starts_with(&format!("{s}://"))),
         }
     }
 
@@ -184,6 +247,7 @@ impl ResolvedStorage {
     pub fn register_handlers(&self) {
         match self {
             Self::Minio { .. } => sync_store::register_s3_handlers(),
+            Self::Azure { .. } => sync_store::register_azure_handlers(),
         }
     }
 
@@ -192,6 +256,14 @@ impl ResolvedStorage {
     pub fn to_storage_options(&self) -> Result<HashMap<String, String>, StorageProfileError> {
         match self {
             Self::Minio { path, config } => {
+                config
+                    .to_storage_options()
+                    .map_err(|reason| StorageProfileError::Unresolvable {
+                        path: path.clone(),
+                        reason,
+                    })
+            }
+            Self::Azure { path, config } => {
                 config
                     .to_storage_options()
                     .map_err(|reason| StorageProfileError::Unresolvable {
@@ -215,7 +287,10 @@ impl ResolvedStorage {
 /// hand to a consumer.  Binding therefore reads the stored config, where the
 /// `${env:...}` references survive, so each replica resolves as itself
 /// (Decision A6).
-async fn read_node_bytes(ship: &mut Ship, path: &str) -> Result<Vec<u8>, StorageProfileError> {
+async fn read_node_bytes(
+    ship: &mut Ship,
+    path: &str,
+) -> Result<(String, Vec<u8>), StorageProfileError> {
     let meta = PondUserMetadata::new(vec!["internal".to_string(), "storage-open".to_string()]);
     let tx = ship
         .begin_read(&meta)
@@ -250,7 +325,7 @@ async fn read_node_bytes(ship: &mut Ship, path: &str) -> Result<Vec<u8>, Storage
         };
 
         match tx.get_dynamic_node_config(node.id()).await {
-            Ok(Some((_factory, config))) => Ok(config),
+            Ok(Some((factory, config))) => Ok((factory, config)),
             Ok(None) => Err(StorageProfileError::NotAProfile {
                 path: path.to_string(),
                 reason: "not a factory node; a storage profile is created by \
@@ -312,12 +387,14 @@ pub async fn prepare_storage(
 mod tests {
     use super::*;
 
+    const MINIO: &str = provider::factory::storage_minio::FACTORY_NAME;
+
     const DOC: &[u8] =
         b"endpoint: http://watershop:9000\naccess_key_id: ${env:PATH}\nsecret_access_key: ${env:PATH}\n";
 
     #[test]
     fn a_minio_document_parses() {
-        let p = ResolvedStorage::from_bytes("/sys/storage/minio", DOC).expect("parse");
+        let p = ResolvedStorage::from_bytes("/sys/storage/minio", MINIO, DOC).expect("parse");
         assert_eq!(p.kind(), "storage-minio");
         assert_eq!(p.path(), "/sys/storage/minio");
         assert!(p.describe().contains("watershop:9000"));
@@ -327,7 +404,7 @@ mod tests {
     /// which is what `pond status` prints.
     #[test]
     fn describe_names_no_credential() {
-        let p = ResolvedStorage::from_bytes("/sys/storage/minio", DOC).expect("parse");
+        let p = ResolvedStorage::from_bytes("/sys/storage/minio", MINIO, DOC).expect("parse");
         let d = p.describe();
         assert!(!d.contains("access_key"), "{d}");
         assert!(!d.contains("secret"), "{d}");
@@ -338,7 +415,7 @@ mod tests {
     /// profile, and a mismatched URL is refused rather than half-working.
     #[test]
     fn scheme_compatibility_is_checked() {
-        let p = ResolvedStorage::from_bytes("/sys/storage/minio", DOC).expect("parse");
+        let p = ResolvedStorage::from_bytes("/sys/storage/minio", MINIO, DOC).expect("parse");
         p.check_scheme("s3://bucket").expect("s3 is served");
         p.check_scheme("s3a://bucket").expect("s3a is served");
 
@@ -355,7 +432,7 @@ mod tests {
 
     #[test]
     fn a_malformed_document_is_not_a_profile() {
-        let err = ResolvedStorage::from_bytes("/sys/storage/x", b"not: a: profile\n")
+        let err = ResolvedStorage::from_bytes("/sys/storage/x", MINIO, b"not: a: profile\n")
             .expect_err("must refuse");
         assert!(matches!(err, StorageProfileError::NotAProfile { .. }));
     }
@@ -367,6 +444,7 @@ mod tests {
     fn a_literal_credential_is_refused_on_read() {
         let err = ResolvedStorage::from_bytes(
             "/sys/storage/minio",
+            MINIO,
             b"endpoint: http://x:9000\naccess_key_id: ${env:PATH}\nsecret_access_key: hunter2\n",
         )
         .expect_err("must refuse");
@@ -375,7 +453,7 @@ mod tests {
 
     #[test]
     fn options_resolve_at_use_time() {
-        let p = ResolvedStorage::from_bytes("/sys/storage/minio", DOC).expect("parse");
+        let p = ResolvedStorage::from_bytes("/sys/storage/minio", MINIO, DOC).expect("parse");
         let opts = p.to_storage_options().expect("resolve");
         let path = std::env::var("PATH").expect("PATH is set");
         assert_eq!(
@@ -389,11 +467,111 @@ mod tests {
     fn an_unresolvable_reference_reports_the_profile_path() {
         let p = ResolvedStorage::from_bytes(
             "/sys/storage/minio",
+            MINIO,
             b"endpoint: http://x:9000\naccess_key_id: ${env:NOT_SET_XYZZY_A}\nsecret_access_key: ${env:NOT_SET_XYZZY_B}\n",
         )
         .expect("parse");
         let err = p.to_storage_options().expect_err("must fail");
         assert!(matches!(err, StorageProfileError::Unresolvable { .. }));
         assert!(format!("{err}").contains("/sys/storage/minio"), "{err}");
+    }
+
+    /// The kind comes from the node's recorded factory, not from guessing at
+    /// the document.  A node created by some other factory is refused by name
+    /// rather than parsed hopefully -- which is what stops a future profile
+    /// kind that happens to parse as MinIO from being served with the wrong
+    /// handlers.
+    #[test]
+    fn a_foreign_factory_is_refused_by_name() {
+        let err = ResolvedStorage::from_bytes("/sys/limits/backup-bytes", "rate-limit", DOC)
+            .expect_err("a rate-limit node is not a storage profile");
+        let msg = format!("{err}");
+        assert!(msg.contains("rate-limit"), "{msg}");
+        assert!(
+            msg.contains("storage-minio"),
+            "should name what is expected: {msg}"
+        );
+    }
+
+    const AZURE: &str = provider::factory::storage_azure::FACTORY_NAME;
+
+    const AZ_DOC: &[u8] = b"account_name: casparwater\naccount_key: ${env:PATH}\n";
+
+    #[test]
+    fn an_azure_document_parses() {
+        let p = ResolvedStorage::from_bytes("/sys/storage/azure", AZURE, AZ_DOC).expect("parse");
+        assert_eq!(p.kind(), "storage-azure");
+        assert_eq!(p.path(), "/sys/storage/azure");
+        assert!(p.describe().contains("casparwater"), "{}", p.describe());
+    }
+
+    /// `describe` feeds `pond status`.  It names the credential shape, which is
+    /// operationally useful, and never the credential.
+    #[test]
+    fn azure_describe_names_the_shape_and_no_credential() {
+        let p = ResolvedStorage::from_bytes("/sys/storage/azure", AZURE, AZ_DOC).expect("parse");
+        let d = p.describe();
+        assert!(d.contains("account_key"), "{d}");
+        let path = std::env::var("PATH").expect("PATH is set");
+        assert!(!d.contains(&path), "{d}");
+        assert!(!d.contains("${env"), "{d}");
+    }
+
+    /// §3.2: an Azure profile paired with an `s3://` URL is refused at attach,
+    /// rather than producing a confusing authentication failure at first push.
+    /// This is the whole reason the profile's kind, not the URL, picks the
+    /// provider.
+    #[test]
+    fn an_azure_profile_refuses_an_s3_url() {
+        let p = ResolvedStorage::from_bytes("/sys/storage/azure", AZURE, AZ_DOC).expect("parse");
+        for url in ["az://c/p", "azure://c/p", "abfs://c/p", "abfss://c/p"] {
+            p.check_scheme(url).unwrap_or_else(|e| panic!("{url}: {e}"));
+        }
+        for url in ["s3://bucket", "s3a://bucket", "file:///tmp/x"] {
+            assert!(
+                matches!(
+                    p.check_scheme(url),
+                    Err(StorageProfileError::SchemeMismatch { .. })
+                ),
+                "{url} must be refused by an azure profile"
+            );
+        }
+    }
+
+    /// The two kinds must not be confusable in either direction.  With dispatch
+    /// on the recorded factory (A9) this holds by construction rather than by
+    /// the documents happening to stay parse-disjoint.
+    #[test]
+    fn the_kinds_do_not_parse_as_each_other() {
+        assert!(ResolvedStorage::from_bytes("/sys/storage/x", AZURE, DOC).is_err());
+        assert!(ResolvedStorage::from_bytes("/sys/storage/x", MINIO, AZ_DOC).is_err());
+    }
+
+    #[test]
+    fn azure_options_resolve_at_use_time() {
+        let p = ResolvedStorage::from_bytes("/sys/storage/azure", AZURE, AZ_DOC).expect("parse");
+        let opts = p.to_storage_options().expect("resolve");
+        let path = std::env::var("PATH").expect("PATH is set");
+        assert_eq!(
+            opts.get("account_key").map(String::as_str),
+            Some(path.as_str())
+        );
+        assert_eq!(
+            opts.get("account_name").map(String::as_str),
+            Some("casparwater")
+        );
+    }
+
+    /// An Azure profile carrying two credential shapes must be refused on read,
+    /// not silently resolved to one of them (Decision A4).
+    #[test]
+    fn an_ambiguous_azure_profile_is_refused_on_read() {
+        let err = ResolvedStorage::from_bytes(
+            "/sys/storage/azure",
+            AZURE,
+            b"account_name: casparwater\naccount_key: ${env:PATH}\nsas_token: ${env:PATH}\n",
+        )
+        .expect_err("must refuse");
+        assert!(format!("{err}").contains("exactly one"), "{err}");
     }
 }

--- a/crates/steward/tests/collapse_survey_test.rs
+++ b/crates/steward/tests/collapse_survey_test.rs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the collapse survey -- the read-only half of version
+//! collapse that `pond maintain --dry-run` reports.
+//!
+//! A preview is only worth having if it predicts the thing it previews, so the
+//! property under test is agreement: the survey must name the same candidates
+//! the collapse then acts on, and must cost nothing to ask.  Both hold by
+//! construction today because the survey IS the discovery collapse runs, and
+//! these tests are what keep that true if the two are ever separated.
+
+use steward::Ship;
+use tempfile::tempdir;
+use tlogfs::PondUserMetadata;
+use tokio::io::AsyncWriteExt;
+
+fn meta(label: &str) -> PondUserMetadata {
+    PondUserMetadata::new(vec!["test".into(), label.into()])
+}
+
+/// Incompressible bytes, distinct per version so no two dedup to one blob.
+fn chunk(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 24) as u8
+        })
+        .collect()
+}
+
+async fn append_series_version(ship: &mut Ship, path: &str, bytes: &[u8]) {
+    let path = path.to_string();
+    let bytes = bytes.to_vec();
+    ship.write_transaction(&meta("series"), async move |fs| {
+        let root = fs.root().await?;
+        let mut writer = root
+            .async_writer_path_with_type(&path, tinyfs::EntryType::FilePhysicalSeries)
+            .await?;
+        writer.write_all(&bytes).await?;
+        writer.shutdown().await?;
+        Ok(())
+    })
+    .await
+    .expect("series transaction");
+}
+
+const VERSIONS: usize = 12;
+const VERSION_LEN: usize = 96 * 1024;
+
+async fn pond_with_series() -> (tempfile::TempDir, Ship) {
+    let tmp = tempdir().expect("tempdir");
+    let mut ship = Ship::create_pond(tmp.path().join("pond"), "collapse-survey")
+        .await
+        .expect("create pond");
+    for i in 0..VERSIONS {
+        let bytes = chunk(i as u64 + 7, VERSION_LEN);
+        append_series_version(&mut ship, "/events.series", &bytes).await;
+    }
+    (tmp, ship)
+}
+
+/// The survey reports the bytes collapse would rewrite, which is what the push
+/// that follows has to carry.  A figure that did not match the content would be
+/// worse than no figure at all: it would be a budget estimate someone trusted.
+#[tokio::test]
+async fn the_survey_reports_the_real_payload() {
+    let (_t, mut ship) = pond_with_series().await;
+
+    let found = ship.survey_collapsible_series(1).await.expect("survey");
+    assert_eq!(found.len(), 1, "one series should qualify: {found:?}");
+
+    let series = &found[0];
+    assert_eq!(series.live_versions, VERSIONS);
+    assert_eq!(
+        series.total_bytes,
+        (VERSIONS * VERSION_LEN) as u64,
+        "reported payload must be the content collapse would merge"
+    );
+}
+
+/// Asking must be free.  The survey runs under a read transaction that takes no
+/// control records and consumes no sequence, so an operator (or a monitor) can
+/// ask as often as they like without moving the pond.
+#[tokio::test]
+async fn asking_changes_nothing() {
+    let (_t, mut ship) = pond_with_series().await;
+
+    let seq_before = ship
+        .control_table()
+        .latest_spine_seq()
+        .await
+        .expect("seq before");
+
+    let first = ship.survey_collapsible_series(1).await.expect("survey");
+    let second = ship.survey_collapsible_series(1).await.expect("resurvey");
+
+    let seq_after = ship
+        .control_table()
+        .latest_spine_seq()
+        .await
+        .expect("seq after");
+
+    assert_eq!(seq_before, seq_after, "a survey must not advance the pond");
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "a survey must be repeatable, not self-consuming"
+    );
+    assert_eq!(first[0].live_versions, second[0].live_versions);
+    assert_eq!(first[0].total_bytes, second[0].total_bytes);
+}
+
+/// The survey must agree with the collapse it predicts.  This is the whole
+/// contract of a dry run: a preview that names a different candidate set than
+/// the operation would act on is misinformation, not caution.
+#[tokio::test]
+async fn the_survey_agrees_with_the_collapse_it_predicts() {
+    let (_t, mut ship) = pond_with_series().await;
+
+    let predicted = ship.survey_collapsible_series(1).await.expect("survey");
+    let report = ship.collapse_versions(1).await.expect("collapse");
+
+    assert_eq!(
+        report.candidates,
+        predicted.len(),
+        "collapse acted on a different candidate set than the survey reported"
+    );
+    assert!(
+        report.files_collapsed > 0,
+        "the candidate should have merged"
+    );
+
+    // Having merged, the series no longer qualifies at the same threshold:
+    // the survey tracks the pond rather than repeating a stale answer.
+    let after = ship.survey_collapsible_series(1).await.expect("resurvey");
+    assert!(
+        after
+            .iter()
+            .all(|c| c.live_versions < predicted[0].live_versions),
+        "post-collapse survey should reflect the merge: {after:?}"
+    );
+}
+
+/// A threshold nothing exceeds yields nothing -- so a quiet pond's dry run
+/// reports "no work" rather than manufacturing candidates.
+#[tokio::test]
+async fn a_high_threshold_finds_nothing() {
+    let (_t, mut ship) = pond_with_series().await;
+
+    let found = ship
+        .survey_collapsible_series(VERSIONS * 10)
+        .await
+        .expect("survey");
+    assert!(found.is_empty(), "expected no candidates, got {found:?}");
+}
+
+/// The report has to name files, and it has to do so without instantiating
+/// them.  Every real pond carries dynamic nodes under `/sys` whose config
+/// expands from the environment; walking the live tree to collect names made
+/// the preview fail on ponds it was written to inspect.  Paths come from stored
+/// directory rows instead, so an unresolvable factory is just another name.
+#[tokio::test]
+async fn naming_files_does_not_instantiate_them() {
+    let (_t, mut ship) = pond_with_series().await;
+
+    ship.write_transaction(&meta("unresolvable"), async move |fs| {
+        let root = fs.root().await?;
+        _ = root.create_dir_path("/sys").await?;
+        _ = root.create_dir_path("/sys/remotes").await?;
+        _ = root
+            .create_dynamic_path(
+                "/sys/remotes/broken.yaml",
+                tinyfs::EntryType::FileDynamic,
+                "no-such-factory-is-registered",
+                b"endpoint: ${MISSING_ENV_VAR_THAT_IS_NOT_SET}\n".to_vec(),
+            )
+            .await?;
+        Ok(())
+    })
+    .await
+    .expect("stage an unresolvable dynamic node");
+
+    let seq_before = ship
+        .control_table()
+        .latest_spine_seq()
+        .await
+        .expect("seq before");
+
+    let paths = ship.node_paths().await.expect(
+        "naming must not depend on any factory resolving: that is what broke the first attempt",
+    );
+
+    let series = ship.survey_collapsible_series(1).await.expect("survey");
+    assert_eq!(
+        paths.get(&series[0].file_id).map(String::as_str),
+        Some("/events.series"),
+        "the survey's candidate must be nameable: {paths:?}"
+    );
+    assert!(
+        paths.values().any(|p| p == "/sys/remotes/broken.yaml"),
+        "the unresolvable node should be named, not skipped: {paths:?}"
+    );
+
+    // A preview that leaves an open transaction behind has modified the pond it
+    // promised only to look at -- the control table would show it as INCOMPLETE.
+    let seq_after = ship
+        .control_table()
+        .latest_spine_seq()
+        .await
+        .expect("seq after");
+    assert_eq!(
+        seq_before, seq_after,
+        "naming nodes must not advance the pond"
+    );
+}

--- a/crates/steward/tests/content_pull_test.rs
+++ b/crates/steward/tests/content_pull_test.rs
@@ -143,6 +143,30 @@ async fn write_dynamic(
     .expect("dynamic transaction");
 }
 
+/// Rewrite an existing dynamic node with the same factory and config.  The
+/// recipe bytes are unchanged, so the node's content hash is unchanged, but the
+/// rewrite mints a new version carrying a fresh mtime.
+async fn rewrite_dynamic(
+    ship: &mut Ship,
+    path: &str,
+    entry_type: tinyfs::EntryType,
+    factory: &str,
+    config: &[u8],
+) {
+    let path = path.to_string();
+    let factory = factory.to_string();
+    let config = config.to_vec();
+    ship.write_transaction(&meta("re-mknod"), async move |fs| {
+        let root = fs.root().await?;
+        let _ = root
+            .create_dynamic_path_with_overwrite(&path, entry_type, &factory, config, true)
+            .await?;
+        Ok(())
+    })
+    .await
+    .expect("dynamic rewrite transaction");
+}
+
 async fn push(ship: &Ship) -> (tempfile::TempDir, ContentRemote) {
     let pond_id = uuid::Uuid::parse_str(ship.data_persistence().pond_id()).expect("pond id");
     let remote_dir = tempdir().expect("remote dir");
@@ -938,5 +962,71 @@ async fn tampered_manifest_is_rejected_before_commit() {
         root_hash(&dst).await,
         empty_root,
         "a rejected pull must not mutate the target pond"
+    );
+}
+
+/// A source-side change to a node's *metadata alone* replicates.
+///
+/// Rewriting a dynamic node with byte-identical config leaves its content hash
+/// untouched but mints a new version with a fresh mtime.  Because the fold
+/// commits to version metadata as well as bytes, the source's root tree hash
+/// moves; a consumer that planned its diff on content alone would copy nothing,
+/// and the post-apply fold -- which runs *after* the import transaction has
+/// committed -- would then fail on this and on every subsequent pull, because
+/// each retry re-diffs against the same stale metadata.
+///
+/// This is the failure that stalled a production consumer for days: an
+/// unchanging dynamic directory whose mtime kept advancing on the producer.
+#[tokio::test]
+async fn metadata_only_change_replicates() {
+    let (_t, mut src) = new_pond("meta-src").await;
+    write_file(&mut src, "/a.txt", b"alpha").await;
+    write_dynamic(
+        &mut src,
+        "/budget",
+        tinyfs::EntryType::FileDynamic,
+        "rate-limit",
+        b"unit: ops/day\nlimit: 10\nburst: 5\n",
+    )
+    .await;
+
+    let (_rt, mut remote) = push(&src).await;
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), "meta-dst")
+        .await
+        .expect("create dst");
+    let graph = fetch_object_graph(&remote, "main").await.expect("fetch");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("rebuild");
+    assert_eq!(root_hash(&dst).await, root_hash(&src).await);
+
+    // Rewrite with identical config: same recipe bytes, new mtime.
+    let before = root_hash(&src).await;
+    rewrite_dynamic(
+        &mut src,
+        "/budget",
+        tinyfs::EntryType::FileDynamic,
+        "rate-limit",
+        b"unit: ops/day\nlimit: 10\nburst: 5\n",
+    )
+    .await;
+    let after = root_hash(&src).await;
+    assert_ne!(
+        before, after,
+        "a metadata-only rewrite must move the source root tree hash, \
+         otherwise this test cannot observe the bug it guards"
+    );
+
+    repush(&src, &mut remote).await;
+    let graph = fetch_object_graph(&remote, "main").await.expect("fetch");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("re-pull after metadata-only change");
+
+    assert_eq!(
+        root_hash(&dst).await,
+        after,
+        "consumer must adopt the source's new metadata, not keep the stale mtime"
     );
 }

--- a/crates/sync-store/src/azure_registration.rs
+++ b/crates/sync-store/src/azure_registration.rs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Register Azure Blob Storage handlers with delta-rs WITHOUT depending on the
+//! `deltalake-azure` crate, for the same version-pinning reason
+//! [`crate::register_s3_handlers`] avoids `deltalake-aws` at deltalake 0.30.
+//!
+//! Call [`register_azure_handlers`] once at process startup BEFORE opening or
+//! creating any `az://` URL.  In practice nothing calls it directly: a storage
+//! profile registers the handlers its own kind needs
+//! (`steward::storage_profile::ResolvedStorage::register_handlers`), which is
+//! how provider selection stopped being a URL-prefix comparison.
+
+use deltalake::logstore::{
+    LogStore, LogStoreFactory, ObjectStoreFactory, ObjectStoreRef, StorageConfig, default_logstore,
+    logstore_factories, object_store_factories,
+};
+use deltalake::{DeltaResult, DeltaTableError, Path};
+use object_store::ObjectStoreScheme;
+use object_store::azure::{AzureConfigKey, MicrosoftAzureBuilder};
+use std::str::FromStr;
+use std::sync::Arc;
+use url::Url;
+
+#[derive(Clone, Default, Debug)]
+struct AzureStoreFactory {}
+
+impl ObjectStoreFactory for AzureStoreFactory {
+    fn parse_url_opts(
+        &self,
+        url: &Url,
+        config: &StorageConfig,
+    ) -> DeltaResult<(ObjectStoreRef, Path)> {
+        let mut builder = MicrosoftAzureBuilder::new().with_url(url.to_string());
+        for (key, value) in config.raw.iter() {
+            if let Ok(config_key) = AzureConfigKey::from_str(&key.to_ascii_lowercase()) {
+                builder = builder.with_config(config_key, value.clone());
+            }
+        }
+        let (_, path) =
+            ObjectStoreScheme::parse(url).map_err(|e| DeltaTableError::GenericError {
+                source: Box::new(e),
+            })?;
+        let prefix = Path::parse(path)?;
+        let store = builder.build().map_err(|e| DeltaTableError::GenericError {
+            source: Box::new(e),
+        })?;
+        Ok((Arc::new(store), prefix))
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+struct AzureLogStoreFactory {}
+
+impl LogStoreFactory for AzureLogStoreFactory {
+    fn with_options(
+        &self,
+        prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
+        location: &Url,
+        options: &StorageConfig,
+    ) -> DeltaResult<Arc<dyn LogStore>> {
+        Ok(default_logstore(
+            prefixed_store,
+            root_store,
+            location,
+            options,
+        ))
+    }
+}
+
+/// Every URL scheme Azure Blob Storage is reachable under.
+///
+/// `az` and `azure` address the Blob endpoint; `abfs`/`abfss` are the Data Lake
+/// Gen2 spellings of the same store.  All four are registered because a URL
+/// copied from the Azure portal or from Hadoop-flavoured documentation may use
+/// any of them, and a scheme that resolves to no handler fails with a message
+/// about the scheme rather than about the storage.
+pub const AZURE_SCHEMES: &[&str] = &["az", "azure", "abfs", "abfss"];
+
+/// Register Azure handlers for every scheme in [`AZURE_SCHEMES`].
+///
+/// Idempotent across multiple calls, as the underlying registry insert is, so
+/// binding several Azure profiles is safe.
+pub fn register_azure_handlers() {
+    let object_factory = Arc::new(AzureStoreFactory::default());
+    let log_factory = Arc::new(AzureLogStoreFactory::default());
+
+    for scheme in AZURE_SCHEMES {
+        let url = Url::parse(&format!("{scheme}://")).expect("valid scheme URL");
+        object_store_factories().insert(url.clone(), object_factory.clone());
+        logstore_factories().insert(url, log_factory.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Registration must be safe to repeat: profiles register their handlers
+    /// at every bind, not once at startup.
+    #[test]
+    fn registering_twice_is_harmless() {
+        register_azure_handlers();
+        register_azure_handlers();
+
+        for scheme in AZURE_SCHEMES {
+            let url = Url::parse(&format!("{scheme}://")).expect("valid scheme URL");
+            assert!(
+                object_store_factories().get(&url).is_some(),
+                "{scheme} should resolve to a handler"
+            );
+        }
+    }
+}

--- a/crates/sync-store/src/lib.rs
+++ b/crates/sync-store/src/lib.rs
@@ -23,6 +23,7 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs)]
 
+mod azure_registration;
 pub mod checksum;
 pub mod content;
 pub mod content_remote;
@@ -32,6 +33,7 @@ pub mod schema;
 mod store;
 pub mod tlog;
 
+pub use azure_registration::{AZURE_SCHEMES, register_azure_handlers};
 pub use s3_registration::register_s3_handlers;
 
 pub use content::{

--- a/crates/tlogfs/src/lib.rs
+++ b/crates/tlogfs/src/lib.rs
@@ -75,6 +75,7 @@ pub use provider::TinyFsObjectStore;
 // Re-export key types
 pub use error::TLogFSError;
 pub use file::OpLogFileWriter;
+pub use persistence::CollapsibleSeries;
 pub use persistence::ExternalAddAction;
 pub use persistence::OpLogPersistence;
 pub use schema::{DirectoryEntry, OplogEntry};

--- a/crates/tlogfs/src/persistence.rs
+++ b/crates/tlogfs/src/persistence.rs
@@ -21,7 +21,7 @@ use log::{debug, info, warn};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use provider::{FactoryContext, FactoryRegistry};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -188,6 +188,25 @@ struct CollapseCandidate {
     pond_id: String,
     part_id: String,
     node_id: String,
+    live_versions: i64,
+    total_bytes: i64,
+}
+
+/// A series that collapse would merge, with the cost of merging it.
+///
+/// Collapse rewrites every live version into one merged run, so `total_bytes`
+/// is both the payload a push must then carry and the storage the remote gains
+/// permanently -- the superseded blobs are never deleted remotely.  Reporting
+/// it is what lets an operator see the bill before it arrives rather than
+/// after (see `docs/rate-limiter-design.md`, Decision L15).
+#[derive(Debug, Clone)]
+pub struct CollapsibleSeries {
+    /// Identity of the series node.
+    pub file_id: FileID,
+    /// Live versions that would be merged into one.
+    pub live_versions: usize,
+    /// Total live bytes across those versions: the merged run's size.
+    pub total_bytes: u64,
 }
 
 /// How many adjacent same-class versions collapse into one run.
@@ -1775,6 +1794,78 @@ impl State {
         &self,
         threshold: usize,
     ) -> Result<Vec<FileID>, TLogFSError> {
+        Ok(self
+            .survey_collapsible_series(threshold)
+            .await?
+            .into_iter()
+            .map(|c| c.file_id)
+            .collect())
+    }
+
+    /// Map every node in the pond to its path, reading directory rows only.
+    ///
+    /// This deliberately does NOT walk the filesystem.  A glob walk has to
+    /// instantiate each node it passes, which for a dynamic node means running
+    /// its factory and expanding its config -- so naming files would fail on a
+    /// pond whose `/sys/remotes/*` config references an environment variable
+    /// that is not set, which is most real ponds.  Reporting must not be able
+    /// to fail for a reason unrelated to what it reports, so this descends the
+    /// stored directory entries and touches no node.
+    ///
+    /// Dynamic directories are not descended: their children are produced by a
+    /// factory at read time and have no stored rows to name.
+    ///
+    /// # Errors
+    /// Returns an error if a directory's entries cannot be loaded.
+    pub async fn node_paths(&self) -> Result<HashMap<FileID, String>, TLogFSError> {
+        let root = FileID::root_for(self.pond_uuid());
+        let mut paths: HashMap<FileID, String> = HashMap::new();
+        let mut queue = vec![(root, String::new())];
+        let mut seen: HashSet<FileID> = HashSet::new();
+        _ = seen.insert(root);
+
+        while let Some((dir_id, prefix)) = queue.pop() {
+            self.ensure_directory_loaded(dir_id).await?;
+            for entry in self.get_all_directory_entries(dir_id).await? {
+                let child_pond_id = entry
+                    .pond_id
+                    .as_ref()
+                    .and_then(|s| s.parse::<uuid7::Uuid>().ok())
+                    .unwrap_or_else(|| dir_id.pond_id());
+                // Same rule the directory itself uses to form a child's
+                // identity; sharing it is what keeps these paths addressing
+                // the same nodes the rest of the system does.
+                let child_id = if entry.entry_type == EntryType::DirectoryPhysical {
+                    FileID::from_physical_dir_node_id(entry.child_node_id, child_pond_id)
+                } else {
+                    FileID::new_from_ids(dir_id.part_id(), entry.child_node_id, child_pond_id)
+                };
+
+                let path = format!("{prefix}/{}", entry.name);
+                _ = paths.insert(child_id, path.clone());
+
+                if entry.entry_type == EntryType::DirectoryPhysical && seen.insert(child_id) {
+                    queue.push((child_id, path));
+                }
+            }
+        }
+
+        Ok(paths)
+    }
+
+    /// Discover collapse candidates *and* what collapsing each would cost.
+    ///
+    /// This is the same discovery `list_collapsible_series` uses -- it is the
+    /// single implementation of both -- so a dry-run report cannot describe a
+    /// different set of candidates than the collapse that follows it.
+    ///
+    /// # Errors
+    /// Returns an error if the discovery query fails or a returned identifier
+    /// cannot be parsed back into a [`FileID`].
+    pub async fn survey_collapsible_series(
+        &self,
+        threshold: usize,
+    ) -> Result<Vec<CollapsibleSeries>, TLogFSError> {
         let inner = self.inner.lock().await;
         let file_series = EntryType::FilePhysicalSeries.as_str();
         let table_series = EntryType::TablePhysicalSeries.as_str();
@@ -1784,9 +1875,11 @@ impl State {
         // collapsed, so it is excluded from candidacy here.
         let log_node = tinyfs::LOG_NODE_UUID;
         let sql = format!(
-            "SELECT pond_id, part_id, node_id FROM ( \
+            "SELECT pond_id, part_id, node_id, \
+                     COUNT(*) AS live_versions, \
+                     CAST(COALESCE(SUM(size), 0) AS BIGINT) AS total_bytes FROM ( \
                  SELECT t.pond_id AS pond_id, t.part_id AS part_id, t.node_id AS node_id, \
-                        t.version AS version, \
+                        t.version AS version, t.size AS size, \
                         CASE WHEN t.collapsed_through IS NULL THEN t.version \
                              ELSE COALESCE(t.collapsed_from, 0) END AS lo, \
                         CASE WHEN t.collapsed_through IS NULL THEN t.version \
@@ -1846,7 +1939,11 @@ impl State {
                                 row.pond_id
                             ),
                         })?;
-                ids.push(FileID::new_from_ids(part_id, node_id, pond_id));
+                ids.push(CollapsibleSeries {
+                    file_id: FileID::new_from_ids(part_id, node_id, pond_id),
+                    live_versions: usize::try_from(row.live_versions).unwrap_or(0),
+                    total_bytes: u64::try_from(row.total_bytes).unwrap_or(0),
+                });
             }
         }
         Ok(ids)
@@ -4347,7 +4444,7 @@ impl InnerState {
         // [collapsed_from, collapsed_through], so rows inside that range are no
         // longer independently readable. Rows of other entry types carry no
         // range and are left unchanged.
-        let live: std::collections::HashSet<i64> = crate::schema::live_series_entries(&records)
+        let live: HashSet<i64> = crate::schema::live_series_entries(&records)
             .into_iter()
             .map(|r| r.version)
             .collect();

--- a/docs/storage-profile-design.md
+++ b/docs/storage-profile-design.md
@@ -257,13 +257,16 @@ which is a union type wearing a struct's clothes: it can express
 not have been able to represent.
 
 Separate kinds also make dispatch trivial (§0.2): the kind *is* the provider,
-so it selects the handler registration and the option builder directly.
+so it selects the handler registration and the option builder directly.  The
+kind is read from the factory recorded on the node rather than inferred from
+the document (Decision A9), so adding a kind cannot change how an existing one
+is interpreted.
 
 **Only `storage-minio` and `storage-azure` are proposed.** `storage-s3` and
 `storage-r2` are sketched in §3.3 solely as evidence that the shape extends;
 building them before there is a bucket to point them at would be speculation.
 
-### 3.1 `storage-minio` (today)
+### 3.1 `storage-minio`
 
 ```yaml
 version: v1
@@ -297,7 +300,7 @@ Registration reuses `register_s3_handlers` unchanged
 (`sync-store/src/s3_registration.rs:72`), which already covers S3-compatible
 backends.
 
-### 3.2 `storage-azure` (next)
+### 3.2 `storage-azure`
 
 ```yaml
 version: v1
@@ -335,16 +338,27 @@ precedence rule in §4.1. This is the concrete reason Azure cannot be optional
 fields on a shared struct: "exactly one of three groups" is not something a
 flat field set can state.
 
-Implementation notes, all of which are new work rather than configuration:
+Implemented in A3:
 
-- `object_store` needs its `azure` feature (`Cargo.toml:78` enables `aws`
-  only).
-- A `sync-store/src/azure_registration.rs` mirroring `s3_registration.rs`,
-  built on `MicrosoftAzureBuilder`/`AzureConfigKey`, registering the `az`,
-  `azure`, `abfs`, and `abfss` schemes.
-- The URL scheme accepted by an attachment must be validated against the
-  profile kind (§4.2), so an `s3://` URL with an Azure profile is refused at
-  attach rather than producing a confusing failure at first push.
+- `object_store`'s `azure` feature, alongside `aws`.
+- `sync-store/src/azure_registration.rs`, mirroring `s3_registration.rs` on
+  `MicrosoftAzureBuilder`/`AzureConfigKey`, registering the `az`, `azure`,
+  `abfs`, and `abfss` schemes.  All four, because a URL copied from the portal
+  and one copied from Hadoop-flavoured documentation name the same store
+  differently.
+- `provider/src/factory/storage_azure.rs`.  `StorageAzureConfig::credential`
+  is the **only** way to read the credential, so the exactly-one rule is
+  enforced wherever a credential is used rather than being a check each call
+  site has to remember.  `to_storage_options` emits only the chosen shape's
+  keys: handing `MicrosoftAzureBuilder` both a key and a token would rebuild,
+  inside the builder, the ambiguity this kind refuses.
+- The URL scheme accepted by an attachment is validated against the profile
+  kind (§4.2), so an `s3://` URL with an Azure profile is refused at attach
+  rather than producing a confusing failure at first push.
+
+`account_name` is deliberately exempt from A1.  It is an identifier that
+appears in every URL, not a secret; requiring it to be indirect would obscure
+which account a profile names while protecting nothing.
 
 ### 3.3 `storage-s3` and `storage-r2` (not proposed)
 
@@ -521,7 +535,7 @@ to replace.
 | A1 | Attach-time validation, `pond status` line | The failure modes, before any deployment depends on them |
 | A2 | Convert `attach-remotes.sh` to `pond apply` documents | §0.1 -- the thing that motivated this |
 | -- | Store `url` raw, expand at use | §0.1a; separate change, see §10.5 |
-| A3 | `storage-azure`: `object_store` azure feature, `azure_registration.rs`, the factory, dispatch | §0.2, and that the abstraction survives a genuinely different provider |
+| A3 | `storage-azure`: `object_store` azure feature, `azure_registration.rs`, the factory, dispatch on the recorded factory name (A9) | §0.2, and that the abstraction survives a genuinely different provider |
 | -- | `storage-s3` / `storage-r2` | Deferred indefinitely; see §3.3 |
 
 A2 is the MinIO payoff and should not be pulled earlier: converting the script
@@ -606,3 +620,4 @@ introduced. That is worth deciding before A3 rather than during it.
 | A6 | `${env:...}` resolution stays at **use time, per replica**; a profile is never inlined into an attachment at attach time. |
 | A7 | Inline connection fields remain supported indefinitely but stay S3-only; Azure is reachable only through a profile. Rollout is binaries-first, config-second. |
 | A8 | Provider dispatch (handler registration and option building) keys off the profile kind, replacing the eight `starts_with("s3://")` comparisons -- including the one that today silently discards credentials for non-S3 URLs. |
+| A9 | A profile's kind comes from the **factory recorded on the node**, not from sniffing the document's shape. Shape dispatch would oblige every kind to stay parse-disjoint from every other one forever -- a constraint `storage-r2` (§3.3) already strains -- and its failure is silent misattribution: the wrong handlers registered, surfacing as an opaque authentication error on first push. The factory name is already stored and returned by `get_dynamic_node_config`; the kind is a known fact, so it should not be guessed. |


### PR DESCRIPTION
Two changes on this branch. The first was diagnostic groundwork; the second is Phase A3 of `docs/storage-profile-design.md`, which is the point.

---

## 1. `pond maintain --dry-run`

`maintain --collapse-versions 100` runs after every tick in production (`run.sh:98`). Four of its five phases -- prune, compact, checkpoint, vacuum -- are content-preserving, so replication never sees them. **Collapse is the exception**: it writes merged rows as an ordinary transaction, so the next push carries the whole series, and with no `delete_blob` anywhere the superseded blobs are stored forever.

That cost was unknowable in advance: `list_collapsible_series` was private and reachable only by *performing* the collapse. Answering the question with DuckDB over the raw volumes produced confident, wrong numbers -- exactly `100.00 MiB` on unrelated ponds including single-version ones -- which is the antipattern `docs/pond-analysis-cli-design.md` names explicitly.

`--dry-run` follows the precedent `control prune --dry-run` already set. Preview and operation share one discovery path (`list_collapsible_series` delegates to the public `survey_collapsible_series`) so they cannot drift.

Naming the candidates was the subtle part, and my first attempt was wrong twice: walking the live tree instantiated `/sys/remotes/*` and died on `S3_ENDPOINT`, and the failure left an `INCOMPLETE` control record. `node_paths()` reads stored directory rows instead, and the read transaction closes on both paths.

**What it found**, against copies of all eight volumes:

| pond | closest series | live versions | collapse payload |
|---|---|---|---|
| septic-staging | `/ingest/septicstation.json` | **84** / 100 | **52.3 MiB** |
| septic-prod | `/ingest/septicstation.json` | **80** / 100 | **52.3 MiB** |
| water, noyo, site (staging + prod) | -- | < 50 | none |

septic is ~16 ticks from a push carrying 52.3 MiB against a 64 MiB burst.

## 2. Phase A3: `storage-azure`, and dispatch on the recorded factory

Azure is the backend we intend to use; MinIO is what the abstraction was built against. Azure does not differ from MinIO in the *values* of a shared field set -- it differs in what the field set is, which is Decision A3's whole argument for one factory per provider.

**Exactly one of three credential shapes** (account key, SAS token, service principal). Zero is an outage deferred to first push; two has no unambiguous intent, and preferring one silently would let an operator rotate a key, leave a stale token, and keep using the stale one invisibly. `StorageAzureConfig::credential` is the only way to read a credential, so the rule holds at every use rather than being a check each site must remember. Only the chosen shape's keys reach `MicrosoftAzureBuilder` -- passing two would rebuild the same ambiguity one layer down. `account_name` is exempt from the `${env:...}` rule: it is an identifier in every URL, and making it indirect would hide which account a profile names while protecting nothing.

**Decision A9 (new).** Adding a second kind exposed a flaw: `ResolvedStorage::from_bytes` dispatched on document *shape*, justified in a comment by "the node does not record which factory produced it." It does -- `get_dynamic_node_config` returns the factory name, and the code discarded it as `_factory`. Shape dispatch obliges every kind to stay parse-disjoint from every other one forever, which holds today only because MinIO requires an `endpoint` Azure lacks, and which `storage-r2` (§3.3) would immediately strain by being MinIO-shaped. Its failure is silent misattribution: wrong handlers registered, surfacing as an opaque auth error on first push -- the exact class of bug profiles exist to remove. Dispatch now keys off the recorded name.

Also: `object_store`'s `azure` feature, and `sync-store/src/azure_registration.rs` registering `az`/`azure`/`abfs`/`abfss` (all four, since a URL from the portal and one from Hadoop-flavoured docs name the same store differently).

## Tests

- `steward/tests/collapse_survey_test.rs` (5, new) -- payload correctness, that asking is free, preview/collapse agreement, and `naming_files_does_not_instantiate_them`, which stages an unresolvable dynamic node and reproduces both dry-run defects.
- `provider/.../storage_azure.rs` (14) -- each shape alone, zero refused, two refused *naming both*, all three refused, literal credentials refused including every service-principal field, options carrying only the chosen shape, render redacting values while naming the shape.
- `steward/.../storage_profile.rs` (+6) -- Azure scheme acceptance and `s3://` refusal, and that the two kinds do not parse as each other in either direction.
- `cmd/tests/test_apply_remote.rs` (+4) -- **the round trip through `pond apply`**, which is the only thing that can prove the factory name is genuinely stored and returned; a unit test can only assert that a name it supplied was honoured. Plus ambiguous / absent / literal credentials refused at apply rather than at first push.

Full workspace suite passes (45 suites), along with `cargo fmt --all`, `cargo clippy --workspace --all-features -- -D warnings`, and `make check-headers` (712/712).

## Not in scope

No Azure account is wired up yet, and no behaviour of `maintain` changed -- `--dry-run` only reports. Whether septic's threshold should move, or whether collapse should be bounded by the byte budget, is now an informed decision rather than an unknowable one.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

### Replicate a version's metadata, not only its bytes

Diagnosed from a live outage: `site-staging` had failed its 3-hourly pull **33 consecutive times since Aug 3**, blocking all three producers, with

```
imported foreign tree folds to 354f73e3... but the tip root tree is e23bf92a...
```

Folding both ponds offline showed a single `DirectoryDynamic` (`/analysis`) with a **byte-identical** `child_hash` but a `timestamp` 21.9 h apart. `plan_one` pruned on content hash alone, so it planned no op; but #127 made `VersionMeta` part of the tree entry, so the fold could never match. Because the fold runs *after* the import commits, every retry re-diffed against the same stale state — a permanent, self-perpetuating stall.

Metadata now counts as a reason to write, as it already does in `content_diff::diff_dir`. A stuck consumer self-heals on the first pull after this change; no reset needed.