### PR TITLE
sitegen: query reports with provider context

### DIFF
--- a/crates/sitegen/src/report.rs
+++ b/crates/sitegen/src/report.rs
@@ -249,7 +249,9 @@ async fn collect_samples(
     };
     let path = node_path.path.to_string_lossy();
     let filesystem = provider_context.filesystem();
-    let provider = provider::Provider::new(Arc::new(filesystem)).with_root(root.clone());
+    let provider =
+        provider::Provider::with_context(Arc::new(filesystem), Arc::new(provider_context.clone()))
+            .with_root(root.clone());
     let url = format!("series://{path}");
     let table_provider = provider
         .create_table_provider_bounded(


### PR DESCRIPTION
## Summary

- construct report query providers with the active `ProviderContext`
- allow report sections to read builtin `series://` pond paths

## Production finding

The first `sitegen report weekly` production smoke test failed because builtin providers reject context-free construction. This supplies the same context-aware provider setup used elsewhere in sitegen.

## Validation

- `cargo test -p sitegen --quiet` (115 passed)
- `cargo fmt --all -- --check`