### PR TITLE
Fix sitegen exports for dynamic series

### DIFF
--- a/crates/sitegen/src/factory.rs
+++ b/crates/sitegen/src/factory.rs
@@ -470,7 +470,8 @@ async fn run_format_provider_export(
     config: &SiteConfig,
 ) -> Result<(BTreeMap<String, Vec<shortcodes::ExportedFile>>, Vec<String>), tinyfs::Error> {
     let fs = provider_ctx.filesystem();
-    let provider = provider::Provider::new(Arc::new(fs)).with_root(root.clone());
+    let provider = provider::Provider::with_context(Arc::new(fs), Arc::new(provider_ctx.clone()))
+        .with_root(root.clone());
 
     // Use UrlPatternMatcher to expand the pattern and get matched files
     let matcher = provider::UrlPatternMatcher::new(provider);


### PR DESCRIPTION
## Summary
- construct URL export providers with the pond ProviderContext
- allow sitegen exports such as `series:///derived/limiters-current` to execute dynamic series nodes

## Validation
- `cargo test -p sitegen`
- `cargo clippy -p sitegen --all-features -- -D warnings`
- `cargo fmt --all -- --check`