### PR TITLE
Enforce limits on multipart upload parts

### DIFF
--- a/crates/steward/tests/limiter_test.rs
+++ b/crates/steward/tests/limiter_test.rs
@@ -180,6 +180,46 @@ async fn an_exhausted_budget_stops_the_push() {
     assert!(text.contains("retry in"), "{text}");
 }
 
+/// A large blob is admitted one multipart part at a time.  The provider must
+/// never receive the part that would cross either configured byte ceiling.
+#[tokio::test]
+async fn a_multipart_blob_cannot_overrun_its_window_or_burst() {
+    const MIB: usize = 1024 * 1024;
+
+    let (_t, mut ship) = new_pond("limiter-multipart-deny").await;
+    write_limiter(&mut ship, "/quota", "MiB/day", 6.0, Some(6.0)).await;
+    let body = vec![b'x'; 12 * MIB];
+    let hash = sync_store::content::ObjectHash::of_bytes(&body);
+    write_file(&mut ship, "/large.bin", &body).await;
+
+    let pond_id = uuid::Uuid::parse_str(ship.data_persistence().pond_id()).expect("pond id");
+    let mut remote = ContentRemote::create_at_url(
+        &sync_store::testing::in_memory_remote_url("push-multipart-denied"),
+        pond_id,
+        [].into(),
+    )
+    .await
+    .expect("create remote");
+
+    let mut limits = LimiterSet::open(&mut ship, &[(LimitUnit::Bytes, "/quota".to_string())])
+        .await
+        .expect("bind");
+    let err = push_content_to_remote_limited(&ship, &mut remote, "main", &mut limits)
+        .await
+        .expect_err("multipart blob must exceed its budget");
+
+    assert!(matches!(err, StewardError::RateLimited(_)), "{err:?}");
+    assert!(
+        limits.states()[0].used <= 6 * MIB as u64,
+        "denied push charged past its configured ceiling: {:?}",
+        limits.states()[0]
+    );
+    assert!(
+        !remote.has_blob(hash).await.expect("probe refused blob"),
+        "a refused multipart blob must not become visible"
+    );
+}
+
 /// An ungoverned dimension costs nothing at all: no pond read, no control
 /// read, no control write.
 #[tokio::test]

--- a/crates/sync-store/src/content_remote.rs
+++ b/crates/sync-store/src/content_remote.rs
@@ -32,6 +32,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::RwLock;
 
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use uuid::Uuid;
 
 use crate::content::ObjectHash;
