### PR TITLE
Add pond limiter dashboard renderer

### DIFF
--- a/crates/sitegen/assets/limiters.js
+++ b/crates/sitegen/assets/limiters.js
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: 2025 Caspar Water Company
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { createFileRegistry, initDuckdb } from "./duckdb-shared.js";
+
+function number(value) {
+  return value == null ? null : Number(value);
+}
+
+function formatValue(value, unit) {
+  const n = number(value);
+  if (n == null || !Number.isFinite(n)) return "unknown";
+  if (unit !== "bytes") return Math.round(n).toLocaleString();
+
+  const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+  let scaled = n;
+  let index = 0;
+  while (Math.abs(scaled) >= 1024 && index < units.length - 1) {
+    scaled /= 1024;
+    index++;
+  }
+  const digits = scaled >= 100 || index === 0 ? 0 : scaled >= 10 ? 1 : 2;
+  return `${scaled.toFixed(digits)} ${units[index]}`;
+}
+
+function formatDuration(value) {
+  const seconds = number(value);
+  if (seconds == null || !Number.isFinite(seconds)) return "unknown";
+  if (seconds < 60) return `${Math.max(0, Math.round(seconds))}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86400) return `${(seconds / 3600).toFixed(1)}h`;
+  return `${(seconds / 86400).toFixed(1)}d`;
+}
+
+function labelFor(row) {
+  const leaf = String(row.limiter || "limiter").split("/").pop();
+  return leaf
+    .replace(/-ops$/, " operations")
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function appendText(parent, tag, className, text) {
+  const element = document.createElement(tag);
+  if (className) element.className = className;
+  element.textContent = text;
+  parent.appendChild(element);
+  return element;
+}
+
+function utilizationClass(ratio) {
+  if (ratio >= 0.9) return "limit-red";
+  if (ratio >= 0.7) return "limit-yellow";
+  return "limit-green";
+}
+
+function renderMeter(parent, title, used, limit, unit, resetSeconds) {
+  const usedNumber = number(used);
+  const limitNumber = number(limit);
+  const ratio =
+    usedNumber != null && limitNumber != null && limitNumber > 0
+      ? usedNumber / limitNumber
+      : 0;
+
+  const heading = document.createElement("div");
+  heading.className = "limiter-meter-heading";
+  appendText(heading, "span", "limiter-meter-name", title);
+  appendText(
+    heading,
+    "span",
+    "limiter-meter-value",
+    `${formatValue(used, unit)} / ${formatValue(limit, unit)} (${(
+      ratio * 100
+    ).toFixed(1)}%)`
+  );
+  parent.appendChild(heading);
+
+  const track = document.createElement("div");
+  track.className = "limiter-meter-track";
+  track.setAttribute("role", "meter");
+  track.setAttribute("aria-valuemin", "0");
+  track.setAttribute("aria-valuemax", String(limitNumber || 0));
+  track.setAttribute("aria-valuenow", String(usedNumber || 0));
+  track.setAttribute("aria-label", `${title} utilization`);
+  const fill = document.createElement("div");
+  fill.className = `limiter-meter-fill ${utilizationClass(ratio)}`;
+  fill.style.width = `${Math.min(100, Math.max(0, ratio * 100))}%`;
+  track.appendChild(fill);
+  parent.appendChild(track);
+
+  appendText(
+    parent,
+    "div",
+    "limiter-meter-reset",
+    `Resets in ${formatDuration(resetSeconds)}`
+  );
+}
+
+function renderLimiter(row) {
+  const card = document.createElement("section");
+  card.className = "limiter-card";
+  appendText(card, "h3", "limiter-name", labelFor(row));
+  appendText(
+    card,
+    "div",
+    "limiter-identity",
+    `${row.remotes || "no remote"} \u00b7 ${row.unit || "unknown unit"}`
+  );
+
+  if (row.error) {
+    appendText(card, "p", "limiter-error", String(row.error));
+    return card;
+  }
+
+  renderMeter(
+    card,
+    "Sliding window",
+    row.charged,
+    row.limit,
+    row.unit,
+    row.reset_secs
+  );
+  if (number(row.burst) > 0 || number(row.burst_charged) > 0) {
+    renderMeter(
+      card,
+      "Burst",
+      row.burst_charged,
+      row.burst,
+      row.unit,
+      row.burst_reset_secs
+    );
+  }
+
+  const observed = formatValue(row.observed, row.unit);
+  const suffix =
+    row.observed_window_complete === true
+      ? ""
+      : row.observed_window_complete === false
+        ? " \u00b7 observation window warming up"
+        : "";
+  appendText(
+    card,
+    "div",
+    "limiter-observed",
+    `Observed ${observed}${suffix}`
+  );
+  return card;
+}
+
+function renderDashboard(container, rows) {
+  container.innerHTML = "";
+  if (!rows.length) {
+    appendText(container, "p", "limiter-empty", "No limiter state available.");
+    return;
+  }
+
+  const grouped = new Map();
+  for (const row of rows) {
+    const pond = String(row.pond || "unknown pond");
+    if (!grouped.has(pond)) grouped.set(pond, []);
+    grouped.get(pond).push(row);
+  }
+
+  for (const [pond, pondRows] of grouped) {
+    const section = document.createElement("section");
+    section.className = "limiter-pond";
+    appendText(section, "h2", "limiter-pond-name", pond);
+
+    const grid = document.createElement("div");
+    grid.className = "limiter-grid";
+    for (const row of pondRows) grid.appendChild(renderLimiter(row));
+    section.appendChild(grid);
+    container.appendChild(section);
+  }
+}
+
+async function main() {
+  const container = document.getElementById("limiters");
+  if (!container) return;
+  const manifestElement = container.querySelector(
+    'script.limiter-data[type="application/json"]'
+  );
+  if (!manifestElement) return;
+
+  const manifest = JSON.parse(manifestElement.textContent);
+  if (!manifest.length) {
+    renderDashboard(container, []);
+    return;
+  }
+  container.innerHTML = '<p class="limiter-loading">Loading limiter state...</p>';
+
+  const { db, conn } = await initDuckdb();
+  const { ensureFile } = createFileRegistry(db);
+  const views = [];
+  for (let i = 0; i < manifest.length; i++) {
+    const file = await ensureFile(manifest[i].file);
+    if (!file) continue;
+    const view = `limiter_${i}`;
+    await conn.query(
+      `CREATE VIEW ${view} AS SELECT * FROM read_parquet('${file}')`
+    );
+    views.push(view);
+  }
+  if (!views.length) {
+    renderDashboard(container, []);
+    return;
+  }
+
+  const result = await conn.query(
+    views
+      .map((view) => `SELECT * FROM ${view}`)
+      .join(" UNION ALL BY NAME ") + " ORDER BY pond, limiter, unit"
+  );
+  renderDashboard(container, result.toArray());
+}
+
+main().catch((error) => {
+  console.error("limiter dashboard failed:", error);
+  const container = document.getElementById("limiters");
+  if (container) {
+    container.innerHTML = "";
+    appendText(
+      container,
+      "p",
+      "limiter-error",
+      `Unable to load limiter state: ${String(error)}`
+    );
+  }
+});

--- a/crates/sitegen/assets/style.css
+++ b/crates/sitegen/assets/style.css
@@ -1203,6 +1203,112 @@ h3:hover .anchor {
 .log-info td  { color: var(--fg); }
 .log-debug td { color: var(--fg-muted); }
 
+/* ---- Limiter utilization dashboard ---- */
+
+.limiter-dashboard {
+  margin-top: 1.5rem;
+}
+
+.limiter-loading,
+.limiter-empty {
+  color: var(--fg-muted);
+}
+
+.limiter-pond {
+  margin: 0 0 2rem;
+}
+
+.limiter-pond-name {
+  margin: 0 0 0.75rem;
+  color: var(--accent);
+  font-size: 1.25rem;
+}
+
+.limiter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 1rem;
+}
+
+.limiter-card {
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-sm);
+}
+
+.limiter-name {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--fg);
+}
+
+.limiter-identity {
+  margin: 0.1rem 0 0.9rem;
+  color: var(--fg-muted);
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.limiter-meter-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  font-size: 0.78rem;
+}
+
+.limiter-meter-name {
+  color: var(--fg-secondary);
+  font-weight: 600;
+}
+
+.limiter-meter-value {
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.limiter-meter-track {
+  height: 0.65rem;
+  margin-top: 0.25rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--border);
+}
+
+.limiter-meter-fill {
+  height: 100%;
+  min-width: 2px;
+  border-radius: inherit;
+  transition: width 0.2s ease;
+}
+
+.limiter-meter-fill.limit-green { background: var(--status-green); }
+.limiter-meter-fill.limit-yellow { background: var(--status-yellow); }
+.limiter-meter-fill.limit-red { background: var(--status-red); }
+
+.limiter-meter-reset {
+  margin-top: 0.15rem;
+  color: var(--fg-muted);
+  font-size: 0.72rem;
+  text-align: right;
+}
+
+.limiter-observed {
+  margin-top: 0.8rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--border-light);
+  color: var(--fg-secondary);
+  font-size: 0.78rem;
+}
+
+.limiter-error {
+  color: var(--status-red);
+  font-weight: 600;
+}
+
 /* Build footer */
 .build-footer {
   grid-column: 1 / -1;

--- a/crates/sitegen/src/factory.rs
+++ b/crates/sitegen/src/factory.rs
@@ -1620,6 +1620,7 @@ fn write_shared_assets(output_dir: &Path) -> Result<(), tinyfs::Error> {
     static VEGA_SHARED_JS: &str = include_str!("../assets/vega-shared.js");
     static OVERLAY_JS: &str = include_str!("../assets/overlay.js");
     static LOG_VIEWER_JS: &str = include_str!("../assets/log-viewer.js");
+    static LIMITERS_JS: &str = include_str!("../assets/limiters.js");
     static RELATIVE_TIME_JS: &str = include_str!("../assets/relative-time.js");
 
     for (name, content) in [
@@ -1630,6 +1631,7 @@ fn write_shared_assets(output_dir: &Path) -> Result<(), tinyfs::Error> {
         ("vega-shared.js", VEGA_SHARED_JS),
         ("overlay.js", OVERLAY_JS),
         ("log-viewer.js", LOG_VIEWER_JS),
+        ("limiters.js", LIMITERS_JS),
         ("relative-time.js", RELATIVE_TIME_JS),
     ] {
         let path = output_dir.join(name);

--- a/crates/sitegen/src/layouts.rs
+++ b/crates/sitegen/src/layouts.rs
@@ -151,6 +151,7 @@ pub fn apply_layout(name: &str, ctx: &LayoutContext) -> String {
     let markup = match name {
         "data" => data_layout(ctx),
         "logs" => logs_layout(ctx),
+        "limiters" => limiters_layout(ctx),
         "explore" => explore_layout(ctx),
         "page" => page_layout(ctx),
         "blog" => blog_layout(ctx),
@@ -245,6 +246,36 @@ fn logs_layout(ctx: &LayoutContext) -> Markup {
                 }
                 (build_footer(ctx.footer))
                 script src=(format!("{}log-viewer.js", ctx.root_base_url)) type="module" {}
+            }
+        }
+    }
+}
+
+/// Layout for the pond-grouped limiter utilization dashboard.
+fn limiters_layout(ctx: &LayoutContext) -> Markup {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                (common_head(ctx))
+            }
+            body {
+                (build_header(ctx.header, ctx.base_url))
+                @if let Some(sidebar_html) = ctx.sidebar {
+                    nav class="sidebar" {
+                        (PreEscaped(sidebar_html))
+                    }
+                }
+                main class="content-page" {
+                    (top_bar(Some("Home"), Some(ctx.base_url), ctx.feed_url, ctx.github_url))
+                    article class="blog-post" {
+                        div class="blog-post-content" {
+                            (PreEscaped(ctx.content))
+                        }
+                    }
+                }
+                (build_footer(ctx.footer))
+                script src=(format!("{}limiters.js", ctx.root_base_url)) type="module" {}
             }
         }
     }
@@ -650,6 +681,28 @@ mod tests {
         assert!(html.contains("type=\"module\""), "Module script: {}", html);
         assert!(html.contains("class=\"sidebar\""), "Sidebar present");
         assert!(!html.contains("chart.js"), "No chart.js in logs layout");
+    }
+
+    #[test]
+    fn test_limiters_layout_loads_dedicated_renderer() {
+        let ctx = LayoutContext {
+            title: "Limiters",
+            site_title: "Watershop Selfmon",
+            base_url: "/selfmon/",
+            root_base_url: "/selfmon/",
+            content: "<div id=\"limiters\"></div>",
+            sidebar: Some("<ul><li>Limiters</li></ul>"),
+            date: None,
+            feed_url: None,
+            github_url: None,
+            footer: None,
+            header: None,
+        };
+        let html = apply_layout("limiters", &ctx);
+        assert!(html.contains("/selfmon/limiters.js"));
+        assert!(html.contains("type=\"module\""));
+        assert!(html.contains("class=\"sidebar\""));
+        assert!(!html.contains("log-viewer.js"));
     }
 
     #[test]

--- a/crates/sitegen/src/shortcodes.rs
+++ b/crates/sitegen/src/shortcodes.rs
@@ -665,6 +665,18 @@ const VIZ_LOGS: VizRenderer = VizRenderer {
     empty_msg: "No log files available.",
 };
 
+/// Current limiter utilization grouped by pond (limiters.js): manifest only.
+const VIZ_LIMITERS: VizRenderer = VizRenderer {
+    id: "limiters",
+    container_class: "limiter-dashboard",
+    data_class: "limiter-data",
+    include_registry: false,
+    include_default_range: false,
+    include_explore: false,
+    include_annotations: false,
+    empty_msg: "No limiter state available.",
+};
+
 /// Resolve a `renderer=` name (from the `{{ viz }}` shortcode) to its
 /// descriptor. Unknown names yield `None` so the shortcode can surface an error.
 fn viz_renderer(name: &str) -> Option<&'static VizRenderer> {
@@ -672,6 +684,7 @@ fn viz_renderer(name: &str) -> Option<&'static VizRenderer> {
         "chart" => Some(&VIZ_CHART),
         "overlay" => Some(&VIZ_OVERLAY),
         "logs" | "log" | "log-viewer" => Some(&VIZ_LOGS),
+        "limiters" => Some(&VIZ_LIMITERS),
         _ => None,
     }
 }
@@ -1936,6 +1949,7 @@ mod tests {
         assert!(viz_renderer("overlay").is_some());
         assert!(viz_renderer("logs").is_some());
         assert!(viz_renderer("log-viewer").is_some());
+        assert!(viz_renderer("limiters").is_some());
         assert!(viz_renderer("nope").is_none());
     }
 


### PR DESCRIPTION
## Summary
- group limiter status by pond instead of showing generic event rows
- graph sliding-window and burst utilization with green/yellow/red meters
- format operations and byte budgets, reset timing, observed traffic, and migration warm-up state
- add a dedicated sitegen renderer, layout, browser asset, and tests

## Validation
- `cargo test -p sitegen`
- `cargo clippy -p sitegen --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `make check-headers`
- `node --check crates/sitegen/assets/limiters.js`