### PR TITLE
remote: migrate verified pull watermarks

### DIFF
--- a/crates/cmd/src/commands/apply.rs
+++ b/crates/cmd/src/commands/apply.rs
@@ -94,7 +94,7 @@ struct MknodSpec {
 ///
 /// These describe *how to attach*, not *what to attach to*, which is why they
 /// are not part of the replicated attachment document.
-const REMOTE_CONTROL_KEYS: [&str; 3] = ["mount", "bidirectional", "overwrite"];
+const REMOTE_CONTROL_KEYS: [&str; 4] = ["mount", "bidirectional", "overwrite", "migrate_watermark"];
 
 /// Spec for `kind: copy`.
 #[derive(Debug, Deserialize)]
@@ -136,6 +136,7 @@ enum ApplyKind {
         /// Mount path, pull-mode only.
         mount: Option<String>,
         overwrite: bool,
+        migrate_watermark: bool,
     },
 }
 
@@ -412,6 +413,7 @@ fn parse_remote_kind(doc: &ResourceDoc, source_file: &str, index: usize) -> Resu
     };
     let bidirectional = as_bool("bidirectional")?;
     let overwrite = as_bool("overwrite")?;
+    let migrate_watermark = as_bool("migrate_watermark")?;
 
     let mount = match control.get("mount") {
         None => None,
@@ -505,6 +507,20 @@ fn parse_remote_kind(doc: &ResourceDoc, source_file: &str, index: usize) -> Resu
                 mount_path
             ));
         }
+    } else if migrate_watermark {
+        return Err(anyhow!(
+            "{}[{}]: 'migrate_watermark' is valid only for kind 'remote'",
+            source_file,
+            index
+        ));
+    }
+
+    if migrate_watermark && !overwrite {
+        return Err(anyhow!(
+            "{}[{}]: 'migrate_watermark: true' requires 'overwrite: true'",
+            source_file,
+            index
+        ));
     }
 
     Ok(ApplyKind::Remote {
@@ -513,6 +529,7 @@ fn parse_remote_kind(doc: &ResourceDoc, source_file: &str, index: usize) -> Resu
         mode,
         mount,
         overwrite,
+        migrate_watermark,
     })
 }
 
@@ -681,6 +698,7 @@ pub async fn apply_command(ship_context: &ShipContext, files: &[String]) -> Resu
             mode,
             mount,
             overwrite,
+            migrate_watermark,
         } = &spec.kind
         else {
             continue;
@@ -692,6 +710,7 @@ pub async fn apply_command(ship_context: &ShipContext, files: &[String]) -> Resu
             *mode,
             mount.as_deref(),
             *overwrite,
+            *migrate_watermark,
         )
         .await
         .map_err(|e| {

--- a/crates/cmd/src/commands/remote.rs
+++ b/crates/cmd/src/commands/remote.rs
@@ -20,7 +20,9 @@
 use crate::common::ShipContext;
 use anyhow::{Result, anyhow};
 use std::collections::BTreeMap;
-use steward::{REMOTE_MODE_PREFIX, REMOTE_MOUNT_PATH_PREFIX, SYS_DIR, SYS_REMOTES_DIR};
+use steward::{
+    ContentSource, REMOTE_MODE_PREFIX, REMOTE_MOUNT_PATH_PREFIX, SYS_DIR, SYS_REMOTES_DIR,
+};
 use tinyfs::EntryType;
 use tokio::io::AsyncWriteExt;
 
@@ -107,6 +109,7 @@ pub async fn add_remote_command(
         RemoteMode::Pull,
         Some(path),
         overwrite,
+        false,
     )
     .await
 }
@@ -152,6 +155,7 @@ pub async fn add_backup_command(
         mode,
         None,
         overwrite,
+        false,
     )
     .await
 }