@@ -74,9 +76,12 @@ pub struct ContentRemote {
 }
 
 impl ContentRemote {
+    /// Multipart providers require non-final parts of at least 5 MiB.
+    const MULTIPART_PART_SIZE: usize = 5 * 1024 * 1024;
     /// Maximum in-flight multipart part uploads allowed while streaming a large
     /// blob to the remote (see [`Self::put_blob`]).  Bounds staged upload memory
-    /// to this many `chunk_size` parts when the reader outpaces the network.
+    /// to this many [`Self::MULTIPART_PART_SIZE`] parts when the reader outpaces
+    /// the network.
     const MAX_INFLIGHT_UPLOAD_PARTS: usize = 16;
 
     /// Create a fresh remote at `path`.  Errors if a Delta table already
@@ -339,11 +344,9 @@ impl ContentRemote {
     /// under a key it does not equal.  Never collects the whole blob in memory.
     ///
     /// Backpressure is applied so a fast local reader cannot outrun a slow
-    /// upload: `WriteMultipart::write` starts a part upload as soon as a chunk
-    /// fills, regardless of how many are already in flight, so without a bound
-    /// the staged parts of a multi-gigabyte blob would accumulate in memory.
-    /// Capping in-flight parts at [`Self::MAX_INFLIGHT_UPLOAD_PARTS`] holds the
-    /// staged bytes to that many `chunk_size` parts.
+    /// upload.  Keeping the multipart handle here, rather than delegating the
+    /// trailing-part flush to `WriteMultipart::finish`, also guarantees every
+    /// failed or refused part can be followed by an explicit abort.
     pub async fn put_blob<R>(&self, hash: ObjectHash, mut reader: R) -> Result<()>
     where
         R: tokio::io::AsyncRead + Unpin,
@@ -356,33 +359,65 @@ impl ContentRemote {
             .put_multipart(&path)
             .await
             .map_err(|e| StoreError::Invariant(format!("blob put_multipart: {e}")))?;
-        let mut writer = object_store::WriteMultipart::new(upload);
+        let mut upload = upload;
+        let mut parts = FuturesUnordered::new();
         let mut hasher = blake3::Hasher::new();
-        let mut buf = vec![0u8; 8 * 1024 * 1024];
+
         loop {
-            let n = reader
-                .read(&mut buf)
-                .await
-                .map_err(|e| StoreError::Invariant(format!("blob read: {e}")))?;
-            if n == 0 {
+            if parts.len() >= Self::MAX_INFLIGHT_UPLOAD_PARTS {
+                match parts.next().await {
+                    Some(Ok(())) => {}
+                    Some(Err(error)) => {
+                        drop(parts);
+                        let abort = upload.abort().await;
+                        return Err(StoreError::Invariant(match abort {
+                            Ok(()) => format!("blob upload part: {error}"),
+                            Err(abort_error) => {
+                                format!("blob upload part: {error}; abort failed: {abort_error}")
+                            }
+                        }));
+                    }
+                    None => {}
+                }
+            }
+
+            let mut part = vec![0u8; Self::MULTIPART_PART_SIZE];
+            let mut filled = 0;
+            while filled < part.len() {
+                let n = match reader.read(&mut part[filled..]).await {
+                    Ok(n) => n,
+                    Err(error) => {
+                        drop(parts);
+                        let abort = upload.abort().await;
+                        return Err(StoreError::Invariant(match abort {
+                            Ok(()) => format!("blob read: {error}"),
+                            Err(abort_error) => {
+                                format!("blob read: {error}; abort failed: {abort_error}")
+                            }
+                        }));
+                    }
+                };
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&part[filled..filled + n]);
+                filled += n;
+            }
+            if filled == 0 {
                 break;
             }
-            hasher.update(&buf[..n]);
-            // Bound the number of in-flight part uploads before staging more, so
-            // a reader faster than the network cannot grow memory without limit.
-            writer
-                .wait_for_capacity(Self::MAX_INFLIGHT_UPLOAD_PARTS)
-                .await
-                .map_err(|e| StoreError::Invariant(format!("blob upload capacity: {e}")))?;
-            writer.write(&buf[..n]);
+            part.truncate(filled);
+            parts.push(upload.put_part(part.into()));
         }
+
         // Verify the streamed content matches its claimed key BEFORE completing
         // the multipart upload.  A multipart object only becomes visible on
         // `finish()`, so aborting here discards the staged parts and a value is
         // never stored under a key it does not equal -- no temporary key needed.
         let computed = ObjectHash::from_bytes(*hasher.finalize().as_bytes());
         if computed != hash {
-            writer
+            drop(parts);
+            upload
                 .abort()
                 .await
                 .map_err(|e| StoreError::Invariant(format!("blob abort: {e}")))?;
@@ -392,10 +427,28 @@ impl ContentRemote {
                 hash.to_hex()
             )));
         }
-        writer
-            .finish()
-            .await
-            .map_err(|e| StoreError::Invariant(format!("blob finish: {e}")))?;
+
+        while let Some(result) = parts.next().await {
+            if let Err(error) = result {
+                drop(parts);
+                let abort = upload.abort().await;
+                return Err(StoreError::Invariant(match abort {
+                    Ok(()) => format!("blob upload part: {error}"),
+                    Err(abort_error) => {
+                        format!("blob upload part: {error}; abort failed: {abort_error}")
+                    }
+                }));
+            }
+        }
+        if let Err(error) = upload.complete().await {
+            let abort = upload.abort().await;
+            return Err(StoreError::Invariant(match abort {
+                Ok(()) => format!("blob complete: {error}"),
+                Err(abort_error) => {
+                    format!("blob complete: {error}; abort failed: {abort_error}")
+                }
+            }));
+        }
         Ok(())
     }
 

