### PR TITLE
Expose bounded limiter state for self-monitoring

### DIFF
--- a/crates/cmd/src/commands/limits.rs
+++ b/crates/cmd/src/commands/limits.rs
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bounded, machine-readable limiter state for monitoring.
+//!
+//! Unlike `/sys/limits/usage`, this command never scans metric history.  It
+//! reads each configured limiter's constant-size bucket state from control,
+//! so a one-minute selfmon probe stays constant in retained pond history.
+
+#![allow(clippy::print_stdout)]
+
+use crate::commands::remote::{list_remote_names, load_remote_attachment};
+use crate::common::ShipContext;
+use anyhow::{Result, anyhow, bail};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use steward::LimiterState;
+
+/// One limiter at one sampling instant.
+///
+/// `remotes` is comma-separated for JSON-log compatibility.  Several remotes
+/// may deliberately share one limiter; deduplicating by `(path, unit)` keeps a
+/// shared site ingress budget from appearing three times.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LimiterStatusRow {
+    pub timestamp: String,
+    pub pond: String,
+    pub remotes: String,
+    pub limiter: String,
+    pub unit: String,
+    pub charged: Option<u64>,
+    pub observed: Option<u64>,
+    pub observed_since_us: Option<i64>,
+    pub observed_window_complete: Option<bool>,
+    pub limit: Option<u64>,
+    pub burst_charged: Option<u64>,
+    pub burst_observed: Option<u64>,
+    pub burst: Option<u64>,
+    pub window_secs: Option<u64>,
+    pub burst_window_secs: Option<u64>,
+    pub reset_secs: Option<u64>,
+    pub burst_reset_secs: Option<u64>,
+    pub error: Option<String>,
+}
+
+impl LimiterStatusRow {
+    fn healthy(timestamp: &str, pond: &str, remotes: String, state: LimiterState) -> Self {
+        Self {
+            timestamp: timestamp.to_string(),
+            pond: pond.to_string(),
+            remotes,
+            limiter: state.path,
+            unit: state.unit.as_str().to_string(),
+            charged: Some(state.used),
+            observed: Some(state.observed),
+            observed_since_us: state.observed_since_us,
+            observed_window_complete: Some(state.observed_window_complete),
+            limit: Some(state.limit),
+            burst_charged: Some(state.burst_used),
+            burst_observed: Some(state.burst_observed),
+            burst: Some(state.burst),
+            window_secs: Some(state.window.as_secs()),
+            burst_window_secs: Some(state.burst_window.as_secs()),
+            reset_secs: Some(state.reset_in.as_secs()),
+            burst_reset_secs: Some(state.burst_reset_in.as_secs()),
+            error: None,
+        }
+    }
+
+    fn broken(
+        timestamp: &str,
+        pond: &str,
+        remotes: String,
+        limiter: String,
+        unit: String,
+        error: String,
+    ) -> Self {
+        Self {
+            timestamp: timestamp.to_string(),
+            pond: pond.to_string(),
+            remotes,
+            limiter,
+            unit,
+            charged: None,
+            observed: None,
+            observed_since_us: None,
+            observed_window_complete: None,
+            limit: None,
+            burst_charged: None,
+            burst_observed: None,
+            burst: None,
+            window_secs: None,
+            burst_window_secs: None,
+            reset_secs: None,
+            burst_reset_secs: None,
+            error: Some(error),
+        }
+    }
+}
+
+/// Read every distinct limiter configured on this pond.
+pub async fn collect_limiter_status(ship_context: &ShipContext) -> Result<Vec<LimiterStatusRow>> {
+    let mut ship = ship_context.open_pond().await?;
+    let pond = ship.control_table().get_pond_metadata().birthplace.clone();
+    let timestamp = chrono::Utc::now().to_rfc3339();
+
+    // First collect identity only.  Opening a limiter needs mutable pond
+    // access, so separating the attachment pass also avoids opening a shared
+    // site limiter once per remote.
+    let mut configured: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
+    for name in list_remote_names(&mut ship).await? {
+        let attachment = load_remote_attachment(&mut ship, &name)
+            .await
+            .map_err(|e| anyhow!("read remote `{name}`: {e}"))?;
+        for (unit, path) in attachment
+            .resolved_limits()
+            .map_err(|e| anyhow!("read limits for remote `{name}`: {e}"))?
+        {
+            configured
+                .entry((path, unit.as_str().to_string()))
+                .or_default()
+                .push(name.clone());
+        }
+    }
+
+    let pond_ship = ship
+        .as_pond_mut()
+        .ok_or_else(|| anyhow!("limits requires a pond steward"))?;
+    let mut rows = Vec::with_capacity(configured.len());
+    for ((path, unit_text), mut remotes) in configured {
+        remotes.sort();
+        remotes.dedup();
+        let remotes = remotes.join(",");
+        let unit = provider::factory::rate_limit::LimitUnit::parse(&unit_text)
+            .map_err(|e| anyhow!("internal limiter unit `{unit_text}`: {e}"))?;
+        let row = match steward::Limiter::open(pond_ship, &path, unit).await {
+            Ok(limiter) => LimiterStatusRow::healthy(&timestamp, &pond, remotes, limiter.state()),
+            Err(e) => {
+                LimiterStatusRow::broken(&timestamp, &pond, remotes, path, unit_text, e.to_string())
+            }
+        };
+        rows.push(row);
+    }
+    Ok(rows)
+}
+
+/// Print limiter state as JSON Lines (for collectors), JSON, or a compact
+/// operator table.
+pub async fn limits_command(ship_context: &ShipContext, format: &str) -> Result<()> {
+    let rows = collect_limiter_status(ship_context).await?;
+    match format {
+        "jsonl" => {
+            for row in rows {
+                println!("{}", serde_json::to_string(&row)?);
+            }
+        }
+        "json" => println!("{}", serde_json::to_string_pretty(&rows)?),
+        "table" => {
+            println!(
+                "{:<24} {:<8} {:>12} {:>12} {:>12} {:>12} {:>12}",
+                "limiter", "unit", "charged", "observed", "limit", "burst used", "burst limit"
+            );
+            for row in rows {
+                if let Some(error) = row.error {
+                    println!("{:<24} {:<8} ERROR: {}", row.limiter, row.unit, error);
+                    continue;
+                }
+                println!(
+                    "{:<24} {:<8} {:>12} {:>12} {:>12} {:>12} {:>12}",
+                    row.limiter,
+                    row.unit,
+                    row.charged.unwrap_or_default(),
+                    row.observed.unwrap_or_default(),
+                    row.limit.unwrap_or_default(),
+                    row.burst_charged.unwrap_or_default(),
+                    row.burst.unwrap_or_default(),
+                );
+            }
+        }
+        other => bail!("unknown limits format `{other}`; expected table, json, or jsonl"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broken_rows_keep_limiter_identity() {
+        let row = LimiterStatusRow::broken(
+            "2026-08-07T00:00:00Z",
+            "water-staging",
+            "origin".to_string(),
+            "/sys/limits/backup-ops".to_string(),
+            "ops".to_string(),
+            "bad policy".to_string(),
+        );
+        let json = serde_json::to_value(row).unwrap();
+        assert_eq!(json["limiter"], "/sys/limits/backup-ops");
+        assert_eq!(json["error"], "bad policy");
+        assert!(json["charged"].is_null());
+    }
+}

--- a/crates/cmd/src/commands/mod.rs
+++ b/crates/cmd/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod export;
 pub mod fsck;
 // pub mod hydrovu;  // Removed: replaced by factory-based `pond run` command
 pub mod init;
+pub mod limits;
 pub mod list;
 pub mod list_factories;
 pub mod maintain;
@@ -38,6 +39,7 @@ pub use describe::describe_command;
 pub use export::export_command;
 pub use fsck::fsck_command;
 pub use init::init_command;
+pub use limits::limits_command;
 pub use list::list_command;
 pub use list_factories::list_factories_command;
 pub use maintain::maintain_command;

--- a/crates/cmd/src/commands/status.rs
+++ b/crates/cmd/src/commands/status.rs
@@ -341,10 +341,17 @@ mod tests {
             path: "/sys/limits/backup".to_string(),
             unit,
             used,
+            observed: used,
+            observed_since_us: Some(0),
+            observed_window_complete: true,
             limit,
+            burst_used: used,
+            burst_observed: used,
             burst: limit,
             window,
+            burst_window: window,
             reset_in: Duration::from_secs(3600),
+            burst_reset_in: Duration::from_secs(3600),
         }
     }
 

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -297,6 +297,12 @@ enum Commands {
     /// Show an operator-facing status aggregate: identity, local commit
     /// state, recovery health, and per-remote sync watermarks (D6).
     Status,
+    /// Show bounded per-limiter state without scanning usage history.
+    Limits {
+        /// Output format for operators or collectors.
+        #[arg(long, default_value = "table", value_parser = ["table", "json", "jsonl"])]
+        format: String,
+    },
     /// Inspect and verify the pond's transparency log (D5).
     Tlog {
         #[command(subcommand)]
@@ -620,6 +626,7 @@ async fn main() -> Result<()> {
         }
         Commands::Verify { name } => commands::verify_command(&ship_context, name).await,
         Commands::Status => commands::status_command(&ship_context).await,
+        Commands::Limits { format } => commands::limits_command(&ship_context, &format).await,
         Commands::Tlog { command } => match command {
             TlogCommand::Show => commands::tlog_show_command(&ship_context).await,
             TlogCommand::Verify => commands::tlog_verify_command(&ship_context).await,

--- a/crates/cmd/tests/test_apply_remote.rs
+++ b/crates/cmd/tests/test_apply_remote.rs
@@ -76,7 +76,7 @@ async fn write_small_file(ctx: &ShipContext, path: &str, bytes: &[u8]) -> anyhow
 /// store, returning that URL.  A pull-mode remote must point at an existing
 /// pond, so an empty directory cannot stand in for one.
 async fn publish_upstream(tmp: &TempDir, name: &str) -> String {
-    let producer = tmp.path().join("producer");
+    let producer = tmp.path().join(format!("producer-{name}"));
     let url = sync_store::testing::in_memory_remote_url(name);
 
     let ctx = ctx_for(&producer, vec!["pond", "init"]);
@@ -222,6 +222,84 @@ async fn apply_creates_a_governed_backup_in_one_document() {
     push_command(&ctx, Some("origin".to_string()))
         .await
         .expect("push under a generous budget must succeed");
+}
+
+/// The monitoring API reports one bounded row per configured limiter without
+/// opening the remote or scanning `/sys/limits/usage`.
+#[tokio::test]
+async fn limits_status_reports_governed_backup_by_path_and_unit() {
+    init_log();
+    let tmp = TempDir::new().expect("tempdir");
+    let pond = tmp.path().join("pond");
+    let url = sync_store::testing::in_memory_remote_url("limits-status");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "limits-status-pond")
+        .await
+        .expect("init");
+
+    apply_yaml(&ctx, tmp.path(), &governed_backup_yaml(&url, 1024, 100_000))
+        .await
+        .expect("apply governed backup");
+
+    let rows = cmd::commands::limits::collect_limiter_status(&ctx)
+        .await
+        .expect("collect limits");
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|r| r.pond == "limits-status-pond"));
+    assert!(rows.iter().all(|r| r.remotes == "origin"));
+    assert!(rows.iter().all(|r| r.error.is_none()));
+    assert!(
+        rows.iter()
+            .any(|r| { r.limiter == "/sys/limits/backup-bytes" && r.unit == "bytes" })
+    );
+    assert!(
+        rows.iter()
+            .any(|r| { r.limiter == "/sys/limits/backup-ops" && r.unit == "ops" })
+    );
+}
+
+/// Several remotes may deliberately share one pond-wide budget.  Monitoring
+/// reports that limiter once, preserving the remote names as context instead
+/// of multiplying the same state by attachment count.
+#[tokio::test]
+async fn limits_status_deduplicates_a_shared_limiter() {
+    init_log();
+    let tmp = TempDir::new().expect("tempdir");
+    let upstream = publish_upstream(&tmp, "limits-shared-upstream-a").await;
+    let upstream2 = publish_upstream(&tmp, "limits-shared-upstream-b").await;
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "limits-shared-consumer")
+        .await
+        .expect("init");
+
+    let mut yaml = governed_pull_yaml(&upstream, 1024, 100_000);
+    yaml.push_str(&format!(
+        r#"---
+version: v1
+kind: remote
+metadata:
+  path: /sys/remotes/upstream2
+spec:
+  url: {upstream2}
+  mount: /sources/upstream2
+  limits:
+    bytes: /sys/limits/pull-bytes
+    ops: /sys/limits/pull-ops
+"#
+    ));
+    apply_yaml(&ctx, tmp.path(), &yaml)
+        .await
+        .expect("apply shared limits");
+
+    let rows = cmd::commands::limits::collect_limiter_status(&ctx)
+        .await
+        .expect("collect limits");
+    assert_eq!(rows.len(), 2, "shared byte/ops limiters must not repeat");
+    assert!(
+        rows.iter().all(|row| row.remotes == "upstream,upstream2"),
+        "{rows:?}"
+    );
 }
 
 /// The binding is not decorative: a backup attached by `pond apply` naming a

--- a/crates/steward/src/limiter.rs
+++ b/crates/steward/src/limiter.rs
@@ -246,6 +246,20 @@ struct StoredWindow {
     bucket_us: i64,
     #[serde(default)]
     buckets: Buckets,
+    /// Physical traffic observed in the same bounded buckets.
+    ///
+    /// Added after charged windows were already deployed.  Serde's default
+    /// makes every v1 control record a valid empty observed window, so this is
+    /// an in-place compatible extension rather than a state reset.
+    #[serde(default)]
+    observed: Buckets,
+    /// First instant independently observed traffic was recorded.
+    ///
+    /// `None` on pre-instrumentation state.  Keeping that unknown is more
+    /// honest than copying charged buckets into observed and manufacturing a
+    /// match the independent instrument never measured.
+    #[serde(default)]
+    observed_since_us: Option<i64>,
 }
 
 const STORED_WINDOW_VERSION: u32 = 1;
@@ -263,6 +277,10 @@ pub struct Limiter {
     loaded: Buckets,
     /// Charges made this session, not yet persisted.
     pending: Buckets,
+    /// Physical traffic seen this session, independently of charging.
+    observed_loaded: Buckets,
+    observed_pending: Buckets,
+    observed_since_us: Option<i64>,
     dirty: bool,
 }
 
@@ -272,11 +290,24 @@ pub struct LimiterState {
     pub path: String,
     pub unit: LimitUnit,
     pub used: u64,
+    /// Physical traffic seen in the same sliding window.
+    pub observed: u64,
+    /// First independently observed sample, in epoch microseconds.
+    pub observed_since_us: Option<i64>,
+    /// Whether independent observation covers this whole sliding window.
+    pub observed_window_complete: bool,
     pub limit: u64,
+    /// Charged traffic in the shorter burst window.
+    pub burst_used: u64,
+    /// Independently observed traffic in the shorter burst window.
+    pub burst_observed: u64,
     pub burst: u64,
     pub window: Duration,
+    pub burst_window: Duration,
     /// How long until any budget frees up, if currently saturated.
     pub reset_in: Duration,
+    /// How long until burst capacity frees up, if saturated.
+    pub burst_reset_in: Duration,
 }
 
 impl Limiter {
@@ -331,11 +362,11 @@ impl Limiter {
                 reason: e.to_string(),
             })?;
 
-        let loaded = match raw {
+        let (loaded, observed_loaded, observed_since_us) = match raw {
             // No key: fresh pond, or the control table was rebuilt.  Start
             // empty rather than refusing to run (Decision L6).
-            None => Buckets::default(),
-            Some(text) if text.is_empty() => Buckets::default(),
+            None => (Buckets::default(), Buckets::default(), None),
+            Some(text) if text.is_empty() => (Buckets::default(), Buckets::default(), None),
             Some(text) => match serde_json::from_str::<StoredWindow>(&text) {
                 // A stored window measured in a different unit or over a
                 // different period is measuring something else; discard it
@@ -346,15 +377,15 @@ impl Limiter {
                         && w.unit == spec.unit
                         && w.window_us == window_micros(spec.window) =>
                 {
-                    w.buckets
+                    (w.buckets, w.observed, w.observed_since_us)
                 }
-                Ok(_) => Buckets::default(),
+                Ok(_) => (Buckets::default(), Buckets::default(), None),
                 Err(e) => {
                     log::warn!(
                         "limiter `{path}`: discarding unreadable control window ({e}); \
                          starting from an empty window"
                     );
-                    Buckets::default()
+                    (Buckets::default(), Buckets::default(), None)
                 }
             },
         };
@@ -364,6 +395,9 @@ impl Limiter {
             spec,
             loaded,
             pending: Buckets::default(),
+            observed_loaded,
+            observed_pending: Buckets::default(),
+            observed_since_us,
             dirty: false,
         })
     }
@@ -446,6 +480,24 @@ impl Limiter {
         self.dirty = true;
     }
 
+    /// Record physical traffic independently of what enforcement charged.
+    pub fn record_observed_at(&mut self, now_us: i64, amount: u64) {
+        if amount == 0 {
+            return;
+        }
+        self.observed_pending
+            .add(now_us, bucket_micros(self.spec.window), amount);
+        if self.observed_since_us.is_none() {
+            self.observed_since_us = Some(now_us);
+        }
+        self.dirty = true;
+    }
+
+    /// Record independently observed physical traffic at the current time.
+    pub fn record_observed(&mut self, amount: u64) {
+        self.record_observed_at(now_micros(), amount);
+    }
+
     /// Fold this session's charges into the persisted window.
     ///
     /// Exactly one control write, and none at all when nothing was charged
@@ -479,12 +531,16 @@ impl Limiter {
             return Ok(None);
         }
         let spent = self.spent();
+        let observed = self.observed_pending.total();
         let window_us = window_micros(self.spec.window);
         let bucket_us = bucket_micros(self.spec.window);
 
         let mut merged = self.loaded.clone();
         merged.merge(&self.pending);
         merged.prune(now_us, window_us, bucket_us);
+        let mut observed_merged = self.observed_loaded.clone();
+        observed_merged.merge(&self.observed_pending);
+        observed_merged.prune(now_us, window_us, bucket_us);
 
         let stored = StoredWindow {
             v: STORED_WINDOW_VERSION,
@@ -492,6 +548,8 @@ impl Limiter {
             window_us,
             bucket_us,
             buckets: merged.clone(),
+            observed: observed_merged.clone(),
+            observed_since_us: self.observed_since_us,
         };
         let text = serde_json::to_string(&stored).map_err(|e| LimiterError::Control {
             path: self.path.clone(),
@@ -507,9 +565,11 @@ impl Limiter {
 
         self.loaded = merged;
         self.pending = Buckets::default();
+        self.observed_loaded = observed_merged;
+        self.observed_pending = Buckets::default();
         self.dirty = false;
 
-        if spent == 0 {
+        if spent == 0 && observed == 0 {
             return Ok(None);
         }
         // Reported after the merge, so `used` is the window total including
@@ -520,9 +580,7 @@ impl Limiter {
             limiter: state.path,
             unit: state.unit.as_str().to_string(),
             amount: spent,
-            // Filled in by the set, which is what knows the measurement for
-            // this dimension; a limiter alone only knows what it charged.
-            observed: 0,
+            observed,
             used: state.used,
             limit: state.limit,
             window_us,
@@ -555,14 +613,24 @@ impl Limiter {
     #[must_use]
     pub fn state_at(&self, now_us: i64) -> LimiterState {
         let window_us = window_micros(self.spec.window);
+        let burst_us = burst_span_micros(&self.spec, window_us);
         LimiterState {
             path: self.path.clone(),
             unit: self.spec.unit,
             used: self.used_at(now_us, window_us),
+            observed: self.observed_at(now_us, window_us),
+            observed_since_us: self.observed_since_us,
+            observed_window_complete: self
+                .observed_since_us
+                .is_some_and(|since| now_us.saturating_sub(since) >= window_us),
             limit: self.spec.amount,
+            burst_used: self.used_at(now_us, burst_us),
+            burst_observed: self.observed_at(now_us, burst_us),
             burst: self.spec.burst,
             window: self.spec.window,
+            burst_window: Duration::from_micros(u64::try_from(burst_us).unwrap_or(u64::MAX)),
             reset_in: Duration::from_secs(self.retry_after_secs(now_us, window_us)),
+            burst_reset_in: Duration::from_secs(self.retry_after_secs(now_us, burst_us)),
         }
     }
 
@@ -570,6 +638,12 @@ impl Limiter {
         self.loaded
             .sum_since(now_us, span_us)
             .saturating_add(self.pending.sum_since(now_us, span_us))
+    }
+
+    fn observed_at(&self, now_us: i64, span_us: i64) -> u64 {
+        self.observed_loaded
+            .sum_since(now_us, span_us)
+            .saturating_add(self.observed_pending.sum_since(now_us, span_us))
     }
 
     fn exceeded(&self, now_us: i64, used: u64, requested: u64, window_us: i64) -> LimiterError {
@@ -810,35 +884,6 @@ impl LimiterSet {
         reported
     }
 
-    /// What an ignored run measured, as samples that record the traffic
-    /// without charging it.  Pure.
-    ///
-    /// `amount` is zero because nothing was charged, and `observed` carries
-    /// what physically happened -- so a seeding import appears in the metric
-    /// as a spike far above `limit` that was deliberately let through.  A run
-    /// that measured nothing emits nothing, like any other.
-    fn ignored_samples_at(&self, now_us: i64) -> Vec<crate::limiter_usage::UsageSample> {
-        let mut samples = Vec::new();
-        for l in &self.bound {
-            let observed = self.observed(l.spec().unit);
-            if l.spent() == 0 && observed == 0 {
-                continue;
-            }
-            let state = l.state_at(now_us);
-            samples.push(crate::limiter_usage::UsageSample {
-                at_us: now_us,
-                limiter: state.path,
-                unit: state.unit.as_str().to_string(),
-                amount: 0,
-                observed,
-                used: state.used,
-                limit: state.limit,
-                window_us: window_micros(l.spec().window),
-            });
-        }
-        samples
-    }
-
     /// Charge `amount` of `unit` after the action succeeded.  Pure: no I/O.
     pub fn record(&mut self, unit: LimitUnit, amount: u64) {
         if let Some(l) = self.get_mut(unit) {
@@ -883,50 +928,59 @@ impl LimiterSet {
         control: &mut ControlTable,
         now_us: i64,
     ) -> Result<(), LimiterError> {
-        // An ignored run does not persist its windows.  A seeding import can be
-        // three orders of magnitude larger than a normal day, so folding it into
-        // the sliding window would leave the budget exhausted and refuse routine
-        // traffic for a full period -- the override would create the outage it
-        // was invoked to avoid.
+        // An ignored run does not persist its CHARGED window.  A seeding import
+        // can be three orders of magnitude larger than a normal day, so folding
+        // it into enforcement would leave the budget exhausted and refuse
+        // routine traffic for a full period -- the override would create the
+        // outage it was invoked to avoid.
         //
-        // The traffic is still *measured*.  Not charging it is the point of the
-        // override; not recording it would mean the largest transfer a pond
-        // ever makes is the one thing its metric cannot show.  So a sample is
-        // emitted with what was observed and an `amount` of zero: the spike is
-        // visible, exceeds the limit, and is plainly marked as having been
-        // let through rather than paid for.
+        // Its observed window IS persisted.  Not charging the import is the
+        // point of the override; not recording it would make the largest
+        // transfer a pond ever performs invisible to status and selfmon.
+        let ignored_spending = self.prepare_windows_at(now_us);
+
+        let mut samples = Vec::new();
+        for l in &mut self.bound {
+            if let Some(sample) = l.commit_window_at(control, now_us).await? {
+                samples.push(sample);
+            }
+        }
+
         if self.ignored {
-            let samples = self.ignored_samples_at(now_us);
-            for (path, unit, spent) in self.discard_ignored_spending() {
+            for (path, unit, spent) in ignored_spending {
                 log::warn!(
                     "[WARN] {IGNORE_LIMITS_ENV} spent {spent} {unit} ungoverned (not charged to `{path}`)"
                 );
             }
-            self.observed_ops = 0;
-            self.observed_bytes = 0;
-            crate::limiter_usage::queue(control, &samples).await;
-            return Ok(());
         }
-
-        let mut samples = Vec::new();
-        for l in &mut self.bound {
-            let observed = match l.spec().unit {
-                LimitUnit::Ops => self.observed_ops,
-                LimitUnit::Bytes => self.observed_bytes,
-            };
-            if let Some(mut sample) = l.commit_window_at(control, now_us).await? {
-                sample.observed = observed;
-                samples.push(sample);
-            }
-        }
-        self.observed_ops = 0;
-        self.observed_bytes = 0;
 
         // Queue for the pond in one write, so spending becomes a durable
         // metric and not just enforcement state that a control rebuild erases
         // (Decision L12).
         crate::limiter_usage::queue(control, &samples).await;
         Ok(())
+    }
+
+    /// Move this activity's independent measurements into each bound
+    /// limiter's bounded window, and remove ignored charged spending before
+    /// anything is persisted.  Split from [`Self::commit_at`] so the subtle
+    /// ignored ordering is directly testable without a control table.
+    fn prepare_windows_at(&mut self, now_us: i64) -> Vec<(String, &'static str, u64)> {
+        let ignored_spending = if self.ignored {
+            self.discard_ignored_spending()
+        } else {
+            Vec::new()
+        };
+        for l in &mut self.bound {
+            let observed = match l.spec().unit {
+                LimitUnit::Ops => self.observed_ops,
+                LimitUnit::Bytes => self.observed_bytes,
+            };
+            l.record_observed_at(now_us, observed);
+        }
+        self.observed_ops = 0;
+        self.observed_bytes = 0;
+        ignored_spending
     }
 
     /// Current position of every bound limiter, for `pond status`.
@@ -1003,6 +1057,9 @@ mod tests {
             spec,
             loaded: Buckets::default(),
             pending: Buckets::default(),
+            observed_loaded: Buckets::default(),
+            observed_pending: Buckets::default(),
+            observed_since_us: None,
             dirty: false,
         }
     }
@@ -1092,18 +1149,13 @@ mod tests {
         set.record(LimitUnit::Bytes, spent);
         set.record_observed(LimitUnit::Bytes, spent);
 
-        let samples = set.ignored_samples_at(0);
-        assert_eq!(samples.len(), 1);
-        assert_eq!(
-            samples[0].amount, 0,
-            "an ignored run charges nothing, and must say so"
-        );
-        assert_eq!(
-            samples[0].observed, spent,
-            "but what physically happened is still measured"
-        );
+        let ignored = set.prepare_windows_at(0);
+        assert_eq!(ignored, vec![("/sys/limits/b".to_string(), "bytes", spent)]);
+        let state = set.bound[0].state_at(0);
+        assert_eq!(state.used, 0, "an ignored run charges nothing");
+        assert_eq!(state.observed, spent, "physical traffic remains visible");
         assert!(
-            samples[0].observed > samples[0].limit,
+            state.observed > state.limit,
             "and the whole point is that it exceeds the ceiling visibly"
         );
     }
@@ -1116,7 +1168,7 @@ mod tests {
             bound: vec![limiter("/sys/limits/b", spec("MiB/day", 1.0, None))],
             ignored: true,
         };
-        assert!(set.ignored_samples_at(0).is_empty());
+        assert_eq!(set.bound[0].state_at(0).observed, 0);
     }
 
     // -------- the unit contract (Decision L10) --------
@@ -1344,12 +1396,49 @@ mod tests {
             window_us: window_micros(s.window),
             bucket_us: bucket_micros(s.window),
             buckets: buckets.clone(),
+            observed: Buckets::default(),
+            observed_since_us: None,
         };
         let text = serde_json::to_string(&stored).unwrap();
         let back: StoredWindow = serde_json::from_str(&text).unwrap();
         assert_eq!(back.buckets, buckets);
         assert_eq!(back.unit, LimitUnit::Bytes);
         assert_eq!(back.window_us, DAY_US);
+    }
+
+    #[test]
+    fn deployed_window_without_observed_buckets_still_loads() {
+        let text = r#"{
+            "v":1,
+            "unit":"bytes",
+            "window_us":86400000000,
+            "bucket_us":864000000,
+            "buckets":[[100,42]]
+        }"#;
+        let back: StoredWindow = serde_json::from_str(text).unwrap();
+        assert_eq!(back.buckets.total(), 42);
+        assert!(
+            back.observed.is_empty(),
+            "observed was added compatibly after v1 windows were deployed"
+        );
+        assert_eq!(back.observed_since_us, None);
+    }
+
+    #[test]
+    fn state_reports_charged_observed_and_burst_windows_separately() {
+        let now = 1_000 * DAY_US;
+        let mut l = limiter("/l", spec("iops/day", 100.0, Some(10.0)));
+        l.record_at(now, 7);
+        l.record_observed_at(now, 9);
+
+        let state = l.state_at(now);
+        assert_eq!(state.used, 7);
+        assert_eq!(state.observed, 9);
+        assert!(!state.observed_window_complete);
+        assert_eq!(state.burst_used, 7);
+        assert_eq!(state.burst_observed, 9);
+        assert_eq!(state.burst, 10);
+        assert_eq!(state.burst_window, Duration::from_secs(8_640));
     }
 
     #[test]

--- a/crates/steward/src/limiter_usage.rs
+++ b/crates/steward/src/limiter_usage.rs
@@ -114,7 +114,11 @@ impl tinyfs::arrow::schema::ForArrow for LimiterUsageRow {
             Arc::new(Field::new("limiter", DataType::Utf8, false)),
             Arc::new(Field::new("unit", DataType::Utf8, false)),
             Arc::new(Field::new("amount", DataType::UInt64, false)),
-            Arc::new(Field::new("observed", DataType::UInt64, false)),
+            // Added after the usage series was already live.  Old parquet
+            // files have no `observed` column, so schema evolution pads them
+            // with null.  Declaring the field non-nullable made every query of
+            // an upgraded pond fail before it could reach the new rows.
+            Arc::new(Field::new("observed", DataType::UInt64, true)),
             Arc::new(Field::new("used", DataType::UInt64, false)),
             Arc::new(Field::new("limit", DataType::UInt64, false)),
             Arc::new(Field::new("window_secs", DataType::UInt64, false)),
@@ -310,5 +314,9 @@ mod tests {
             DataType::Timestamp(TimeUnit::Microsecond, _)
         ));
         assert_eq!(fields.len(), 8);
+        assert!(
+            fields[4].is_nullable(),
+            "observed was added after the series went live, so old rows must be readable"
+        );
     }
 }

--- a/crates/steward/tests/limiter_test.rs
+++ b/crates/steward/tests/limiter_test.rs
@@ -78,12 +78,15 @@ async fn a_window_survives_rebinding_through_the_control_table() {
         .await
         .expect("open");
     l.record(4 * 1024 * 1024);
+    l.record_observed(5 * 1024 * 1024);
     l.commit(ship.control_table_mut()).await.expect("commit");
 
     let again = Limiter::open(&mut ship, "/quota", LimitUnit::Bytes)
         .await
         .expect("reopen");
     assert_eq!(again.state().used, 4 * 1024 * 1024);
+    assert_eq!(again.state().observed, 5 * 1024 * 1024);
+    assert!(again.state().observed_since_us.is_some());
     assert_eq!(again.state().limit, 10 * 1024 * 1024);
 }
 


### PR DESCRIPTION
## Summary
- persist independently observed traffic beside charged traffic in bounded sliding/burst windows
- add `pond limits --format table|json|jsonl` for constant-time local monitoring
- keep pre-instrument usage rows queryable by making `observed` schema-compatible
- report observation-window coverage so upgrades do not look like attribution gaps

## Why
Physical metering on watershop showed the limits working, but operators could only see refusals in journals and `/sys/limits/usage` became unreadable on ponds containing older rows. Selfmon needs a bounded status surface that does not scan retained history or contact remote storage.

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `make check-headers`