@@ -168,6 +172,7 @@ pub async fn add_backup_command(
 ///
 /// Persists the attachment YAML, records mode and -- for pull -- the mount
 /// path, and auto-initializes the remote Delta table.
+#[allow(clippy::too_many_arguments)]
 pub async fn attach_remote(
     ship_context: &ShipContext,
     name: &str,
@@ -175,6 +180,7 @@ pub async fn attach_remote(
     mode: RemoteMode,
     mount_path: Option<&str>,
     overwrite: bool,
+    migrate_watermark: bool,
 ) -> Result<()> {
     validate_name(name)?;
     let url = attachment.url.as_str();
@@ -224,6 +230,12 @@ pub async fn attach_remote(
 
     let mut ship = ship_context.open_pond().await?;
 
+    let watermark_migration = if migrate_watermark {
+        Some(prepare_watermark_migration(&mut ship, name, url, mode, mount_path, overwrite).await?)
+    } else {
+        None
+    };
+
     // D5.7b.5: mount-conflict pre-checks (local only) for pull-mode
     // remotes.  Refuse if another pull-mode attachment already mounts
     // the same `mount_path` (would create overlapping mount entries).
@@ -272,9 +284,16 @@ pub async fn attach_remote(
         // either a content remote (`s3://`, `file://`) or a producer pond clone
         // on local disk (`pond://<path>`, the develop-and-preview workflow).
         let remote_store_id = if let Some(path) = attachment.url.strip_prefix("pond://") {
-            use steward::ContentSource;
             match steward::LocalPondSource::open(path).await {
-                Ok(source) => source.pond_id(),
+                Ok(source) => {
+                    verify_watermark_destination(
+                        &source,
+                        watermark_migration.as_ref(),
+                        &attachment.url,
+                    )
+                    .await?;
+                    source.pond_id()
+                }
                 Err(e) => {
                     return Err(anyhow!(
                         "remote `{}` at {} is not a readable local pond: {}; pull-mode \
@@ -289,7 +308,15 @@ pub async fn attach_remote(
             match sync_store::ContentRemote::open_at_url(&attachment.url, storage_options.clone())
                 .await
             {
-                Ok(remote) => remote.pond_id(),
+                Ok(remote) => {
+                    verify_watermark_destination(
+                        &remote,
+                        watermark_migration.as_ref(),
+                        &attachment.url,
+                    )
+                    .await?;
+                    remote.pond_id()
+                }
                 Err(_) => {
                     return Err(anyhow!(
                         "remote `{}` at {} is not a content remote; pull-mode remotes must \
@@ -445,6 +472,29 @@ pub async fn attach_remote(
     .await
     .map_err(|e| anyhow!("Failed to add remote: {}", e))?;
 
+    if let Some(migration) = watermark_migration {
+        ship.control_table_mut()
+            .raw_config_set(&format!("last_pulled_tip:{url}"), &migration.tip)
+            .await
+            .map_err(|e| anyhow!("record migrated pull watermark for `{name}`: {e}"))?;
+        if migration.old_url == url {
+            log::info!(
+                "[OK] verified existing pull watermark for {} at {} ({})",
+                name,
+                url,
+                migration.tip
+            );
+        } else {
+            log::info!(
+                "[OK] migrated pull watermark for {}: {} -> {} at {}",
+                name,
+                migration.old_url,
+                url,
+                migration.tip
+            );
+        }
+    }
+
     match mount_path {
         Some(p) => log::info!(
             "[OK] added remote {} -> {} (mode={}, mount={})",
@@ -459,6 +509,184 @@ pub async fn attach_remote(
             url,
             mode.as_str()
         ),
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct PullWatermarkMigration {
+    old_url: String,
+    tip: String,
+    foreign_pond_id: String,
+}
+
+impl PullWatermarkMigration {
+    fn verify(&self, remote_pond_id: uuid::Uuid, remote_tip: Option<&str>) -> Result<()> {
+        if remote_pond_id.to_string() != self.foreign_pond_id {
+            return Err(anyhow!(
+                "cannot migrate pull watermark: replacement remote has pond_id {}, \
+                 but graft pin records {}",
+                remote_pond_id,
+                self.foreign_pond_id
+            ));
+        }
+        match remote_tip {
+            Some(tip) if tip == self.tip => Ok(()),
+            Some(tip) => Err(anyhow!(
+                "cannot migrate pull watermark: replacement remote tip {} does not \
+                 exactly match pinned tip {}; refresh the source pond while both remotes \
+                 are synchronized before retrying",
+                tip,
+                self.tip
+            )),
+            None => Err(anyhow!(
+                "cannot migrate pull watermark: replacement remote has no `main` tip"
+            )),
+        }
+    }
+}
+
+async fn prepare_watermark_migration(
+    ship: &mut steward::Steward,
+    name: &str,
+    new_url: &str,
+    mode: RemoteMode,
+    mount_path: Option<&str>,
+    overwrite: bool,
+) -> Result<PullWatermarkMigration> {
+    if !overwrite || mode != RemoteMode::Pull {
+        return Err(anyhow!(
+            "pull watermark migration requires overwrite of a pull remote"
+        ));
+    }
+    let mount_path = mount_path
+        .filter(|path| *path != "/")
+        .ok_or_else(|| anyhow!("pull watermark migration requires a cross-pond mount path"))?;
+    let old_attachment = load_remote_attachment(ship, name).await.map_err(|e| {
+        anyhow!(
+            "cannot migrate pull watermark: existing remote `{}` is unavailable: {}",
+            name,
+            e
+        )
+    })?;
+    if remote_mode_for(ship, name).await? != RemoteMode::Pull {
+        return Err(anyhow!(
+            "cannot migrate pull watermark: existing remote `{}` is not pull-mode",
+            name
+        ));
+    }
+    let old_mount = ship
+        .control_table()
+        .raw_config_get(&format!("{REMOTE_MOUNT_PATH_PREFIX}{name}"))
+        .await
+        .map_err(|e| anyhow!("read existing mount path for `{name}`: {e}"))?
+        .ok_or_else(|| {
+            anyhow!("cannot migrate pull watermark: existing remote has no mount path")
+        })?;
+    if !paths_equivalent(&old_mount, mount_path) {
+        return Err(anyhow!(
+            "cannot migrate pull watermark: existing mount `{}` differs from replacement mount `{}`",
+            old_mount,
+            mount_path
+        ));
+    }
+
+    let tip = ship
+        .control_table()
+        .raw_config_get(&format!("last_pulled_tip:{}", old_attachment.url))
+        .await
+        .map_err(|e| anyhow!("read existing pull watermark for `{name}`: {e}"))?
+        .filter(|tip| !tip.is_empty())
+        .ok_or_else(|| {
+            if old_attachment.url == new_url {
+                anyhow!(
+                    "cannot verify completed pull watermark migration: replacement URL `{}` \
+                     is already attached but has no pull watermark; restore the original \
+                     attachment and retry the migration",
+                    old_attachment.url
+                )
+            } else {
+                anyhow!(
+                    "cannot migrate pull watermark: existing URL `{}` has no pull watermark",
+                    old_attachment.url
+                )
+            }
+        })?;
+
+    let pin_path = steward::GraftPin::pin_path(name);
+    let tx = ship
+        .begin_read(&steward::PondUserMetadata::new(vec![
+            "remote".to_string(),
+            "migrate-watermark".to_string(),
+            name.to_string(),
+        ]))
+        .await
+        .map_err(|e| anyhow!("begin graft pin read for `{name}`: {e}"))?;
+    let pin_bytes = {
+        let root = tx.root().await?;
+        if !root.exists(&pin_path).await {
+            return Err(anyhow!(
+                "cannot migrate pull watermark: graft pin `{}` does not exist",
+                pin_path
+            ));
+        }
+        root.read_file_path_to_vec(&pin_path)
+            .await
+            .map_err(|e| anyhow!("read graft pin `{pin_path}`: {e}"))?
+    };
+    let _ = tx
+        .commit()
+        .await
+        .map_err(|e| anyhow!("commit graft pin read for `{name}`: {e}"))?;
+    let pin = steward::GraftPin::from_yaml_bytes(&pin_bytes)
+        .map_err(|e| anyhow!("parse graft pin `{pin_path}`: {e}"))?;
+    if !paths_equivalent(&pin.mount_path, mount_path) {
+        return Err(anyhow!(
+            "cannot migrate pull watermark: graft pin mount `{}` differs from replacement mount `{}`",
+            pin.mount_path,
+            mount_path
+        ));
+    }
+    if pin.pinned_tip != tip {
+        return Err(anyhow!(
+            "cannot migrate pull watermark: graft pin tip {} differs from existing URL watermark {}",
+            pin.pinned_tip,
+            tip
+        ));
+    }
+
+    Ok(PullWatermarkMigration {
+        old_url: old_attachment.url,
+        tip,
+        foreign_pond_id: pin.foreign_pond_id,
+    })
+}
+
+async fn verify_watermark_destination(
+    source: &impl ContentSource,
+    migration: Option<&PullWatermarkMigration>,
+    url: &str,
+) -> Result<()> {
+    let Some(migration) = migration else {
+        return Ok(());
+    };
+    let tip = source
+        .get_tip("main")
+        .await
+        .map_err(|e| anyhow!("read tip from `{url}`: {e}"))?;
+    let tip_text = tip.as_ref().map(ToString::to_string);
+    migration.verify(source.pond_id(), tip_text.as_deref())?;
+    let tip = tip.expect("verified destination tip is present");
+    if source
+        .get_object(tip)
+        .await
+        .map_err(|e| anyhow!("read pinned commit {} from `{url}`: {e}", migration.tip))?
+        .is_none()
+    {
+        return Err(anyhow!(
+            "cannot migrate pull watermark: replacement remote does not contain pinned commit {}",
+            migration.tip
+        ));
     }
     Ok(())
 }

--- a/crates/cmd/tests/test_apply_remote.rs
+++ b/crates/cmd/tests/test_apply_remote.rs
@@ -19,7 +19,7 @@ use cmd::commands::{
 };
 use cmd::common::ShipContext;
 use provider::factory::rate_limit::LimitUnit;
-use std::sync::Once;
+use std::{collections::HashMap, sync::Once};
 use steward::{PondUserMetadata, REMOTE_MODE_PREFIX, RemoteMode};
 use tempfile::TempDir;
 use tinyfs::EntryType;
@@ -170,6 +170,47 @@ spec:
     ops: /sys/limits/backup-ops
 "#
     )
+}
+
+fn pull_remote_yaml(url: &str, overwrite: bool, migrate_watermark: bool) -> String {
+    format!(
+        r#"version: v1
+kind: remote
+metadata:
+  path: /sys/remotes/upstream
+spec:
+  url: {url}
+  mount: /sources/upstream
+  overwrite: {overwrite}
+  migrate_watermark: {migrate_watermark}
+"#
+    )
+}
+
+async fn publish_equivalent_remotes(tmp: &TempDir, name: &str) -> (ShipContext, String, String) {
+    let producer = tmp.path().join(format!("producer-{name}"));
+    let first = sync_store::testing::in_memory_remote_url(&format!("{name}-first"));
+    let second = sync_store::testing::in_memory_remote_url(&format!("{name}-second"));
+    let ctx = ctx_for(&producer, vec!["pond", "init"]);
+    init_command(&ctx, "producer-host")
+        .await
+        .expect("init producer");
+    apply_yaml(
+        &ctx,
+        tmp.path(),
+        &format!(
+            "version: v1\nkind: backup\nmetadata:\n  path: /sys/remotes/first\nspec:\n  url: {first}\n---\nversion: v1\nkind: backup\nmetadata:\n  path: /sys/remotes/second\nspec:\n  url: {second}\n"
+        ),
+    )
+    .await
+    .expect("attach equivalent producer remotes");
+    write_small_file(&ctx, "/hello.txt", b"same commit on both remotes")
+        .await
+        .expect("write producer content");
+    push_command(&ctx, None)
+        .await
+        .expect("publish identical producer tip");
+    (ctx, first, second)
 }
 
 /// A governed backup authored entirely in YAML behaves like one authored with
@@ -746,6 +787,339 @@ async fn a_governed_pull_within_budget_still_succeeds() {
     assert!(
         tip.is_some_and(|t| !t.is_empty()),
         "a successful governed pull must record the tip it pulled"
+    );
+}
+
+#[tokio::test]
+async fn overwrite_can_migrate_a_verified_pull_watermark_between_equivalent_remotes() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let (_producer, first, second) = publish_equivalent_remotes(&tmp, "migration-ok").await;
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&first, false, false))
+        .await
+        .expect("attach first remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("pull first remote");
+
+    let old_tip = ctx
+        .open_pond()
+        .await
+        .expect("open")
+        .control_table()
+        .raw_config_get(&format!("last_pulled_tip:{first}"))
+        .await
+        .expect("read old watermark")
+        .expect("old watermark");
+
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&second, true, true))
+        .await
+        .expect("migrate equivalent remote watermark");
+
+    let mut ship = ctx.open_pond().await.expect("open migrated pond");
+    assert_eq!(
+        load_remote_attachment(&mut ship, "upstream")
+            .await
+            .expect("load migrated attachment")
+            .url,
+        second
+    );
+    assert_eq!(
+        ship.control_table()
+            .raw_config_get(&format!("last_pulled_tip:{second}"))
+            .await
+            .expect("read migrated watermark"),
+        Some(old_tip.clone())
+    );
+    assert_eq!(
+        ship.control_table()
+            .raw_config_get(&format!("last_pulled_tip:{first}"))
+            .await
+            .expect("read retained old watermark"),
+        Some(old_tip)
+    );
+    drop(ship);
+
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&second, true, true))
+        .await
+        .expect("reapplying a completed migration must be safe");
+}
+
+#[tokio::test]
+async fn watermark_migration_refuses_an_advanced_destination_without_replacing_the_remote() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let (producer, first, second) = publish_equivalent_remotes(&tmp, "migration-advanced").await;
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&first, false, false))
+        .await
+        .expect("attach first remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("pull first remote");
+
+    write_small_file(&producer, "/later.txt", b"new producer commit")
+        .await
+        .expect("advance producer");
+    push_command(&producer, None)
+        .await
+        .expect("publish advanced tip");
+
+    let err = apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&second, true, true))
+        .await
+        .expect_err("advanced destination must not inherit an older watermark");
+    assert!(
+        format!("{err:#}").contains("does not exactly match pinned tip"),
+        "unexpected migration error: {err:#}"
+    );
+
+    let mut ship = ctx.open_pond().await.expect("open unchanged pond");
+    assert_eq!(
+        load_remote_attachment(&mut ship, "upstream")
+            .await
+            .expect("load original attachment")
+            .url,
+        first
+    );
+    assert_eq!(
+        ship.control_table()
+            .raw_config_get(&format!("last_pulled_tip:{second}"))
+            .await
+            .expect("read replacement watermark"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn watermark_migration_refuses_a_different_producer_identity() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let (_producer, first, _equivalent) =
+        publish_equivalent_remotes(&tmp, "migration-identity-a").await;
+    let different = publish_upstream(&tmp, "migration-identity-b").await;
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&first, false, false))
+        .await
+        .expect("attach first remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("pull first producer");
+
+    let err = apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&different, true, true))
+        .await
+        .expect_err("a different producer must not inherit the watermark");
+    assert!(
+        format!("{err:#}").contains("replacement remote has pond_id"),
+        "unexpected identity error: {err:#}"
+    );
+    let mut ship = ctx.open_pond().await.expect("open unchanged pond");
+    assert_eq!(
+        load_remote_attachment(&mut ship, "upstream")
+            .await
+            .expect("load original attachment")
+            .url,
+        first
+    );
+}
+
+#[tokio::test]
+async fn watermark_migration_refuses_when_the_graft_pin_is_missing() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let (_producer, first, second) = publish_equivalent_remotes(&tmp, "migration-no-pin").await;
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&first, false, false))
+        .await
+        .expect("attach first remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("pull first remote");
+
+    let mut ship = ctx.open_pond().await.expect("open consumer");
+    ship.write_transaction(
+        &PondUserMetadata::new(vec!["test".to_string(), "remove-graft-pin".to_string()]),
+        async |fs| {
+            let root = fs.root().await?;
+            root.open_dir_path(steward::SYS_GRAFTS_DIR)
+                .await?
+                .remove_entry("upstream")
+                .await?;
+            Ok(())
+        },
+    )
+    .await
+    .expect("remove graft pin");
+    drop(ship);
+
+    let err = apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&second, true, true))
+        .await
+        .expect_err("missing graft pin must prevent migration");
+    assert!(
+        format!("{err:#}").contains("graft pin `/sys/grafts/upstream` does not exist"),
+        "unexpected missing-pin error: {err:#}"
+    );
+    let mut ship = ctx.open_pond().await.expect("open unchanged pond");
+    assert_eq!(
+        load_remote_attachment(&mut ship, "upstream")
+            .await
+            .expect("load original attachment")
+            .url,
+        first
+    );
+}
+
+#[tokio::test]
+async fn watermark_migration_refuses_a_watermark_that_disagrees_with_the_graft_pin() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let (_producer, first, second) =
+        publish_equivalent_remotes(&tmp, "migration-bad-watermark").await;
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&first, false, false))
+        .await
+        .expect("attach first remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("pull first remote");
+
+    let mut ship = ctx.open_pond().await.expect("open consumer");
+    ship.control_table_mut()
+        .raw_config_set(&format!("last_pulled_tip:{first}"), &"0".repeat(64))
+        .await
+        .expect("corrupt old watermark");
+    drop(ship);
+
+    let err = apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&second, true, true))
+        .await
+        .expect_err("watermark and graft pin disagreement must prevent migration");
+    assert!(
+        format!("{err:#}").contains("graft pin tip")
+            && format!("{err:#}").contains("differs from existing URL watermark"),
+        "unexpected mismatched-watermark error: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn watermark_migration_refuses_a_destination_missing_the_pinned_commit() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let (_producer, first, second) =
+        publish_equivalent_remotes(&tmp, "migration-missing-commit").await;
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&first, false, false))
+        .await
+        .expect("attach first remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("pull first remote");
+
+    let remote = sync_store::ContentRemote::open_at_url(&second, HashMap::new())
+        .await
+        .expect("open equivalent remote");
+    let pond_id = remote.pond_id();
+    let tip = remote
+        .get_tip("main")
+        .await
+        .expect("read remote tip")
+        .expect("remote tip");
+    let mut store = sync_store::Store::open_at_url(&second, HashMap::new())
+        .await
+        .expect("open backing store");
+    let txn_seq = store.last_txn_seq(pond_id).await.expect("last sequence") + 1;
+    store
+        .apply_batch(
+            pond_id,
+            txn_seq,
+            chrono::Utc::now().timestamp_micros(),
+            vec![sync_store::Op::Delete {
+                partition: "objects".to_string(),
+                key: tip.to_string(),
+            }],
+        )
+        .await
+        .expect("remove pinned commit while retaining the ref");
+
+    let err = apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&second, true, true))
+        .await
+        .expect_err("missing pinned commit must prevent migration");
+    assert!(
+        format!("{err:#}").contains("does not contain pinned commit"),
+        "unexpected missing-commit error: {err:#}"
+    );
+    let mut ship = ctx.open_pond().await.expect("open unchanged pond");
+    assert_eq!(
+        load_remote_attachment(&mut ship, "upstream")
+            .await
+            .expect("load original attachment")
+            .url,
+        first
+    );
+}
+
+#[tokio::test]
+async fn ordinary_overwrite_without_a_prior_pull_does_not_require_migration_state() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let (_producer, first, second) = publish_equivalent_remotes(&tmp, "ordinary-overwrite").await;
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&first, false, false))
+        .await
+        .expect("attach first remote");
+
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&second, true, false))
+        .await
+        .expect("ordinary overwrite remains unchanged");
+    let mut ship = ctx.open_pond().await.expect("open overwritten pond");
+    assert_eq!(
+        load_remote_attachment(&mut ship, "upstream")
+            .await
+            .expect("load replacement attachment")
+            .url,
+        second
+    );
+    assert_eq!(
+        ship.control_table()
+            .raw_config_get(&format!("last_pulled_tip:{second}"))
+            .await
+            .expect("read absent watermark"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn watermark_migration_requires_overwrite() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let pond = tmp.path().join("consumer");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+
+    let err = apply_yaml(
+        &ctx,
+        tmp.path(),
+        &pull_remote_yaml("file:///unused", false, true),
+    )
+    .await
+    .expect_err("migration without overwrite must fail during parsing");
+    assert!(
+        format!("{err:#}").contains("'migrate_watermark: true' requires 'overwrite: true'"),
+        "unexpected apply guard error: {err:#}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add explicit `migrate_watermark: true` apply control for pull-remote overwrites
- migrate only when the existing watermark and graft pin agree and the replacement remote proves the same pond, exact tip, and pinned commit
- reject advanced, incomplete, missing-pin, and identity-mismatched destinations before replacing the attachment
- preserve the old URL watermark and make completed migrations safe to reapply

## Tests
- `cargo test -p cmd --test test_apply_remote`
- `cargo clippy -p cmd --test test_apply_remote -- -D warnings`