--- a/crates/sync-store/src/metered_store.rs
+++ b/crates/sync-store/src/metered_store.rs
@@ -601,16 +601,23 @@ struct MeteredUpload {
 impl MultipartUpload for MeteredUpload {
     fn put_part(&mut self, data: PutPayload) -> UploadPart {
         let bytes = data.content_length() as u64;
+        if let Err(error) = check(self.meter.as_ref(), 1, bytes) {
+            return Box::pin(async move { Err(error) });
+        }
         record(&self.key, self.meter.as_ref(), 1, bytes);
         self.inner.put_part(data)
     }
 
     async fn complete(&mut self) -> ObjectStoreResult<PutResult> {
+        check(self.meter.as_ref(), 1, 0)?;
         record(&self.key, self.meter.as_ref(), 1, 0);
         self.inner.complete().await
     }
 
     async fn abort(&mut self) -> ObjectStoreResult<()> {
+        // Cleanup must remain possible after the request budget is exhausted:
+        // refusing an abort can leave staged multipart data accruing storage
+        // charges.  Account for the request, but deliberately do not admit it.
         record(&self.key, self.meter.as_ref(), 1, 0);
         self.inner.abort().await
     }
@@ -640,6 +647,54 @@ mod tests {
         fn record(&self, ops: u64, bytes: u64) {
             *self.ops.lock().unwrap() += ops;
             *self.bytes.lock().unwrap() += bytes;
+        }
+    }
+
+    #[derive(Debug)]
+    struct ByteBudget {
+        limit: u64,
+        used: Mutex<u64>,
+    }
+
+    impl StorageMeter for ByteBudget {
+        fn check(&self, _ops: u64, bytes: u64) -> Result<(), String> {
+            let used = *self.used.lock().unwrap();
+            if used.saturating_add(bytes) > self.limit {
+                return Err(format!(
+                    "byte budget exceeded: {used}/{} used, request for {bytes} denied",
+                    self.limit
+                ));
+            }
+            Ok(())
+        }
+
+        fn record(&self, _ops: u64, bytes: u64) {
+            let mut used = self.used.lock().unwrap();
+            *used = used.saturating_add(bytes);
+        }
+    }
+
+    #[derive(Debug)]
+    struct RequestBudget {
+        limit: u64,
+        used: Mutex<u64>,
+    }
+
+    impl StorageMeter for RequestBudget {
+        fn check(&self, ops: u64, _bytes: u64) -> Result<(), String> {
+            let used = *self.used.lock().unwrap();
+            if used.saturating_add(ops) > self.limit {
+                return Err(format!(
+                    "request budget exceeded: {used}/{} used, request for {ops} denied",
+                    self.limit
+                ));
+            }
+            Ok(())
+        }
+
+        fn record(&self, ops: u64, _bytes: u64) {
+            let mut used = self.used.lock().unwrap();
+            *used = used.saturating_add(ops);
         }
     }
 
@@ -693,6 +748,79 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("budget spent"), "{err}");
+    }
+
+    /// Every multipart part is a separate physical request, so it must be
+    /// admitted before reaching the provider.  Checking only when the upload
+    /// is opened lets one large blob overrun the entire budget before the next
+    /// object-store call notices.
+    #[tokio::test]
+    async fn a_multipart_upload_stops_before_exceeding_its_byte_budget() {
+        const MIB: u64 = 1024 * 1024;
+
+        let meter = Arc::new(ByteBudget {
+            limit: 6 * MIB,
+            used: Mutex::new(0),
+        });
+        let (store, key) = store("multipart-byte-budget");
+        let path = ObjectPath::from("large");
+        let binding = bind_meter(&key, meter.clone());
+        let upload = store.put_multipart(&path).await.unwrap();
+        let mut writer = object_store::WriteMultipart::new(upload);
+
+        // WriteMultipart emits 5 MiB parts.  The first fits; admitting the
+        // second would exceed the 6 MiB budget and must fail before upload.
+        writer.write(&vec![0u8; 12 * MIB as usize]);
+        let err = writer
+            .finish()
+            .await
+            .expect_err("second part must be denied");
+        drop(binding);
+
+        assert!(err.to_string().contains("byte budget exceeded"), "{err}");
+        assert_eq!(*meter.used.lock().unwrap(), 5 * MIB);
+        assert!(
+            store.head(&path).await.is_err(),
+            "a refused multipart upload must not publish a partial object"
+        );
+    }
+
+    /// Completing a multipart upload is itself a physical request.  It must
+    /// not slip past an exhausted IOPS budget, but the subsequent abort must
+    /// still reach the provider so staged parts do not become a storage cost.
+    #[tokio::test]
+    async fn multipart_completion_is_limited_but_cleanup_is_not_refused() {
+        let meter = Arc::new(RequestBudget {
+            limit: 2,
+            used: Mutex::new(0),
+        });
+        let (store, key) = store("multipart-request-budget");
+        let path = ObjectPath::from("large");
+        let binding = bind_meter(&key, meter.clone());
+        let mut upload = store.put_multipart(&path).await.unwrap();
+
+        upload
+            .put_part(PutPayload::from_static(b"part"))
+            .await
+            .unwrap();
+        let err = upload
+            .complete()
+            .await
+            .expect_err("completion must exceed the request budget");
+        assert!(err.to_string().contains("request budget exceeded"), "{err}");
+
+        upload.abort().await.expect("cleanup must remain possible");
+        drop(binding);
+
+        assert_eq!(
+            *meter.used.lock().unwrap(),
+            3,
+            "initiation, part, and mandatory cleanup are charged"
+        );
+        assert!(
+            store.head(&path).await.is_err(),
+            "a refused completion must not publish the object"
+        );
     }
 
     /// Unmetered work still functions: the wrapper is installed


### PR DESCRIPTION
## Summary
- admit every multipart part against byte and operation budgets before sending it
- retain multipart upload control so refused, failed, or invalid blobs abort staged provider data
- limit completion requests while always allowing charged abort cleanup
- add storage-layer and real pond-push regressions for blobs larger than window and burst limits

## Production finding
A water-prod Azure push transferred roughly 11.27 GB despite a 1 GiB/day limit because multipart parts were recorded without being checked. The next request observed the overspent window and refused, too late to prevent the upload. This change enforces at each 5 MiB part boundary.

## Validation
- `cargo test -p sync-store` (170 passed)
- `cargo test -p steward --test limiter_test` (12 passed)
- `cargo clippy -p sync-store --all-targets -- -D warnings`
- `cargo clippy -p steward --lib --test limiter_test -- -D warnings`

Workspace-wide steward all-target clippy remains blocked by the pre-existing `clone_on_copy` warning in `crates/steward/tests/fsck_test.rs:94`.