### PR TITLE
Make graft replication atomic and recoverable

### DIFF
--- a/crates/cmd/src/commands/mod.rs
+++ b/crates/cmd/src/commands/mod.rs
@@ -45,7 +45,7 @@ pub use list_factories::list_factories_command;
 pub use maintain::maintain_command;
 pub use mkdir::mkdir_command;
 pub use mknod::mknod_command;
-pub use pull::pull_command;
+pub use pull::{pull_command, pull_command_with_rebuild};
 pub use push::push_command;
 pub use rebuild_control::rebuild_control_command;
 pub use recover::recover_command;

--- a/crates/cmd/src/commands/pull.rs
+++ b/crates/cmd/src/commands/pull.rs
@@ -13,12 +13,24 @@ use crate::commands::remote::{
 use crate::common::ShipContext;
 use anyhow::{Result, anyhow};
 use std::collections::HashMap;
-use steward::{REMOTE_MOUNT_PATH_PREFIX, StewardError};
-use uuid::Uuid;
+use steward::REMOTE_MOUNT_PATH_PREFIX;
 
 /// Pull from `name`, or from every remote in `pull`/`both` mode when `name`
 /// is `None`.  Each remote is processed independently.
 pub async fn pull_command(ship_context: &ShipContext, name: Option<String>) -> Result<()> {
+    pull_command_with_rebuild(ship_context, name, false).await
+}
+
+pub async fn pull_command_with_rebuild(
+    ship_context: &ShipContext,
+    name: Option<String>,
+    rebuild_graft: bool,
+) -> Result<()> {
+    if rebuild_graft && name.is_none() {
+        return Err(anyhow!(
+            "`pond pull --rebuild-graft` requires one remote name"
+        ));
+    }
     let mut ship = ship_context.open_pond().await?;
 
     let targets: Vec<String> = if let Some(n) = name {
@@ -49,7 +61,7 @@ pub async fn pull_command(ship_context: &ShipContext, name: Option<String>) -> R
     // makes a routine throttle look like an outage.
     let mut failures: Vec<String> = Vec::new();
     for name in targets {
-        if let Err(e) = pull_one(&mut ship, &name).await {
+        if let Err(e) = pull_one(&mut ship, &name, rebuild_graft).await {
             log::error!("[ERR] pull {}: {}", name, e);
             failures.push(format!("{}: {}", name, e));
         }
@@ -62,32 +74,114 @@ pub async fn pull_command(ship_context: &ShipContext, name: Option<String>) -> R
     }
 }
 
+async fn pulled_frontier(
+    ship: &mut steward::Ship,
+    url: &str,
+    name: &str,
+    graft: Option<(&str, uuid::Uuid)>,
+) -> Result<Option<String>> {
+    let watermark = ship
+        .control_table()
+        .raw_config_get(&format!("last_pulled_tip:{url}"))
+        .await
+        .map_err(|e| anyhow!("read last_pulled_tip for `{name}`: {e}"))?
+        .filter(|tip| !tip.is_empty());
+    if let Some((mount_path, foreign_pond_id)) = graft {
+        let pin_path = steward::GraftPin::pin_path(name);
+        let tx = ship
+            .begin_read(&steward::PondUserMetadata::new(vec![
+                "pull".to_string(),
+                "read-graft-pin".to_string(),
+                name.to_string(),
+            ]))
+            .await?;
+        let pin_bytes = {
+            let root = tx.root().await?;
+            if root.exists(&pin_path).await {
+                Some(root.read_file_path_to_vec(&pin_path).await?)
+            } else {
+                None
+            }
+        };
+        let _ = tx.commit().await?;
+        let Some(bytes) = pin_bytes else {
+            return Ok(watermark);
+        };
+        let pin = steward::GraftPin::from_yaml_bytes(&bytes)
+            .map_err(|e| anyhow!("parse graft pin `{pin_path}`: {e}"))?;
+        let same_mount = pin.mount_path.trim_end_matches('/') == mount_path.trim_end_matches('/');
+        if pin.foreign_pond_id == foreign_pond_id.to_string() && same_mount {
+            return Ok(Some(pin.pinned_tip));
+        }
+        return Ok(None);
+    }
+    Ok(watermark)
+}
+
 /// Return `true` when the remote's tip commit for ref `main` already equals the
-/// tip we last pulled for `url`, meaning the local mirror/mount is up to date
-/// and the full graph fetch can be skipped.  Records nothing; the caller
-/// refreshes `last_pulled_tip` only after a real rebuild/import lands.
+/// durable graft pin (or mirror watermark), so the graph fetch can be skipped.
 async fn already_at_tip(
-    ship: &steward::Ship,
+    ship: &mut steward::Ship,
     remote: &dyn steward::ContentSource,
     url: &str,
     name: &str,
+    graft: Option<(&str, uuid::Uuid)>,
 ) -> Result<bool> {
     let remote_tip = remote
         .get_tip("main")
         .await
-        .map_err(|e| anyhow!("get tip from `{}`: {}", url, e))?;
-    let last_pulled = ship
-        .control_table()
-        .raw_config_get(&format!("last_pulled_tip:{url}"))
-        .await
-        .map_err(|e| anyhow!("read last_pulled_tip for `{}`: {}", name, e))?;
+        .map_err(|e| anyhow!("get tip from `{url}`: {e}"))?;
+    let last_pulled = pulled_frontier(ship, url, name, graft).await?;
     if let (Some(tip), Some(prev)) = (remote_tip, last_pulled.as_deref())
         && tip.to_hex() == prev
     {
+        if graft.is_some() {
+            let key = format!("last_pulled_tip:{url}");
+            let tip_hex = tip.to_hex();
+            let watermark = ship
+                .control_table()
+                .raw_config_get(&key)
+                .await
+                .map_err(|e| anyhow!("read last_pulled_tip for `{name}`: {e}"))?;
+            if watermark.as_deref() != Some(tip_hex.as_str()) {
+                ship.control_table_mut()
+                    .raw_config_set(&key, &tip_hex)
+                    .await
+                    .map_err(|e| anyhow!("repair last_pulled_tip for `{name}`: {e}"))?;
+            }
+        }
         log::info!("[OK] pull {name} already up to date (tip={prev})");
         return Ok(true);
     }
     Ok(false)
+}
+
+async fn require_fast_forward(
+    ship: &mut steward::Ship,
+    graph: &steward::FetchedGraph,
+    url: &str,
+    name: &str,
+    graft: Option<(&str, uuid::Uuid)>,
+) -> Result<()> {
+    let Some(previous) = pulled_frontier(ship, url, name, graft).await? else {
+        return Ok(());
+    };
+    let previous_hash = sync_store::content::ObjectHash::from_hex(&previous)
+        .map_err(|e| anyhow!("invalid last_pulled_tip for `{name}`: {e}"))?;
+    if graph
+        .commits
+        .iter()
+        .any(|(commit_hash, _)| *commit_hash == previous_hash)
+    {
+        return Ok(());
+    }
+    let remote_tip = graph
+        .tip
+        .map(|tip| tip.to_hex())
+        .unwrap_or_else(|| "<empty>".to_string());
+    Err(anyhow!(
+        "remote `{name}` tip {remote_tip} does not descend from last pulled tip {previous}; refusing non-fast-forward pull"
+    ))
 }
 
 /// Open a [`steward::ContentSource`] for `attachment`: a `pond://<path>` URL
@@ -113,7 +207,7 @@ async fn open_content_source(
     }
 }
 
-async fn pull_one(ship: &mut steward::Steward, name: &str) -> Result<()> {
+async fn pull_one(ship: &mut steward::Steward, name: &str, rebuild_graft: bool) -> Result<()> {
     let attachment = load_remote_attachment(ship, name).await?;
 
     // One dispatch, from the profile when there is one (Decision A8).  A
@@ -182,8 +276,13 @@ async fn pull_one(ship: &mut steward::Steward, name: &str) -> Result<()> {
     // (non-root mount): fetch the foreign content graph and rebuild it under
     // the foreign pond_id, then mount it.
     let result: Result<()> = match mount_path {
+        None if rebuild_graft => Err(anyhow!(
+            "remote `{name}` is a mirror; --rebuild-graft only replaces a non-root graft"
+        )),
         None => pull_mirror(ship, name, &attachment, &source).await,
-        Some(mount_path) => pull_import(ship, name, &attachment, &source, &mount_path).await,
+        Some(mount_path) => {
+            pull_import(ship, name, &attachment, &source, &mount_path, rebuild_graft).await
+        }
     };
 
     // A budget's refusal outranks the storage error it surfaced as, so an
@@ -219,6 +318,7 @@ async fn pull_import(
     attachment: &steward::RemoteAttachment,
     remote: &dyn steward::ContentSource,
     mount_path: &str,
+    rebuild_graft: bool,
 ) -> Result<()> {
     let ship_ref = ship
         .as_pond_mut()
@@ -240,7 +340,10 @@ async fn pull_import(
     // tip we last pulled, the mount is up to date -- skip the full graph fetch
     // and re-import entirely.  This is the bandwidth-bug guard: without it,
     // every pull re-walks and re-downloads the whole reachable object closure.
-    if already_at_tip(ship_ref, remote, &attachment.url, name).await? {
+    let graft_identity = Some((mount_path, remote.pond_id()));
+    if !rebuild_graft
+        && already_at_tip(ship_ref, remote, &attachment.url, name, graft_identity).await?
+    {
         return Ok(());
     }
 
@@ -257,35 +360,26 @@ async fn pull_import(
         );
         return Ok(());
     }
+    require_fast_forward(ship_ref, &graph, &attachment.url, name, graft_identity).await?;
     let foreign_uuid7 = uuid7::Uuid::from(*foreign_pond_id.as_bytes());
-    let outcome = steward::import_pond(ship_ref, remote, &graph, foreign_uuid7)
-        .await
-        .map_err(|e| anyhow!("import from `{}`: {}", attachment.url, e))?;
+    let pinned_tip = graph
+        .tip
+        .ok_or_else(|| anyhow!("imported graph from `{}` has no tip commit", name))?;
+    let outcome = if rebuild_graft {
+        steward::replace_graft(ship_ref, remote, &graph, foreign_uuid7, name, mount_path).await
+    } else {
+        steward::import_graft(ship_ref, remote, &graph, foreign_uuid7, name, mount_path).await
+    }
+    .map_err(|e| anyhow!("import from `{}`: {}", attachment.url, e))?;
     log::info!(
         "[OK] pull {} complete (cross-pond import: {:?})",
         name,
         outcome
     );
 
-    // Materialize the mount and record the graft pin in ONE transaction.  The
-    // mount node is omitted from the content-tree fold (keeping the graft
-    // non-transitive); the pin file is ordinary pond-owned content -- covered
-    // by our commit hash and replicated to consumers as a content-addressed
-    // reference to the foreign tip.
-    let pinned_tip = graph
-        .tip
-        .ok_or_else(|| anyhow!("imported graph from `{}` has no tip commit", name))?;
-    materialize_mount(
-        ship_ref,
-        name,
-        mount_path,
-        foreign_pond_id,
-        &pinned_tip.to_hex(),
-    )
-    .await?;
-
     // Record the per-ref frontier we last pulled: the foreign tip commit hash
-    // now mounted (CA3 replacement for the retired seq watermark).
+    // now atomically imported, mounted, and pinned. If this control-table write
+    // fails, a retry safely repeats the idempotent graft transaction.
     ship_ref
         .control_table_mut()
         .raw_config_set(
@@ -313,7 +407,7 @@ async fn pull_mirror(
 
     // Incremental short-circuit (CA3): skip the full graph fetch and rebuild
     // when the mirror already reflects the remote tip.
-    if already_at_tip(ship_ref, remote, &attachment.url, name).await? {
+    if already_at_tip(ship_ref, remote, &attachment.url, name, None).await? {
         return Ok(());
     }
 
@@ -327,6 +421,7 @@ async fn pull_mirror(
         );
         return Ok(());
     }
+    require_fast_forward(ship_ref, &graph, &attachment.url, name, None).await?;
     let outcome = steward::rebuild_pond(ship_ref, remote, &graph)
         .await
         .map_err(|e| anyhow!("rebuild from `{}`: {}", attachment.url, e))?;
@@ -351,123 +446,11 @@ async fn pull_mirror(
     Ok(())
 }
 
-/// Insert (idempotently) a directory entry at `mount_path` whose `pond_id` is
-/// the foreign pond's id, and record the graft pin at `/sys/grafts/<name>` --
-/// both in a SINGLE transaction so a cross-pond pull adds exactly one local
-/// commit.  Reading through the mount entry yields the foreign pond's tree; the
-/// pin file is ordinary pond-owned content (covered by our commit hash and
-/// replicated to consumers) that pins the foreign tip commit hash without
-/// re-replicating the foreign closure.
-async fn materialize_mount(
-    ship: &mut steward::Ship,
-    name: &str,
-    mount_path: &str,
-    foreign_pond_id: Uuid,
-    pinned_tip_hex: &str,
-) -> Result<()> {
-    let (parent, leaf) = split_mount_path(mount_path)?;
-    let name_owned = name.to_string();
-    let mount_owned = mount_path.to_string();
-    let parent_owned = parent.to_string();
-    let leaf_owned = leaf.to_string();
-
-    let pin = steward::GraftPin {
-        foreign_pond_id: foreign_pond_id.to_string(),
-        mount_path: mount_path.to_string(),
-        pinned_tip: pinned_tip_hex.to_string(),
-    };
-    let pin_yaml = pin
-        .to_yaml()
-        .map_err(|e| anyhow!("serialize graft pin for `{}`: {}", name, e))?;
-    let pin_path = steward::GraftPin::pin_path(name);
-    let pin_name = name_owned.clone();
-
-    ship.write_transaction(
-        &steward::PondUserMetadata::new(vec![
-            "pull".to_string(),
-            "mount".to_string(),
-            name_owned,
-            mount_owned,
-        ]),
-        async move |fs| {
-            use tinyfs::EntryType;
-            use tokio::io::AsyncWriteExt;
-
-            let root = fs.root().await?;
-            let _ = root.create_dir_all(&parent_owned).await?;
-            let parent_wd = root.open_dir_path(&parent_owned).await?;
-
-            let foreign_uuid7 = uuid7::Uuid::from(*foreign_pond_id.as_bytes());
-
-            if let Some(existing) = parent_wd.get(&leaf_owned).await? {
-                let existing_pond = existing.node.id().pond_id();
-                if existing_pond != foreign_uuid7 {
-                    return Err(StewardError::Aborted(format!(
-                        "mount path `{}/{}` already exists with pond_id {}; cannot \
-                         attach foreign pond {}",
-                        parent_owned, leaf_owned, existing_pond, foreign_uuid7
-                    )));
-                }
-                // Idempotent: mount already points at the right pond.
-            } else {
-                let foreign_node = fs.foreign_root_node(foreign_uuid7).await?;
-                let _ = parent_wd.insert_node(&leaf_owned, foreign_node).await?;
-            }
-
-            // Record / refresh the graft pin in the same transaction.
-            let _ = root.create_dir_all(steward::SYS_DIR).await?;
-            let _ = root.create_dir_all(steward::SYS_GRAFTS_DIR).await?;
-            if root.exists(&pin_path).await {
-                let grafts_dir = root.open_dir_path(steward::SYS_GRAFTS_DIR).await?;
-                grafts_dir.remove_entry(&pin_name).await.map_err(|e| {
-                    StewardError::Aborted(format!("remove existing graft pin {}: {}", pin_path, e))
-                })?;
-            }
-            let mut writer = root
-                .async_writer_path_with_type(&pin_path, EntryType::FilePhysicalVersion)
-                .await?;
-            writer
-                .write_all(pin_yaml.as_bytes())
-                .await
-                .map_err(|e| StewardError::Aborted(format!("write graft pin: {}", e)))?;
-            writer
-                .shutdown()
-                .await
-                .map_err(|e| StewardError::Aborted(format!("close graft pin: {}", e)))?;
-            Ok(())
-        },
-    )
-    .await
-    .map_err(|e| anyhow!("materialize mount `{}`: {}", mount_path, e))?;
-    Ok(())
-}
-
 /// Split an absolute mount path into (parent_dir, leaf_name).
 /// Errors if the path is `/` (root mount is mirror mode, handled
 /// elsewhere) or has no leaf segment.
 pub(crate) fn split_mount_path(path: &str) -> Result<(&str, &str)> {
-    if !path.starts_with('/') {
-        return Err(anyhow!("mount path `{}` must be absolute", path));
-    }
-    if path == "/" {
-        return Err(anyhow!(
-            "internal: split_mount_path called on `/` (mirror restart should be filtered earlier)"
-        ));
-    }
-    let trimmed = path.trim_end_matches('/');
-    let last_slash = trimmed
-        .rfind('/')
-        .ok_or_else(|| anyhow!("mount path `{}` has no leaf", path))?;
-    let parent = if last_slash == 0 {
-        "/"
-    } else {
-        &trimmed[..last_slash]
-    };
-    let leaf = &trimmed[last_slash + 1..];
-    if leaf.is_empty() {
-        return Err(anyhow!("mount path `{}` has empty leaf", path));
-    }
-    Ok((parent, leaf))
+    steward::split_mount_path(path).map_err(anyhow::Error::msg)
 }
 
 #[cfg(test)]

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -616,7 +616,13 @@ async fn main() -> Result<()> {
         Commands::Pull {
             name,
             rebuild_graft,
-        } => commands::pull_command_with_rebuild(&ship_context, name, rebuild_graft).await,
+        } => {
+            if rebuild_graft {
+                commands::pull_command_with_rebuild(&ship_context, name, true).await
+            } else {
+                commands::pull_command(&ship_context, name).await
+            }
+        }
         Commands::Restore { name, url, options } => {
             commands::restore_command(
                 &ship_context,

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -274,6 +274,9 @@ enum Commands {
     Pull {
         /// Remote name.  Omit to pull every remote in `pull` or `both` mode.
         name: Option<String>,
+        /// Atomically replace this remote's graft partition, mount, and pin.
+        #[arg(long, requires = "name")]
+        rebuild_graft: bool,
     },
     /// Restore a whole pond from a backup published to a remote.
     ///
@@ -610,7 +613,10 @@ async fn main() -> Result<()> {
             commands::control_command(&ship_context, control_mode).await
         }
         Commands::Push { name } => commands::push_command(&ship_context, name).await,
-        Commands::Pull { name } => commands::pull_command(&ship_context, name).await,
+        Commands::Pull {
+            name,
+            rebuild_graft,
+        } => commands::pull_command_with_rebuild(&ship_context, name, rebuild_graft).await,
         Commands::Restore { name, url, options } => {
             commands::restore_command(
                 &ship_context,

--- a/crates/cmd/tests/test_apply_remote.rs
+++ b/crates/cmd/tests/test_apply_remote.rs
@@ -14,8 +14,8 @@
 //! All remotes are `file://`, so nothing here touches the network.
 
 use cmd::commands::{
-    apply_command, init_command, pull_command, push_command, remote::list_remote_names,
-    remote::load_remote_attachment, status_command,
+    apply_command, init_command, pull_command, pull_command_with_rebuild, push_command,
+    remote::list_remote_names, remote::load_remote_attachment, status_command,
 };
 use cmd::common::ShipContext;
 use provider::factory::rate_limit::LimitUnit;
@@ -787,6 +787,334 @@ async fn a_governed_pull_within_budget_still_succeeds() {
     assert!(
         tip.is_some_and(|t| !t.is_empty()),
         "a successful governed pull must record the tip it pulled"
+    );
+}
+
+#[tokio::test]
+async fn missing_watermark_retries_graft_without_another_data_commit() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let url = publish_upstream(&tmp, "watermark-retry").await;
+    let pond = tmp.path().join("consumer-watermark-retry");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&url, false, false))
+        .await
+        .expect("attach pull remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("initial pull");
+
+    let mut ship = ctx.open_pond().await.expect("open consumer");
+    let key = format!("last_pulled_tip:{url}");
+    let pulled_tip = ship
+        .control_table()
+        .raw_config_get(&key)
+        .await
+        .expect("read watermark")
+        .expect("watermark");
+    let version = ship
+        .as_pond()
+        .expect("pond steward")
+        .data_persistence()
+        .table()
+        .version();
+    ship.control_table_mut()
+        .raw_config_set(&key, "")
+        .await
+        .expect("simulate lost trailing watermark");
+    drop(ship);
+
+    // Remove the commit object while retaining the ref. A full graph fetch
+    // would now fail; success proves the graft pin short-circuits the retry.
+    let remote = sync_store::ContentRemote::open_at_url(&url, HashMap::new())
+        .await
+        .expect("open remote");
+    let mut store = sync_store::Store::open_at_url(&url, HashMap::new())
+        .await
+        .expect("open backing store");
+    let txn_seq = store
+        .last_txn_seq(remote.pond_id())
+        .await
+        .expect("last remote sequence")
+        + 1;
+    store
+        .apply_batch(
+            remote.pond_id(),
+            txn_seq,
+            chrono::Utc::now().timestamp_micros(),
+            vec![sync_store::Op::Delete {
+                partition: "objects".to_string(),
+                key: pulled_tip.clone(),
+            }],
+        )
+        .await
+        .expect("remove tip object while retaining ref");
+
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("retry after watermark loss");
+    let ship = ctx.open_pond().await.expect("reopen consumer");
+    assert_eq!(
+        ship.as_pond()
+            .expect("pond steward")
+            .data_persistence()
+            .table()
+            .version(),
+        version,
+        "idempotent retry must not add a data commit"
+    );
+    assert_eq!(
+        ship.control_table()
+            .raw_config_get(&key)
+            .await
+            .expect("read restored watermark"),
+        Some(pulled_tip)
+    );
+}
+
+#[tokio::test]
+async fn matching_tip_does_not_short_circuit_a_mismatched_graft_pin() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let url = publish_upstream(&tmp, "pin-identity").await;
+    let pond = tmp.path().join("consumer-pin-identity");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&url, false, false))
+        .await
+        .expect("attach pull remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("initial pull");
+
+    let pin_path = steward::GraftPin::pin_path("upstream");
+    let mut ship = ctx.open_pond().await.expect("open consumer");
+    let pond = ship.as_pond_mut().expect("pond steward");
+    let tx = pond
+        .begin_read(&PondUserMetadata::new(vec![
+            "test".to_string(),
+            "read-pin".to_string(),
+        ]))
+        .await
+        .expect("begin pin read");
+    let pin_bytes = tx
+        .root()
+        .await
+        .expect("root")
+        .read_file_path_to_vec(&pin_path)
+        .await
+        .expect("read pin");
+    let _ = tx.commit().await.expect("close pin read");
+    let mut pin = steward::GraftPin::from_yaml_bytes(&pin_bytes).expect("parse pin");
+    pin.mount_path = "/wrong/path".to_string();
+    let wrong_yaml = pin.to_yaml().expect("serialize wrong pin");
+    pond.write_transaction(
+        &PondUserMetadata::new(vec!["test".to_string(), "wrong-pin".to_string()]),
+        async |fs| {
+            let root = fs.root().await?;
+            root.open_dir_path(steward::SYS_GRAFTS_DIR)
+                .await?
+                .remove_entry("upstream")
+                .await?;
+            let mut writer = root
+                .async_writer_path_with_type(&pin_path, EntryType::FilePhysicalVersion)
+                .await?;
+            writer.write_all(wrong_yaml.as_bytes()).await?;
+            writer.shutdown().await?;
+            Ok(())
+        },
+    )
+    .await
+    .expect("write mismatched pin");
+    let version_before = pond.data_persistence().table().version();
+    drop(ship);
+
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("repair mismatched pin");
+    let mut ship = ctx.open_pond().await.expect("reopen consumer");
+    let pond = ship.as_pond_mut().expect("pond steward");
+    assert_eq!(
+        pond.data_persistence().table().version(),
+        version_before.map(|version| version + 1),
+        "pin identity mismatch must bypass the matching-tip shortcut"
+    );
+    let tx = pond
+        .begin_read(&PondUserMetadata::new(vec![
+            "test".to_string(),
+            "verify-pin".to_string(),
+        ]))
+        .await
+        .expect("begin pin verification");
+    let pin_bytes = tx
+        .root()
+        .await
+        .expect("root")
+        .read_file_path_to_vec(&pin_path)
+        .await
+        .expect("read repaired pin");
+    let _ = tx.commit().await.expect("close pin verification");
+    let pin = steward::GraftPin::from_yaml_bytes(&pin_bytes).expect("parse repaired pin");
+    assert_eq!(pin.mount_path, "/sources/upstream");
+}
+
+#[tokio::test]
+async fn rebuild_graft_command_runs_end_to_end() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let url = publish_upstream(&tmp, "rebuild-graft-command").await;
+    let pond = tmp.path().join("consumer-rebuild-graft");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&url, false, false))
+        .await
+        .expect("attach pull remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("initial pull");
+
+    let ship = ctx.open_pond().await.expect("open consumer");
+    let version_before = ship
+        .as_pond()
+        .expect("pond steward")
+        .data_persistence()
+        .table()
+        .version();
+    let watermark_before = ship
+        .control_table()
+        .raw_config_get(&format!("last_pulled_tip:{url}"))
+        .await
+        .expect("read watermark");
+    drop(ship);
+
+    pull_command_with_rebuild(&ctx, Some("upstream".to_string()), true)
+        .await
+        .expect("explicit graft rebuild");
+    let ship = ctx.open_pond().await.expect("reopen consumer");
+    assert_eq!(
+        ship.as_pond()
+            .expect("pond steward")
+            .data_persistence()
+            .table()
+            .version(),
+        version_before.map(|version| version + 1),
+        "scoped replacement must land as one data commit"
+    );
+    assert_eq!(
+        ship.control_table()
+            .raw_config_get(&format!("last_pulled_tip:{url}"))
+            .await
+            .expect("read watermark"),
+        watermark_before
+    );
+
+    let err = pull_command_with_rebuild(&ctx, None, true)
+        .await
+        .expect_err("rebuild requires one named graft");
+    assert!(format!("{err:#}").contains("requires one remote name"));
+
+    let mirror_url = sync_store::testing::in_memory_remote_url("rebuild-graft-mirror");
+    apply_yaml(
+        &ctx,
+        tmp.path(),
+        &format!(
+            "version: v1\nkind: backup\nmetadata:\n  path: /sys/remotes/mirror\nspec:\n  url: {mirror_url}\n"
+        ),
+    )
+    .await
+    .expect("attach local mirror backup");
+    push_command(&ctx, Some("mirror".to_string()))
+        .await
+        .expect("publish local mirror");
+    let err = pull_command_with_rebuild(&ctx, Some("mirror".to_string()), true)
+        .await
+        .expect_err("rebuild-graft must reject a root mirror");
+    assert!(format!("{err:#}").contains("only replaces a non-root graft"));
+}
+
+#[tokio::test]
+async fn out_of_order_remote_tip_cannot_roll_back_a_graft() {
+    init_log();
+    let tmp = TempDir::new().expect("tmp");
+    let (producer, url, _second) = publish_equivalent_remotes(&tmp, "tip-regression").await;
+    let remote = sync_store::ContentRemote::open_at_url(&url, HashMap::new())
+        .await
+        .expect("open remote");
+    let old_tip = remote
+        .get_tip("main")
+        .await
+        .expect("read old tip")
+        .expect("old tip");
+
+    let pond = tmp.path().join("consumer-tip-regression");
+    let ctx = ctx_for(&pond, vec!["pond", "init"]);
+    init_command(&ctx, "consumer-host").await.expect("init");
+    apply_yaml(&ctx, tmp.path(), &pull_remote_yaml(&url, false, false))
+        .await
+        .expect("attach pull remote");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("pull old tip");
+
+    write_small_file(&producer, "/later.txt", b"newer")
+        .await
+        .expect("advance producer");
+    push_command(&producer, None)
+        .await
+        .expect("publish newer tip");
+    pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect("pull newer tip");
+
+    let mut ship = ctx.open_pond().await.expect("open advanced consumer");
+    let key = format!("last_pulled_tip:{url}");
+    let new_tip = ship
+        .control_table()
+        .raw_config_get(&key)
+        .await
+        .expect("read newer watermark")
+        .expect("newer watermark");
+    assert_ne!(new_tip, old_tip.to_hex());
+    let version = ship
+        .as_pond()
+        .expect("pond steward")
+        .data_persistence()
+        .table()
+        .version();
+    ship.control_table_mut()
+        .raw_config_set(&key, &old_tip.to_hex())
+        .await
+        .expect("simulate stale trailing watermark");
+    drop(ship);
+
+    let mut remote = sync_store::ContentRemote::open_at_url(&url, HashMap::new())
+        .await
+        .expect("reopen current remote");
+    let _ = remote
+        .push_commit(&[], "main", old_tip)
+        .await
+        .expect("publish stale ref view");
+    let err = pull_command(&ctx, Some("upstream".to_string()))
+        .await
+        .expect_err("older remote tip must be rejected");
+    assert!(format!("{err:#}").contains("refusing non-fast-forward pull"));
+
+    let ship = ctx.open_pond().await.expect("reopen consumer");
+    assert_eq!(
+        ship.as_pond()
+            .expect("pond steward")
+            .data_persistence()
+            .table()
+            .version(),
+        version
+    );
+    assert_eq!(
+        ship.control_table()
+            .raw_config_get(&key)
+            .await
+            .expect("read preserved watermark"),
+        Some(old_tip.to_hex())
     );
 }
 

--- a/crates/steward/src/content_pull.rs
+++ b/crates/steward/src/content_pull.rs
@@ -510,43 +510,19 @@ pub async fn rebuild_pond(
     let (ops, outcome) = plan_node_diff(graph, root, &target_nodes, &target_series)?;
 
     let root_node_id = src_root_id(graph)?.to_string();
-    target
-        .write_transaction(
-            &PondUserMetadata::new(vec!["pull".to_string()]),
-            async move |fs| {
-                let root_wd = fs.root().await?;
-                apply_ops(&root_node_id, root_wd, &ops, remote).await?;
-                Ok(())
-            },
-        )
+    let mut tx = target
+        .begin_write(&PondUserMetadata::new(vec!["pull".to_string()]))
         .await?;
-
-    let report = crate::compute_content_tree(target).await?;
-    if report.root_tree_hash != root {
-        return Err(StewardError::Content(format!(
-            "rebuilt pond folds to {} but the tip root tree is {}",
-            report.root_tree_hash.to_hex(),
-            root.to_hex()
-        )));
+    tx.expect_content_roots(root, tip_manifest_hash, tip_manifest_root);
+    let apply_result = async {
+        let root_wd = tx.root().await?;
+        apply_ops(&root_node_id, root_wd, &ops, remote).await
     }
-
-    let pond_id = target.data_persistence().pond_id().to_string();
-    let table = target.data_persistence().table().clone();
-    let roots = crate::content_tree::compute_commit_roots_for_table(table, &pond_id).await?;
-    if roots.node_manifest_hash != tip_manifest_hash {
-        return Err(StewardError::Content(format!(
-            "rebuilt node manifest hashes to {} but the tip commit's manifest is {}",
-            roots.node_manifest_hash.to_hex(),
-            tip_manifest_hash.to_hex()
-        )));
+    .await;
+    if let Err(error) = apply_result {
+        return Err(tx.abort_preserving(error).await);
     }
-    if roots.node_manifest_root != tip_manifest_root {
-        return Err(StewardError::Content(format!(
-            "rebuilt node manifest Merkle root is {} but the tip commit's root is {}",
-            roots.node_manifest_root.to_hex(),
-            tip_manifest_root.to_hex()
-        )));
-    }
+    _ = tx.commit().await?;
 
     Ok(outcome)
 }
@@ -569,6 +545,81 @@ pub async fn import_pond(
     remote: &dyn ContentSource,
     graph: &FetchedGraph,
     foreign_pond_id: uuid7::Uuid,
+) -> Result<RebuildOutcome, StewardError> {
+    import_pond_inner(target, remote, graph, foreign_pond_id, None, false).await
+}
+
+/// Atomically import a foreign pond, materialize its local mount, and pin the
+/// imported tip. A failed import cannot leave either the foreign rows or the
+/// local graft metadata partially committed.
+pub async fn import_graft(
+    target: &mut Ship,
+    remote: &dyn ContentSource,
+    graph: &FetchedGraph,
+    foreign_pond_id: uuid7::Uuid,
+    name: &str,
+    mount_path: &str,
+) -> Result<RebuildOutcome, StewardError> {
+    let graft = prepare_graft(graph, foreign_pond_id, name, mount_path)?;
+    import_pond_inner(target, remote, graph, foreign_pond_id, Some(graft), false).await
+}
+
+/// Atomically discard and recreate one foreign pond partition together with
+/// its mount and pin. Local content and other foreign partitions are untouched.
+pub async fn replace_graft(
+    target: &mut Ship,
+    remote: &dyn ContentSource,
+    graph: &FetchedGraph,
+    foreign_pond_id: uuid7::Uuid,
+    name: &str,
+    mount_path: &str,
+) -> Result<RebuildOutcome, StewardError> {
+    let graft = prepare_graft(graph, foreign_pond_id, name, mount_path)?;
+    import_pond_inner(target, remote, graph, foreign_pond_id, Some(graft), true).await
+}
+
+fn prepare_graft(
+    graph: &FetchedGraph,
+    foreign_pond_id: uuid7::Uuid,
+    name: &str,
+    mount_path: &str,
+) -> Result<PreparedGraft, StewardError> {
+    let pinned_tip = graph
+        .tip
+        .ok_or_else(|| StewardError::Content("cannot graft a graph with no tip".to_string()))?;
+    let pin = crate::GraftPin {
+        foreign_pond_id: foreign_pond_id.to_string(),
+        mount_path: mount_path.to_string(),
+        pinned_tip: pinned_tip.to_hex(),
+    };
+    let pin_yaml = pin
+        .to_yaml()
+        .map_err(|error| StewardError::Content(format!("serialize graft pin: {error}")))?;
+    let (parent, leaf) = crate::split_mount_path(mount_path).map_err(StewardError::Content)?;
+    Ok(PreparedGraft {
+        parent: parent.to_string(),
+        leaf: leaf.to_string(),
+        pin_path: crate::GraftPin::pin_path(name),
+        pin_name: name.to_string(),
+        pin_yaml,
+    })
+}
+
+struct PreparedGraft {
+    parent: String,
+    leaf: String,
+    pin_path: String,
+    pin_name: String,
+    pin_yaml: String,
+}
+
+async fn import_pond_inner(
+    target: &mut Ship,
+    remote: &dyn ContentSource,
+    graph: &FetchedGraph,
+    foreign_pond_id: uuid7::Uuid,
+    graft: Option<PreparedGraft>,
+    replace: bool,
 ) -> Result<RebuildOutcome, StewardError> {
     let root = graph
         .root_tree_hash()
@@ -597,55 +648,114 @@ pub async fn import_pond(
     // before any mutation (see verify_manifest_matches_tree).
     verify_manifest_matches_tree(graph)?;
 
-    let (ops, outcome) = plan_node_diff(graph, root, &target_nodes, &target_series)?;
+    let (ops, outcome) = if replace {
+        plan_full_replacement(graph, root, &target_nodes)?
+    } else {
+        plan_node_diff(graph, root, &target_nodes, &target_series)?
+    };
 
     let root_node_id = src_root_id(graph)?.to_string();
     let first_import = target_nodes.is_empty();
-    target
-        .write_transaction(
-            &PondUserMetadata::new(vec!["pull".to_string(), "import".to_string()]),
-            async move |fs| {
-                if first_import {
-                    fs.initialize_foreign_root(foreign_pond_id).await?;
-                }
-                let foreign_node = fs.foreign_root_node(foreign_pond_id).await?;
-                let foreign_np = tinyfs::NodePath {
-                    node: foreign_node,
-                    path: "/".into(),
-                };
-                let root_wd = fs.wd(&foreign_np, foreign_np.clone()).await?;
-                apply_ops(&root_node_id, root_wd, &ops, remote).await?;
-                Ok(())
-            },
-        )
+    let tx = target
+        .begin_write(&PondUserMetadata::new(vec![
+            "pull".to_string(),
+            "import".to_string(),
+        ]))
         .await?;
+    let apply_result = async {
+        if first_import {
+            tx.initialize_foreign_root(foreign_pond_id).await?;
+        }
+        let foreign_node = tx.foreign_root_node(foreign_pond_id).await?;
+        let foreign_np = tinyfs::NodePath {
+            node: foreign_node,
+            path: "/".into(),
+        };
+        let root_wd = tx.wd(&foreign_np, foreign_np.clone()).await?;
+        if let Some(graft) = &graft {
+            use tinyfs::EntryType;
 
-    let table = target.data_persistence().table().clone();
-    let report =
-        crate::content_tree::compute_content_tree_for_table(table.clone(), &foreign_id).await?;
-    if report.root_tree_hash != root {
-        return Err(StewardError::Content(format!(
-            "imported foreign tree folds to {} but the tip root tree is {}",
-            report.root_tree_hash.to_hex(),
-            root.to_hex()
-        )));
-    }
+            let root = tx.root().await?;
+            let _ = root.create_dir_all(&graft.parent).await?;
+            let parent_wd = root.open_dir_path(&graft.parent).await?;
+            let foreign_node = tx.foreign_root_node(foreign_pond_id).await?;
+            if let Some(existing) = parent_wd.entry(&graft.leaf).await? {
+                let existing_pond = existing.pond_id.as_deref().ok_or_else(|| {
+                    StewardError::Aborted(format!(
+                        "mount path `{}/{}` contains local content; refusing scoped graft replacement",
+                        graft.parent, graft.leaf
+                    ))
+                })?;
+                if existing_pond != foreign_id {
+                    return Err(StewardError::Aborted(format!(
+                        "mount path `{}/{}` belongs to pond {}; refusing to replace graft {}",
+                        graft.parent, graft.leaf, existing_pond, foreign_id
+                    )));
+                }
+                if replace {
+                    parent_wd.remove_entry(&graft.leaf).await?;
+                    let _ = parent_wd.insert_node(&graft.leaf, foreign_node).await?;
+                } else if existing.child_node_id != foreign_node.id().node_id() {
+                    return Err(StewardError::Aborted(format!(
+                        "mount path `{}/{}` points to foreign node {} instead of root {}",
+                        graft.parent,
+                        graft.leaf,
+                        existing.child_node_id,
+                        foreign_node.id().node_id()
+                    )));
+                }
+            } else {
+                let _ = parent_wd.insert_node(&graft.leaf, foreign_node).await?;
+            }
 
-    let roots = crate::content_tree::compute_commit_roots_for_table(table, &foreign_id).await?;
-    if roots.node_manifest_hash != tip_manifest_hash {
-        return Err(StewardError::Content(format!(
-            "imported node manifest hashes to {} but the tip commit's manifest is {}",
-            roots.node_manifest_hash.to_hex(),
-            tip_manifest_hash.to_hex()
-        )));
+            let _ = root.create_dir_all(crate::SYS_DIR).await?;
+            let _ = root.create_dir_all(crate::SYS_GRAFTS_DIR).await?;
+            let pin_is_current = if root.exists(&graft.pin_path).await {
+                root.read_file_path_to_vec(&graft.pin_path).await? == graft.pin_yaml.as_bytes()
+            } else {
+                false
+            };
+            if !pin_is_current && root.exists(&graft.pin_path).await {
+                let grafts_dir = root.open_dir_path(crate::SYS_GRAFTS_DIR).await?;
+                grafts_dir.remove_entry(&graft.pin_name).await?;
+            }
+            if !pin_is_current {
+                let mut writer = root
+                    .async_writer_path_with_type(
+                        &graft.pin_path,
+                        EntryType::FilePhysicalVersion,
+                    )
+                    .await?;
+                writer.write_all(graft.pin_yaml.as_bytes()).await?;
+                writer.shutdown().await?;
+            }
+        }
+        apply_ops(&root_node_id, root_wd, &ops, remote).await?;
+        let uncommitted = tx.state()?.uncommitted_live_rows().await?;
+        let committed_table = tx.data_persistence()?.table().clone();
+        crate::content_tree::in_txn_content_state(committed_table, uncommitted, &foreign_id).await
     }
-    if roots.node_manifest_root != tip_manifest_root {
-        return Err(StewardError::Content(format!(
-            "imported node manifest Merkle root is {} but the tip commit's root is {}",
-            roots.node_manifest_root.to_hex(),
-            tip_manifest_root.to_hex()
-        )));
+    .await;
+    let preview = match apply_result {
+        Ok(preview) => preview,
+        Err(error) => return Err(tx.abort_preserving(error).await),
+    };
+    let validation = preview_validation_error(
+        graph,
+        &preview,
+        root,
+        tip_manifest_hash,
+        tip_manifest_root,
+        "imported foreign tree",
+    );
+    let validation = match validation {
+        Ok(validation) => validation,
+        Err(error) => return Err(tx.abort_preserving(error).await),
+    };
+    if let Some(error) = validation {
+        return Err(tx.abort(error).await);
     }
+    _ = tx.commit().await?;
 
     // Advance only the foreign pond's seq frontier so the local allocator stays
     // contiguous; the highest source seq is the foreign tip's commit seq.
@@ -668,6 +778,210 @@ fn src_root_id(graph: &FetchedGraph) -> Result<&str, StewardError> {
         .find(|e| e.parent_node_id.is_empty() && e.name.is_empty())
         .map(|e| e.node_id.as_str())
         .ok_or_else(|| StewardError::Content("manifest has no root entry".to_string()))
+}
+
+fn first_replica_divergence(
+    graph: &FetchedGraph,
+    actual_nodes: &HashMap<String, ManifestEntry>,
+    actual_series: &HashMap<String, Vec<ObjectHash>>,
+) -> Result<Option<String>, StewardError> {
+    let mut expected_nodes: BTreeMap<&str, &ManifestEntry> = BTreeMap::new();
+    for entry in &graph.manifest {
+        if expected_nodes
+            .insert(entry.node_id.as_str(), entry)
+            .is_some()
+        {
+            return Ok(Some(format!(
+                "source manifest contains duplicate node {}",
+                entry.node_id
+            )));
+        }
+    }
+    let actual_nodes_sorted: BTreeMap<&str, &ManifestEntry> = actual_nodes
+        .values()
+        .map(|entry| (entry.node_id.as_str(), entry))
+        .collect();
+
+    for node_id in expected_nodes
+        .keys()
+        .chain(actual_nodes_sorted.keys())
+        .copied()
+        .collect::<BTreeSet<_>>()
+    {
+        let Some(expected) = expected_nodes.get(node_id) else {
+            let actual = actual_nodes_sorted[node_id];
+            return Ok(Some(format!(
+                "unexpected node {node_id} ({:?} {:?})",
+                actual.entry_type, actual.name
+            )));
+        };
+        let Some(actual) = actual_nodes_sorted.get(node_id) else {
+            return Ok(Some(format!(
+                "missing node {node_id} ({:?} {:?})",
+                expected.entry_type, expected.name
+            )));
+        };
+        if expected.parent_node_id != actual.parent_node_id {
+            return Ok(Some(format!(
+                "node {node_id} parent differs: expected {:?}, actual {:?}",
+                expected.parent_node_id, actual.parent_node_id
+            )));
+        }
+        if expected.name != actual.name {
+            return Ok(Some(format!(
+                "node {node_id} name differs: expected {:?}, actual {:?}",
+                expected.name, actual.name
+            )));
+        }
+        if expected.entry_type != actual.entry_type {
+            return Ok(Some(format!(
+                "node {node_id} type differs: expected {:?}, actual {:?}",
+                expected.entry_type, actual.entry_type
+            )));
+        }
+    }
+
+    for (node_id, expected) in &expected_nodes {
+        let actual = actual_nodes_sorted[node_id];
+        if matches!(
+            expected.entry_type,
+            EntryType::FilePhysicalSeries | EntryType::TablePhysicalSeries
+        ) {
+            let expected_versions = series_versions(graph, expected.child_hash)?;
+            let actual_versions = actual_series
+                .get(*node_id)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let compared = expected_versions.len().min(actual_versions.len());
+            for index in 0..compared {
+                if expected_versions[index] != actual_versions[index] {
+                    return Ok(Some(format!(
+                        "series node {node_id} ({:?}) blob {index} differs: expected {}, actual {}",
+                        expected.name,
+                        expected_versions[index].to_hex(),
+                        actual_versions[index].to_hex()
+                    )));
+                }
+            }
+            if expected_versions.len() != actual_versions.len() {
+                return Ok(Some(format!(
+                    "series node {node_id} ({:?}) blob count differs: expected {}, actual {}",
+                    expected.name,
+                    expected_versions.len(),
+                    actual_versions.len()
+                )));
+            }
+        } else if expected.entry_type != EntryType::DirectoryPhysical
+            && expected.child_hash != actual.child_hash
+        {
+            return Ok(Some(format!(
+                "node {node_id} ({:?}) content hash differs: expected {}, actual {}",
+                expected.name,
+                expected.child_hash.to_hex(),
+                actual.child_hash.to_hex()
+            )));
+        }
+
+        let compared = expected.versions.len().min(actual.versions.len());
+        for index in 0..compared {
+            let expected_meta = &expected.versions[index];
+            let actual_meta = &actual.versions[index];
+            if expected_meta.timestamp != actual_meta.timestamp {
+                return Ok(Some(format!(
+                    "node {node_id} ({:?}) version {index} timestamp differs: expected {:?}, actual {:?}",
+                    expected.name, expected_meta.timestamp, actual_meta.timestamp
+                )));
+            }
+            if expected_meta.min_event_time != actual_meta.min_event_time {
+                return Ok(Some(format!(
+                    "node {node_id} ({:?}) version {index} min_event_time differs: expected {:?}, actual {:?}",
+                    expected.name, expected_meta.min_event_time, actual_meta.min_event_time
+                )));
+            }
+            if expected_meta.max_event_time != actual_meta.max_event_time {
+                return Ok(Some(format!(
+                    "node {node_id} ({:?}) version {index} max_event_time differs: expected {:?}, actual {:?}",
+                    expected.name, expected_meta.max_event_time, actual_meta.max_event_time
+                )));
+            }
+            if expected_meta.extended_attributes != actual_meta.extended_attributes {
+                return Ok(Some(format!(
+                    "node {node_id} ({:?}) version {index} extended_attributes differ: expected {:?}, actual {:?}",
+                    expected.name,
+                    expected_meta.extended_attributes,
+                    actual_meta.extended_attributes
+                )));
+            }
+        }
+        if expected.versions.len() != actual.versions.len() {
+            return Ok(Some(format!(
+                "node {node_id} ({:?}) metadata count differs: expected {}, actual {}",
+                expected.name,
+                expected.versions.len(),
+                actual.versions.len()
+            )));
+        }
+    }
+
+    for (node_id, expected) in expected_nodes {
+        let actual = actual_nodes_sorted[node_id];
+        if expected.child_hash != actual.child_hash {
+            return Ok(Some(format!(
+                "directory node {node_id} ({:?}) derived hash differs: expected {}, actual {}",
+                expected.name,
+                expected.child_hash.to_hex(),
+                actual.child_hash.to_hex()
+            )));
+        }
+    }
+
+    Ok(None)
+}
+
+fn preview_validation_error(
+    graph: &FetchedGraph,
+    preview: &crate::content_tree::FoldedContentState,
+    expected_root: ObjectHash,
+    expected_manifest_hash: ObjectHash,
+    expected_manifest_root: ObjectHash,
+    label: &str,
+) -> Result<Option<String>, StewardError> {
+    let mismatch = if preview.root_tree_hash != expected_root {
+        Some(format!(
+            "{label} would fold to {} but the tip root tree is {}",
+            preview.root_tree_hash.to_hex(),
+            expected_root.to_hex()
+        ))
+    } else if preview.node_manifest_hash != expected_manifest_hash {
+        Some(format!(
+            "{label} node manifest would hash to {} but the tip commit's manifest is {}",
+            preview.node_manifest_hash.to_hex(),
+            expected_manifest_hash.to_hex()
+        ))
+    } else if preview.node_manifest_root != expected_manifest_root {
+        Some(format!(
+            "{label} node manifest Merkle root would be {} but the tip commit's root is {}",
+            preview.node_manifest_root.to_hex(),
+            expected_manifest_root.to_hex()
+        ))
+    } else {
+        None
+    };
+    let Some(mut mismatch) = mismatch else {
+        return Ok(None);
+    };
+
+    let actual_nodes: HashMap<String, ManifestEntry> = preview
+        .manifest
+        .iter()
+        .cloned()
+        .map(|entry| (entry.node_id.clone(), entry))
+        .collect();
+    match first_replica_divergence(graph, &actual_nodes, &preview.series_versions)? {
+        Some(detail) => mismatch.push_str(&format!("; first divergence: {detail}")),
+        None => mismatch.push_str("; manifests match field-by-field"),
+    }
+    Ok(Some(mismatch))
 }
 
 /// Verify the fetched node manifest is structurally consistent with the fetched
@@ -789,7 +1103,12 @@ struct RenameIntent {
 /// rotation) has no such rename; it is broken by first moving one node to a
 /// unique temporary name (freeing its old name so the rest of the cycle can
 /// proceed), then renaming that temporary to its final name once the name frees.
-fn emit_collision_safe_renames(parent: &str, intents: Vec<RenameIntent>, ops: &mut Vec<ApplyOp>) {
+fn emit_collision_safe_renames(
+    parent: &str,
+    intents: Vec<RenameIntent>,
+    mut reserved_names: BTreeSet<String>,
+    ops: &mut Vec<ApplyOp>,
+) {
     // Pending renames keyed by the name each currently occupies. A target `new`
     // is blocked exactly while it is still a key here (some node has not yet
     // vacated it).
@@ -836,7 +1155,14 @@ fn emit_collision_safe_renames(parent: &str, intents: Vec<RenameIntent>, ops: &m
             .cloned()
             .expect("pending is non-empty in the cycle branch");
         let intent = pending.remove(&victim).expect("victim key is present");
-        let temp = format!(".pull-rename-tmp-{}", intent.node_id);
+        let base = format!(".pull-rename-tmp-{}", intent.node_id);
+        let mut temp = base.clone();
+        let mut suffix = 0_u64;
+        while reserved_names.contains(&temp) || pending.contains_key(&temp) {
+            suffix += 1;
+            temp = format!("{base}-{suffix}");
+        }
+        let _ = reserved_names.insert(temp.clone());
         ops.push(ApplyOp::Rename {
             parent: parent.to_string(),
             old: intent.old,
@@ -855,6 +1181,29 @@ fn emit_collision_safe_renames(parent: &str, intents: Vec<RenameIntent>, ops: &m
 
 /// Diff the fetched source manifest against the target's current node state,
 /// keyed by `node_id`, producing the ordered apply plan and the create counts.
+fn plan_full_replacement(
+    graph: &FetchedGraph,
+    root: ObjectHash,
+    target_nodes: &HashMap<String, ManifestEntry>,
+) -> Result<(Vec<ApplyOp>, RebuildOutcome), StewardError> {
+    let root_id = src_root_id(graph)?;
+    let mut existing: Vec<&ManifestEntry> = target_nodes
+        .values()
+        .filter(|entry| entry.node_id != root_id)
+        .collect();
+    existing.sort_by_key(|entry| std::cmp::Reverse(target_depth(&entry.node_id, target_nodes)));
+    let mut deletes = existing
+        .into_iter()
+        .map(|entry| ApplyOp::Delete {
+            parent_path: target_path(&entry.parent_node_id, target_nodes),
+            name: entry.name.clone(),
+        })
+        .collect::<Vec<_>>();
+    let (mut creates, outcome) = plan_node_diff(graph, root, &HashMap::new(), &HashMap::new())?;
+    deletes.append(&mut creates);
+    Ok((deletes, outcome))
+}
+
 fn plan_node_diff(
     graph: &FetchedGraph,
     root: ObjectHash,
@@ -930,7 +1279,17 @@ fn plan_node_diff(
                 });
             }
         }
-        emit_collision_safe_renames(parent_id, renames, &mut ops);
+        let reserved_names = kids
+            .iter()
+            .map(|entry| entry.name.clone())
+            .chain(
+                target_nodes
+                    .values()
+                    .filter(|entry| entry.parent_node_id == parent_id)
+                    .map(|entry| entry.name.clone()),
+            )
+            .collect();
+        emit_collision_safe_renames(parent_id, renames, reserved_names, &mut ops);
 
         for entry in kids {
             plan_one(
@@ -1404,21 +1763,25 @@ fn timestamp_column(meta: &VersionMeta) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn series_metadata_divergence_forces_full_rewrite() {
-        let blob_hash = ObjectHash::of_bytes(b"unchanged");
-        let series_hash = ObjectHash::of_bytes(b"series");
-        let entry = ManifestEntry::new(
+    fn series_entry(child_hash: ObjectHash, timestamp: i64) -> ManifestEntry {
+        ManifestEntry::new(
             "series-node",
             "root",
             "events.series",
             EntryType::FilePhysicalSeries,
-            series_hash,
+            child_hash,
             vec![VersionMeta {
-                timestamp: Some(2),
+                timestamp: Some(timestamp),
                 ..VersionMeta::default()
             }],
-        );
+        )
+    }
+
+    #[test]
+    fn series_metadata_divergence_forces_full_rewrite() {
+        let blob_hash = ObjectHash::of_bytes(b"unchanged");
+        let series_hash = ObjectHash::of_bytes(b"series");
+        let entry = series_entry(series_hash, 2);
         let mut graph = FetchedGraph::default();
         _ = graph
             .objects
@@ -1435,6 +1798,57 @@ mod tests {
         assert_eq!(versions.len(), 1);
         assert!(collapse_first);
         assert_eq!(versions[0].meta.timestamp, Some(2));
+    }
+
+    #[test]
+    fn divergence_diagnostic_identifies_series_metadata_field() {
+        let blob_hash = ObjectHash::of_bytes(b"unchanged");
+        let series_hash = ObjectHash::of_bytes(b"series");
+        let mut graph = FetchedGraph {
+            manifest: vec![series_entry(series_hash, 2)],
+            ..FetchedGraph::default()
+        };
+        _ = graph
+            .objects
+            .insert(series_hash, FetchedObject::Series(vec![blob_hash]));
+        let actual_nodes =
+            HashMap::from([("series-node".to_string(), series_entry(series_hash, 1))]);
+        let actual_series = HashMap::from([("series-node".to_string(), vec![blob_hash])]);
+
+        let detail = first_replica_divergence(&graph, &actual_nodes, &actual_series)
+            .expect("diagnosis")
+            .expect("divergence");
+
+        assert!(detail.contains("version 0 timestamp differs"), "{detail}");
+        assert!(
+            detail.contains("expected Some(2), actual Some(1)"),
+            "{detail}"
+        );
+    }
+
+    #[test]
+    fn divergence_diagnostic_identifies_series_blob() {
+        let expected_blob = ObjectHash::of_bytes(b"expected");
+        let actual_blob = ObjectHash::of_bytes(b"actual");
+        let series_hash = ObjectHash::of_bytes(b"series");
+        let mut graph = FetchedGraph {
+            manifest: vec![series_entry(series_hash, 2)],
+            ..FetchedGraph::default()
+        };
+        _ = graph
+            .objects
+            .insert(series_hash, FetchedObject::Series(vec![expected_blob]));
+        let actual_nodes =
+            HashMap::from([("series-node".to_string(), series_entry(series_hash, 2))]);
+        let actual_series = HashMap::from([("series-node".to_string(), vec![actual_blob])]);
+
+        let detail = first_replica_divergence(&graph, &actual_nodes, &actual_series)
+            .expect("diagnosis")
+            .expect("divergence");
+
+        assert!(detail.contains("blob 0 differs"), "{detail}");
+        assert!(detail.contains(&expected_blob.to_hex()), "{detail}");
+        assert!(detail.contains(&actual_blob.to_hex()), "{detail}");
     }
 }
 

--- a/crates/steward/src/content_push.rs
+++ b/crates/steward/src/content_push.rs
@@ -155,42 +155,17 @@ async fn push_content_inner(
     remote: &mut ContentRemote,
     ref_name: &str,
 ) -> Result<ContentPushOutcome, StewardError> {
-    let seq = ship
-        .control_table()
-        .latest_spine_seq()
-        .await?
-        .ok_or_else(|| {
-            StewardError::Content("no content-changing commit to push (empty pond)".to_string())
-        })?;
-
-    let commit_hash_hex = ship
-        .control_table()
-        .commit_hash_at(seq)
-        .await?
-        .ok_or_else(|| {
-            StewardError::Content(format!("no commit spine recorded at write seq {seq}"))
-        })?;
-    let commit_object_hex = ship
-        .control_table()
-        .commit_object_at(seq)
-        .await?
-        .ok_or_else(|| {
-            StewardError::Content(format!("no commit object recorded at write seq {seq}"))
-        })?;
-
-    let tip = ObjectHash::from_hex(&commit_hash_hex)
-        .map_err(|e| StewardError::Content(format!("invalid commit hash: {e}")))?;
-    let commit_bytes = hex::decode(&commit_object_hex)
-        .map_err(|e| StewardError::Content(format!("invalid commit object hex: {e}")))?;
-
-    let recomputed = ObjectHash::of_bytes(&commit_bytes);
-    if recomputed != tip {
-        return Err(StewardError::Content(format!(
-            "commit object hashes to {} but the spine records tip {}",
-            recomputed.to_hex(),
-            tip.to_hex()
-        )));
-    }
+    let commit_log = crate::content_tree::read_log_leaves(
+        ship.data_persistence().table().clone(),
+        &ship.control_table().pond_id_uuid().to_string(),
+    )
+    .await?;
+    let commit_bytes = commit_log.last().cloned().ok_or_else(|| {
+        StewardError::Content("no content-changing commit to push (empty pond)".to_string())
+    })?;
+    let tip = sync_store::content::Commit::decode(&commit_bytes)
+        .map_err(|e| StewardError::Content(format!("decode commit-log tip: {e}")))?
+        .hash();
 
     let materialized = materialize_content_objects(ship).await?;
 
@@ -256,7 +231,17 @@ async fn push_content_inner(
         )));
     }
     objects.push((manifest_hash, manifest_bytes));
-    objects.push((tip, commit_bytes));
+    for bytes in commit_log {
+        let commit = sync_store::content::Commit::decode(&bytes)
+            .map_err(|e| StewardError::Content(format!("decode commit-log leaf: {e}")))?;
+        let hash = commit.hash();
+        objects.push((hash, bytes));
+    }
+    if !objects.iter().any(|(hash, _)| *hash == tip) {
+        return Err(StewardError::Content(
+            "commit-log does not contain the advertised tip".to_string(),
+        ));
+    }
 
     // The batched commit is one call carrying every inline object; what it
     // costs is whatever the resulting Delta transaction actually performs.

--- a/crates/steward/src/content_source.rs
+++ b/crates/steward/src/content_source.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use sync_store::ContentRemote;
-use sync_store::content::ObjectHash;
+use sync_store::content::{Commit, ObjectHash};
 use uuid::Uuid;
 
 use crate::content_tree::materialize_content_objects;
@@ -160,42 +160,17 @@ impl LocalPondSource {
             StewardError::Content("pond:// source path is not a pond steward".to_string())
         })?;
 
-        // Resolve the tip exactly as `push_content_to_remote` does: the highest
-        // content-changing spine seq, its commit hash, and the persisted commit
-        // object bytes.
-        let seq = ship
-            .control_table()
-            .latest_spine_seq()
-            .await?
-            .ok_or_else(|| {
-                StewardError::Content("pond:// source has no content-changing commit".to_string())
-            })?;
-        let commit_hash_hex = ship
-            .control_table()
-            .commit_hash_at(seq)
-            .await?
-            .ok_or_else(|| {
-                StewardError::Content(format!("no commit spine recorded at write seq {seq}"))
-            })?;
-        let commit_object_hex = ship
-            .control_table()
-            .commit_object_at(seq)
-            .await?
-            .ok_or_else(|| {
-                StewardError::Content(format!("no commit object recorded at write seq {seq}"))
-            })?;
-        let tip = ObjectHash::from_hex(&commit_hash_hex)
-            .map_err(|e| StewardError::Content(format!("invalid commit hash: {e}")))?;
-        let commit_bytes = hex::decode(&commit_object_hex)
-            .map_err(|e| StewardError::Content(format!("invalid commit object hex: {e}")))?;
-        let recomputed = ObjectHash::of_bytes(&commit_bytes);
-        if recomputed != tip {
-            return Err(StewardError::Content(format!(
-                "commit object hashes to {} but the spine records tip {}",
-                recomputed.to_hex(),
-                tip.to_hex()
-            )));
-        }
+        let pond_id = ship.control_table().pond_id_uuid();
+        let commit_log = crate::content_tree::read_log_leaves(
+            ship.data_persistence().table().clone(),
+            &pond_id.to_string(),
+        )
+        .await?;
+        let tip = Commit::decode(commit_log.last().ok_or_else(|| {
+            StewardError::Content("pond:// source has no content-changing commit".to_string())
+        })?)
+        .map_err(|e| StewardError::Content(format!("decode commit-log tip: {e}")))?
+        .hash();
 
         let materialized = materialize_content_objects(ship).await?;
         let mut objects: BTreeMap<ObjectHash, Vec<u8>> = materialized.inline;
@@ -203,11 +178,16 @@ impl LocalPondSource {
             StewardError::Content("materialized objects carry no node manifest".to_string())
         })?;
         let _ = objects.insert(manifest_hash, manifest_bytes);
-        // The tip commit object is added by the push layer on top of the
-        // materialized closure; add it here so a consumer can fetch it too.
-        let _ = objects.insert(tip, commit_bytes);
+        // Serve the authoritative commit-log chain, not only the tip. A
+        // consumer uses this lineage to reject stale/out-of-order refs while
+        // still accepting an ordinary producer fast-forward.
+        for bytes in commit_log {
+            let commit = Commit::decode(&bytes)
+                .map_err(|e| StewardError::Content(format!("decode commit-log leaf: {e}")))?;
+            let hash = commit.hash();
+            let _ = objects.insert(hash, bytes);
+        }
         let external_blobs = materialized.external_blobs;
-        let pond_id = ship.control_table().pond_id_uuid();
 
         Ok(Self {
             steward,

--- a/crates/steward/src/content_tree.rs
+++ b/crates/steward/src/content_tree.rs
@@ -347,36 +347,6 @@ pub(crate) fn node_manifest_entries(index: &ContentTreeIndex) -> Vec<ManifestEnt
     entries
 }
 
-/// Compute the node-manifest commitments a commit references: the node
-/// manifest object's content hash (`node_manifest_hash`) and the node-keyed
-/// Merkle root over that manifest (`node_manifest_root`).  Both come from a
-/// single fold of the data table, so they are mutually consistent.
-///
-/// # Errors
-///
-/// Returns an error if the data table cannot be read or folded, or if the
-/// manifest cannot be encoded or hashed (a duplicate `node_id`).
-pub(crate) async fn compute_commit_roots_for_table(
-    table: deltalake::DeltaTable,
-    local_pond_id: &str,
-) -> Result<CommitRoots, StewardError> {
-    let index = build_content_tree_for_table(table, local_pond_id).await?;
-    let manifest = node_manifest_entries(&index);
-    let node_manifest_hash = manifest_hash(&manifest).map_err(StewardError::Content)?;
-    let node_manifest_root = node_merkle_rebuild_root(&manifest).map_err(StewardError::Content)?;
-    Ok(CommitRoots {
-        node_manifest_hash,
-        node_manifest_root,
-    })
-}
-
-/// The node-manifest commitments a commit object references, recomputed from a
-/// pond's live state (used by the pull path to verify a rebuilt mirror).
-pub(crate) struct CommitRoots {
-    pub node_manifest_hash: ObjectHash,
-    pub node_manifest_root: ObjectHash,
-}
-
 /// Build the full node-manifest bytes for the current in-transaction live state
 /// (design `docs/incremental-content-tree-design.md` Section 4, Approach A /
 /// Phase 2).

--- a/crates/steward/src/content_tree.rs
+++ b/crates/steward/src/content_tree.rs
@@ -412,32 +412,60 @@ pub(crate) struct SpineInputs {
     pub node_manifest_root: ObjectHash,
 }
 
-pub(crate) async fn in_txn_spine_inputs(
+/// Canonical full-fold view of one pond partition, including the state needed
+/// to explain a root mismatch at node and series-version granularity.
+pub(crate) struct FoldedContentState {
+    pub manifest: Vec<ManifestEntry>,
+    pub series_versions: HashMap<String, Vec<ObjectHash>>,
+    pub root_tree_hash: ObjectHash,
+    pub node_manifest_hash: ObjectHash,
+    pub node_manifest_root: ObjectHash,
+}
+
+pub(crate) async fn in_txn_content_state(
     committed_table: deltalake::DeltaTable,
     uncommitted: Vec<OplogEntry>,
-    local_pond_id: &str,
-) -> Result<SpineInputs, StewardError> {
+    pond_id: &str,
+) -> Result<FoldedContentState, StewardError> {
     let mut rows = scan_live_rows(committed_table, false).await?;
     rows.extend(uncommitted);
-    // fold_rows takes the latest version per node from ascending-version order;
-    // pending and synthesized rows carry higher (or `i64::MAX`) versions, so
-    // ordering by version per node makes them win over their committed rows.
     rows.sort_by(|a, b| {
         a.pond_id
             .cmp(&b.pond_id)
             .then_with(|| a.node_id.to_string().cmp(&b.node_id.to_string()))
             .then_with(|| a.version.cmp(&b.version))
     });
-    let index = fold_rows(rows, local_pond_id, None)?;
+    let index = fold_rows(rows, pond_id, None)?;
     let manifest = node_manifest_entries(&index);
     let node_manifest_hash = manifest_hash(&manifest).map_err(StewardError::Content)?;
     let node_manifest_root = node_merkle_rebuild_root(&manifest).map_err(StewardError::Content)?;
-    let manifest_bytes = encode_manifest(&manifest).map_err(StewardError::Content)?;
-    Ok(SpineInputs {
-        manifest_bytes,
+    let series_versions = index
+        .series_versions
+        .iter()
+        .filter(|((row_pond_id, _), _)| row_pond_id == pond_id)
+        .map(|((_, node_id), versions)| (node_id.clone(), versions.clone()))
+        .collect();
+    Ok(FoldedContentState {
+        manifest,
+        series_versions,
         root_tree_hash: index.root_tree_hash,
         node_manifest_hash,
         node_manifest_root,
+    })
+}
+
+pub(crate) async fn in_txn_spine_inputs(
+    committed_table: deltalake::DeltaTable,
+    uncommitted: Vec<OplogEntry>,
+    local_pond_id: &str,
+) -> Result<SpineInputs, StewardError> {
+    let state = in_txn_content_state(committed_table, uncommitted, local_pond_id).await?;
+    let manifest_bytes = encode_manifest(&state.manifest).map_err(StewardError::Content)?;
+    Ok(SpineInputs {
+        manifest_bytes,
+        root_tree_hash: state.root_tree_hash,
+        node_manifest_hash: state.node_manifest_hash,
+        node_manifest_root: state.node_manifest_root,
     })
 }
 

--- a/crates/steward/src/graft.rs
+++ b/crates/steward/src/graft.rs
@@ -28,7 +28,8 @@ pub const SYS_GRAFTS_DIR: &str = "/sys/grafts";
 
 /// The content-addressed reference a pond keeps to a grafted foreign tip.
 ///
-/// Written at `/sys/grafts/<name>` after a successful cross-pond import.  The
+/// Written at `/sys/grafts/<name>` in the same transaction as a cross-pond
+/// import. The
 /// `pinned_tip` is the foreign pond's tip commit hash at import time; the
 /// foreign content it commits to is NOT fetched into this pond (the graft is
 /// non-transitive), so the reference is intentionally dangling for any
@@ -72,6 +73,34 @@ impl GraftPin {
     }
 }
 
+/// Split an absolute, non-root graft mount path into its parent and leaf.
+///
+/// # Errors
+///
+/// Returns an error when the path is relative, root, or has no leaf name.
+pub fn split_mount_path(path: &str) -> Result<(&str, &str), String> {
+    if !path.starts_with('/') {
+        return Err(format!("mount path `{path}` must be absolute"));
+    }
+    if path == "/" {
+        return Err("graft mount path cannot be `/`".to_string());
+    }
+    let trimmed = path.trim_end_matches('/');
+    let last_slash = trimmed
+        .rfind('/')
+        .ok_or_else(|| format!("mount path `{path}` has no leaf"))?;
+    let parent = if last_slash == 0 {
+        "/"
+    } else {
+        &trimmed[..last_slash]
+    };
+    let leaf = &trimmed[last_slash + 1..];
+    if leaf.is_empty() {
+        return Err(format!("mount path `{path}` has empty leaf"));
+    }
+    Ok((parent, leaf))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,5 +126,16 @@ mod tests {
     fn rejects_unknown_fields() {
         let yaml = "foreign_pond_id: x\nmount_path: /imports/A\npinned_tip: y\nbogus: 1\n";
         assert!(GraftPin::from_yaml_bytes(yaml.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn splits_mount_paths() {
+        assert_eq!(split_mount_path("/imports").unwrap(), ("/", "imports"));
+        assert_eq!(
+            split_mount_path("/imports/upstream/").unwrap(),
+            ("/imports", "upstream")
+        );
+        assert!(split_mount_path("/").is_err());
+        assert!(split_mount_path("imports/upstream").is_err());
     }
 }

--- a/crates/steward/src/guard.rs
+++ b/crates/steward/src/guard.rs
@@ -40,6 +40,17 @@ struct PostCommitFactoryConfig {
     factory_mode: String,
 }
 
+struct ExpectedContentRoots {
+    root_tree_hash: String,
+    node_manifest_hash: String,
+    node_manifest_root: String,
+}
+
+struct PreparedCommit {
+    spine: CommitSpine,
+    content_roots: ExpectedContentRoots,
+}
+
 /// Steward transaction guard wraps TLogFS transaction with control table lifecycle tracking
 pub struct StewardTransactionGuard<'a> {
     /// The underlying tlogfs transaction guard
@@ -49,6 +60,9 @@ pub struct StewardTransactionGuard<'a> {
     transaction_type: TransactionType,
     /// Reference to control table for transaction tracking
     control_table: &'a mut ControlTable,
+    /// Ship's in-memory allocator, advanced at begin and restored when a write
+    /// aborts before the underlying TLogFS transaction commits.
+    last_write_seq: &'a mut i64,
     /// Start time for duration tracking
     start_time: std::time::Instant,
     /// Pond path for reloading OpLogPersistence during post-commit
@@ -66,6 +80,7 @@ pub struct StewardTransactionGuard<'a> {
     /// control queue only once this transaction commits, so an aborted write
     /// re-emits rather than losing them.
     emitted_usage: std::sync::atomic::AtomicUsize,
+    expected_content_roots: Option<ExpectedContentRoots>,
 }
 
 impl<'a> StewardTransactionGuard<'a> {
@@ -75,6 +90,7 @@ impl<'a> StewardTransactionGuard<'a> {
         txn_meta: &PondTxnMetadata,
         transaction_type: TransactionType,
         control_table: &'a mut ControlTable,
+        last_write_seq: &'a mut i64,
         path: P,
         write_lock: Option<WriteLockGuard>,
     ) -> Self {
@@ -83,11 +99,13 @@ impl<'a> StewardTransactionGuard<'a> {
             txn_meta: txn_meta.clone(),
             transaction_type,
             control_table,
+            last_write_seq,
             start_time: std::time::Instant::now(),
             pond_path: path.as_ref().to_path_buf(),
             committed: false,
             write_lock,
             emitted_usage: std::sync::atomic::AtomicUsize::new(0),
+            expected_content_roots: None,
         }
     }
 
@@ -256,9 +274,18 @@ impl<'a> StewardTransactionGuard<'a> {
     /// Abort the transaction and record it as failed
     /// Use this when an error occurs that should be recorded in the control table
     pub async fn abort(mut self, error: impl std::fmt::Display) -> StewardError {
-        let duration_ms = self.start_time.elapsed().as_millis() as i64;
         let error_msg = error.to_string();
+        self.rollback(&error_msg).await;
+        StewardError::Aborted(error_msg)
+    }
 
+    pub(crate) async fn abort_preserving(mut self, error: StewardError) -> StewardError {
+        self.rollback(&error.to_string()).await;
+        error
+    }
+
+    async fn rollback(&mut self, error_msg: &str) {
+        let duration_ms = self.start_time.elapsed().as_millis() as i64;
         debug!(
             "Aborting steward transaction {} (seq={}): {}",
             self.txn_meta.user.txn_id, self.txn_meta.txn_seq, error_msg
@@ -272,7 +299,7 @@ impl<'a> StewardTransactionGuard<'a> {
                 .record_failed(
                     &self.txn_meta,
                     self.transaction_type,
-                    error_msg.clone(),
+                    error_msg.to_string(),
                     duration_ms,
                 )
                 .await
@@ -281,11 +308,11 @@ impl<'a> StewardTransactionGuard<'a> {
         }
 
         // Drop the transaction guard without committing (will rollback)
+        if self.transaction_type == TransactionType::Write {
+            *self.last_write_seq = self.txn_meta.txn_seq - 1;
+        }
         self.committed = true; // Mark as handled to avoid Drop warning
         drop(self.data_tx.take());
-
-        // Return the original error wrapped in StewardError
-        StewardError::Aborted(error_msg)
     }
 
     /// Commit the transaction with proper steward sequencing
@@ -298,6 +325,91 @@ impl<'a> StewardTransactionGuard<'a> {
     pub fn note_emitted_usage(&self, count: usize) {
         self.emitted_usage
             .store(count, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn expect_content_roots(
+        &mut self,
+        root_tree_hash: sync_store::content::ObjectHash,
+        node_manifest_hash: sync_store::content::ObjectHash,
+        node_manifest_root: sync_store::content::ObjectHash,
+    ) {
+        self.expected_content_roots = Some(ExpectedContentRoots {
+            root_tree_hash: root_tree_hash.to_hex(),
+            node_manifest_hash: node_manifest_hash.to_hex(),
+            node_manifest_root: node_manifest_root.to_hex(),
+        });
+    }
+
+    async fn prepare_commit(&self) -> Result<Option<PreparedCommit>, StewardError> {
+        let mut prepared_commit = None;
+        if self.transaction_type == TransactionType::Write {
+            let data_tx = self.data_tx.as_ref().ok_or_else(|| {
+                StewardError::DataInit(tlogfs::TLogFSError::TinyFS(tinyfs::Error::Other(
+                    "Transaction already consumed".to_string(),
+                )))
+            })?;
+            let (pending_records, modified_dirs) = data_tx.state()?.pending_operation_counts();
+            if pending_records > 0 || modified_dirs > 0 {
+                prepared_commit = self
+                    .write_reserved_nodes(
+                        data_tx,
+                        self.txn_meta.txn_seq,
+                        self.txn_meta.user.args.join(" "),
+                    )
+                    .await?;
+            }
+        }
+
+        if let Some(expected) = &self.expected_content_roots {
+            let actual = if let Some(prepared) = &prepared_commit {
+                (
+                    prepared.content_roots.root_tree_hash.clone(),
+                    prepared.content_roots.node_manifest_hash.clone(),
+                    prepared.content_roots.node_manifest_root.clone(),
+                )
+            } else {
+                let data_tx = self.data_tx.as_ref().ok_or_else(|| {
+                    StewardError::DataInit(tlogfs::TLogFSError::TinyFS(tinyfs::Error::Other(
+                        "Transaction already consumed".to_string(),
+                    )))
+                })?;
+                let pond_id = self.control_table.pond_id_uuid().to_string();
+                let current = crate::content_tree::in_txn_content_state(
+                    data_tx.persistence().table().clone(),
+                    Vec::new(),
+                    &pond_id,
+                )
+                .await?;
+                (
+                    current.root_tree_hash.to_hex(),
+                    current.node_manifest_hash.to_hex(),
+                    current.node_manifest_root.to_hex(),
+                )
+            };
+            let mismatch = if actual.0 != expected.root_tree_hash {
+                Some(format!(
+                    "precommit root tree is {} but expected {}",
+                    actual.0, expected.root_tree_hash
+                ))
+            } else if actual.1 != expected.node_manifest_hash {
+                Some(format!(
+                    "precommit node manifest hash is {} but expected {}",
+                    actual.1, expected.node_manifest_hash
+                ))
+            } else if actual.2 != expected.node_manifest_root {
+                Some(format!(
+                    "precommit node manifest Merkle root is {} but expected {}",
+                    actual.2, expected.node_manifest_root
+                ))
+            } else {
+                None
+            };
+            if let Some(error) = mismatch {
+                return Err(StewardError::Content(error));
+            }
+        }
+
+        Ok(prepared_commit)
     }
 
     pub async fn commit(mut self) -> Result<Option<i64>, StewardError> {
@@ -315,32 +427,22 @@ impl<'a> StewardTransactionGuard<'a> {
         // the chunked-parquet remote factory in D4.5; cross-pond import
         // is planned for D5 via row-level `pond_id` partitioning.)
 
-        // Step 2: Extract the underlying transaction guard and commit it
-        let data_tx = self.take_transaction().ok_or_else(|| {
-            StewardError::DataInit(tlogfs::TLogFSError::TinyFS(tinyfs::Error::Other(
-                "Transaction already consumed".to_string(),
-            )))
-        })?;
-
         // Incremental content tree (Phase 2, Approach A): persist the pond's
         // node manifest into the reserved index node as part of this same
         // transaction, before it is finalized.  Only write transactions that
         // actually changed something get an index-node version; a read
         // transaction (or a no-op write) leaves it untouched.
-        let mut in_txn_spine: Option<CommitSpine> = None;
-        if self.transaction_type == TransactionType::Write {
-            let (pending_records, modified_dirs) = data_tx.state()?.pending_operation_counts();
-            if pending_records > 0 || modified_dirs > 0 {
-                in_txn_spine = self
-                    .write_reserved_nodes(
-                        &data_tx,
-                        self.txn_meta.txn_seq,
-                        self.txn_meta.user.args.join(" "),
-                    )
-                    .await?;
-            }
-        }
+        let prepared_commit = match self.prepare_commit().await {
+            Ok(prepared) => prepared,
+            Err(error) => return Err(self.abort_preserving(error).await),
+        };
 
+        // Step 2: Extract the underlying transaction guard and commit it.
+        let data_tx = self.take_transaction().ok_or_else(|| {
+            StewardError::DataInit(tlogfs::TLogFSError::TinyFS(tinyfs::Error::Other(
+                "Transaction already consumed".to_string(),
+            )))
+        })?;
         let commit_result = data_tx.commit().await;
 
         // Step 3: Record transaction lifecycle in control table based on result
@@ -373,7 +475,7 @@ impl<'a> StewardTransactionGuard<'a> {
                 // same Delta transaction as the data, by `write_reserved_nodes`.
                 // The control-table copy recorded below is a disposable,
                 // rebuildable cache -- not the source of truth.
-                let commit_spine = in_txn_spine;
+                let commit_spine = prepared_commit.map(|prepared| prepared.spine);
 
                 // The leaf appended to the transparency log is the commit
                 // object of this commit; a spine is present exactly when the
@@ -468,6 +570,7 @@ impl<'a> StewardTransactionGuard<'a> {
                 // never recorded a Begin so there's nothing to terminate).
                 let error_msg = format!("{}", e);
                 if self.transaction_type == TransactionType::Write {
+                    *self.last_write_seq = self.txn_meta.txn_seq - 1;
                     self.control_table
                         .record_failed(
                             &self.txn_meta,
@@ -532,7 +635,7 @@ impl<'a> StewardTransactionGuard<'a> {
         data_tx: &TransactionGuard<'_>,
         txn_seq: i64,
         commit_args: String,
-    ) -> Result<Option<CommitSpine>, StewardError> {
+    ) -> Result<Option<PreparedCommit>, StewardError> {
         use tokio::io::AsyncWriteExt;
 
         let pond_id = self.control_table.pond_id_uuid();
@@ -634,7 +737,14 @@ impl<'a> StewardTransactionGuard<'a> {
         log_writer.write_all(&commit_object).await?;
         log_writer.shutdown().await?;
 
-        Ok(Some(spine))
+        Ok(Some(PreparedCommit {
+            spine,
+            content_roots: ExpectedContentRoots {
+                root_tree_hash: inputs.root_tree_hash.to_hex(),
+                node_manifest_hash: inputs.node_manifest_hash.to_hex(),
+                node_manifest_root: inputs.node_manifest_root.to_hex(),
+            },
+        }))
     }
 
     /// Run post-commit factories after a successful write transaction
@@ -1092,7 +1202,8 @@ impl<'a> StewardTransactionGuard<'a> {
             } else {
                 None
             }
-        };
+        }
+        .map(|prepared| prepared.spine);
 
         // Commit the post-commit factory execution transaction
         // Metadata was already provided at begin()
@@ -1492,6 +1603,9 @@ impl<'a> Deref for StewardTransactionGuard<'a> {
 impl<'a> Drop for StewardTransactionGuard<'a> {
     fn drop(&mut self) {
         if self.data_tx.is_some() && !self.committed {
+            if self.transaction_type == TransactionType::Write {
+                *self.last_write_seq = self.txn_meta.txn_seq - 1;
+            }
             // Transaction was neither committed nor explicitly failed
             // This happens when an error occurs before commit() is called
             // The transaction will rollback but we can't record failure here (Drop isn't async)

--- a/crates/steward/src/lib.rs
+++ b/crates/steward/src/lib.rs
@@ -41,7 +41,8 @@ mod write_lock;
 pub use content_diff::{ContentComparison, ContentDiff, DiffKind, compare_content_trees};
 pub use content_objects::{ObjectInventory, ObjectKind, inventory_content_objects};
 pub use content_pull::{
-    FetchedGraph, FetchedObject, RebuildOutcome, fetch_object_graph, import_pond, rebuild_pond,
+    FetchedGraph, FetchedObject, RebuildOutcome, fetch_object_graph, import_graft, import_pond,
+    rebuild_pond, replace_graft,
 };
 pub use content_push::{
     ContentPushOutcome, open_and_push_to_remote_limited, push_content_to_remote,
@@ -53,10 +54,10 @@ pub use content_tree::{
     materialize_content_objects,
 };
 pub use content_verify::{ContentVerifyReport, ContentVerifyState, verify_content_against_remote};
-pub use control_table::{CommitSpine, ControlTable};
+pub use control_table::{CommitSpine, ControlTable, TransactionType};
 pub use dispatch::{Steward, Transaction};
 pub use fsck::{FsckError, FsckOptions, FsckReport, PartitionDigest, fsck};
-pub use graft::{GraftPin, SYS_GRAFTS_DIR};
+pub use graft::{GraftPin, SYS_GRAFTS_DIR, split_mount_path};
 pub use guard::StewardTransactionGuard;
 pub use host::{HostSteward, HostTransaction};
 pub use limiter::{

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -436,7 +436,7 @@ impl Ship {
             Err(e) => {
                 let error_msg = format!("{}", e);
                 debug!("Transaction failed: {error_msg}");
-                Err(e)
+                Err(tx.abort_preserving(e).await)
             }
         }
     }
@@ -486,10 +486,9 @@ impl Ship {
                 Ok(value)
             }
             Err(e) => {
-                // Error - steward transaction guard will auto-rollback on drop
                 let error_msg = format!("{}", e);
                 debug!("Transaction replay failed {error_msg}");
-                Err(e)
+                Err(tx.abort_preserving(e).await)
             }
         }
     }
@@ -611,35 +610,47 @@ impl Ship {
             None
         };
 
-        // Lock acquired — now commit the sequence advance.
-        if is_write {
-            self.last_write_seq = txn_seq;
-        }
-
         // Record transaction begin in control table — writes only.
         // Reads no longer leave audit rows; the per-read Delta write
         // was pure overhead now that exclusion is enforced by the lock.
         if is_write {
-            self.control_table
+            if let Err(error) = self
+                .control_table
                 .record_begin(&txn_meta, based_on_seq, transaction_type)
                 .await
-                .map_err(|e| {
-                    StewardError::ControlTable(format!("Failed to record transaction begin: {}", e))
-                })?;
+            {
+                return Err(StewardError::ControlTable(format!(
+                    "Failed to record transaction begin: {error}"
+                )));
+            }
         }
 
         // Begin Data FS transaction guard with metadata
-        let data_tx = if is_write {
-            self.data_persistence
-                .begin_write(&txn_meta)
-                .await
-                .map_err(StewardError::DataInit)?
+        let data_tx_result = if is_write {
+            self.data_persistence.begin_write(&txn_meta).await
         } else {
-            self.data_persistence
-                .begin_read(&txn_meta)
-                .await
-                .map_err(StewardError::DataInit)?
+            self.data_persistence.begin_read(&txn_meta).await
         };
+        let data_tx = match data_tx_result {
+            Ok(data_tx) => data_tx,
+            Err(error) => {
+                if is_write {
+                    if let Err(record_error) = self
+                        .control_table
+                        .record_failed(&txn_meta, transaction_type, error.to_string(), 0)
+                        .await
+                    {
+                        log::error!(
+                            "Failed to record data transaction begin failure: {record_error}"
+                        );
+                    }
+                }
+                return Err(StewardError::DataInit(error));
+            }
+        };
+        if is_write {
+            self.last_write_seq = txn_seq;
+        }
 
         // Limiter usage queued by an earlier push rides out on this write
         // (Decision L12).  Spending happens during the post-commit push, which
@@ -659,6 +670,7 @@ impl Ship {
             &txn_meta,
             transaction_type,
             &mut self.control_table,
+            &mut self.last_write_seq,
             &self.pond_path,
             write_lock,
         );
@@ -716,9 +728,6 @@ impl Ship {
             )));
         }
 
-        // Update last_write_seq to this sequence
-        self.last_write_seq = txn_seq;
-
         debug!("Transaction replay {txn_id:?} using sequence {txn_seq} (type=write, replay=true)",);
 
         // Acquire process-level write lock (same exclusion contract as
@@ -742,11 +751,22 @@ impl Ship {
         // Begin Data FS transaction guard with metadata
 
         // For now, we still need to begin a transaction to get State access
-        let data_tx = self
-            .data_persistence
-            .begin_write(txn_meta)
-            .await
-            .map_err(StewardError::DataInit)?;
+        let data_tx = match self.data_persistence.begin_write(txn_meta).await {
+            Ok(data_tx) => data_tx,
+            Err(error) => {
+                if let Err(record_error) = self
+                    .control_table
+                    .record_failed(txn_meta, TransactionType::Write, error.to_string(), 0)
+                    .await
+                {
+                    log::error!(
+                        "Failed to record replay data transaction begin failure: {record_error}"
+                    );
+                }
+                return Err(StewardError::DataInit(error));
+            }
+        };
+        self.last_write_seq = txn_seq;
 
         // Create steward transaction guard with sequence tracking
         Ok(StewardTransactionGuard::new(
@@ -754,6 +774,7 @@ impl Ship {
             txn_meta,
             TransactionType::Write,
             &mut self.control_table,
+            &mut self.last_write_seq,
             self.pond_path.clone(),
             Some(write_lock),
         ))

--- a/crates/steward/src/ship.rs
+++ b/crates/steward/src/ship.rs
@@ -613,16 +613,15 @@ impl Ship {
         // Record transaction begin in control table — writes only.
         // Reads no longer leave audit rows; the per-read Delta write
         // was pure overhead now that exclusion is enforced by the lock.
-        if is_write {
-            if let Err(error) = self
+        if is_write
+            && let Err(error) = self
                 .control_table
                 .record_begin(&txn_meta, based_on_seq, transaction_type)
                 .await
-            {
-                return Err(StewardError::ControlTable(format!(
-                    "Failed to record transaction begin: {error}"
-                )));
-            }
+        {
+            return Err(StewardError::ControlTable(format!(
+                "Failed to record transaction begin: {error}"
+            )));
         }
 
         // Begin Data FS transaction guard with metadata
@@ -634,16 +633,13 @@ impl Ship {
         let data_tx = match data_tx_result {
             Ok(data_tx) => data_tx,
             Err(error) => {
-                if is_write {
-                    if let Err(record_error) = self
+                if is_write
+                    && let Err(record_error) = self
                         .control_table
                         .record_failed(&txn_meta, transaction_type, error.to_string(), 0)
                         .await
-                    {
-                        log::error!(
-                            "Failed to record data transaction begin failure: {record_error}"
-                        );
-                    }
+                {
+                    log::error!("Failed to record data transaction begin failure: {record_error}");
                 }
                 return Err(StewardError::DataInit(error));
             }

--- a/crates/steward/tests/content_pull_test.rs
+++ b/crates/steward/tests/content_pull_test.rs
@@ -11,7 +11,7 @@ use sync_store::content::ObjectHash;
 use tempfile::tempdir;
 use tinyfs::arrow::parquet::ParquetExt;
 use tinyfs::async_helpers::convenience::create_file_path;
-use tlogfs::PondUserMetadata;
+use tlogfs::{PondTxnMetadata, PondUserMetadata};
 
 use std::sync::Arc;
 
@@ -31,6 +31,65 @@ async fn write_file(ship: &mut Ship, path: &str, bytes: &[u8]) {
     })
     .await
     .expect("write transaction");
+}
+
+async fn write_foreign_file(ship: &mut Ship, pond_id: uuid7::Uuid, path: &str, bytes: &[u8]) {
+    let tx = ship
+        .begin_write(&meta("write-foreign"))
+        .await
+        .expect("begin write");
+    let foreign_node = tx.foreign_root_node(pond_id).await.expect("foreign root");
+    let foreign_path = tinyfs::NodePath {
+        node: foreign_node,
+        path: "/".into(),
+    };
+    let root = tx
+        .wd(&foreign_path, foreign_path.clone())
+        .await
+        .expect("foreign wd");
+    let _ = create_file_path(&root, path, bytes)
+        .await
+        .expect("write foreign file");
+    let _ = tx.commit().await.expect("commit foreign write");
+}
+
+async fn point_mount_at_foreign_child(
+    ship: &mut Ship,
+    pond_id: uuid7::Uuid,
+    mount_parent: &str,
+    mount_name: &str,
+    child_name: &str,
+) {
+    let tx = ship
+        .begin_write(&meta("mispoint-mount"))
+        .await
+        .expect("begin write");
+    let foreign_root = tx.foreign_root_node(pond_id).await.expect("foreign root");
+    let foreign_path = tinyfs::NodePath {
+        node: foreign_root,
+        path: "/".into(),
+    };
+    let foreign_wd = tx
+        .wd(&foreign_path, foreign_path.clone())
+        .await
+        .expect("foreign wd");
+    let child = foreign_wd
+        .get(child_name)
+        .await
+        .expect("lookup child")
+        .expect("foreign child")
+        .node;
+    let root = tx.root().await.expect("local root");
+    let parent = root
+        .open_dir_path(mount_parent)
+        .await
+        .expect("mount parent");
+    parent.remove_entry(mount_name).await.expect("remove mount");
+    let _ = parent
+        .insert_node(mount_name, child)
+        .await
+        .expect("insert wrong mount");
+    let _ = tx.commit().await.expect("commit wrong mount");
 }
 
 async fn mkdir_and_file(ship: &mut Ship, dir: &str, file: &str, bytes: &[u8]) {
@@ -350,6 +409,103 @@ async fn fetched_closure_matches_pushed_objects() {
     }
 }
 
+#[tokio::test]
+async fn push_includes_ancestry_across_multiple_local_commits() {
+    let (_t, mut src) = new_pond("push-ancestry-src").await;
+    write_file(&mut src, "/v1.txt", b"one").await;
+    let (_rt, mut remote) = push(&src).await;
+    let old_tip = remote
+        .get_tip("main")
+        .await
+        .expect("read old tip")
+        .expect("old tip");
+
+    write_file(&mut src, "/v2.txt", b"two").await;
+    write_file(&mut src, "/v3.txt", b"three").await;
+    repush(&src, &mut remote).await;
+
+    let graph = fetch_object_graph(&remote, "main").await.expect("fetch");
+    assert!(
+        graph
+            .commits
+            .iter()
+            .any(|(commit_hash, _)| *commit_hash == old_tip),
+        "a later push must include enough commit ancestry to prove a fast-forward"
+    );
+    assert!(
+        graph.commits.len() >= 3,
+        "two unpushed local commits must not break the remote commit chain"
+    );
+}
+
+#[tokio::test]
+async fn push_uses_log_tip_when_control_spine_is_stale() {
+    let (_t, mut src) = new_pond("push-log-tip-src").await;
+    write_file(&mut src, "/v1.txt", b"one").await;
+    let old_seq = src.last_write_seq();
+    let old_spine = steward::CommitSpine {
+        root_tree_hash: src
+            .control_table()
+            .root_tree_hash_at(old_seq)
+            .await
+            .expect("read old root")
+            .expect("old root"),
+        parent_commit_hash: src
+            .control_table()
+            .parent_commit_hash_at(old_seq)
+            .await
+            .expect("read old parent"),
+        commit_hash: src
+            .control_table()
+            .commit_hash_at(old_seq)
+            .await
+            .expect("read old hash")
+            .expect("old hash"),
+        commit_object: src
+            .control_table()
+            .commit_object_at(old_seq)
+            .await
+            .expect("read old object")
+            .expect("old object"),
+    };
+
+    write_file(&mut src, "/v2.txt", b"two").await;
+    let current_seq = src.last_write_seq();
+    let authoritative_tip = src
+        .control_table()
+        .commit_hash_at(current_seq)
+        .await
+        .expect("read current hash")
+        .expect("current hash");
+    let fake_meta = PondTxnMetadata::new(current_seq + 100, meta("stale-control-spine"));
+    let data_version = src
+        .data_persistence()
+        .table()
+        .version()
+        .expect("data version");
+    src.control_table_mut()
+        .record_data_committed(
+            &fake_meta,
+            steward::TransactionType::Write,
+            data_version,
+            0,
+            Some(old_spine),
+        )
+        .await
+        .expect("inject stale control spine");
+
+    let (_rt, remote) = push(&src).await;
+    assert_eq!(
+        remote
+            .get_tip("main")
+            .await
+            .expect("read pushed tip")
+            .expect("pushed tip")
+            .to_hex(),
+        authoritative_tip
+    );
+}
+
 /// The full round trip: push a pond, fetch its graph, rebuild into a fresh
 /// empty pond, and confirm the rebuilt pond is content-equal to the source
 /// (its read-side fold equals the source's root tree hash).
@@ -490,6 +646,38 @@ async fn rebuild_streams_large_external_blob() {
         dst_root, src_root,
         "rebuilt pond with a streamed large blob must be content-equal to the source"
     );
+}
+
+#[tokio::test]
+async fn external_blob_validation_failure_leaves_target_unchanged() {
+    let (_t, mut src) = new_pond("large-abort-src").await;
+    let big: Vec<u8> = (0..256 * 1024).map(|i| (i * 31 + 7) as u8).collect();
+    write_file(&mut src, "/big.bin", &big).await;
+
+    let (_rt, remote) = push(&src).await;
+    let valid = fetch_object_graph(&remote, "main").await.expect("fetch");
+    assert_eq!(valid.external_blobs.len(), 1);
+    let mut invalid = valid.clone();
+    invalid.commits[0].1.node_manifest_root =
+        ObjectHash::of_bytes(b"wrong external-blob manifest root");
+
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), "large-abort-dst")
+        .await
+        .expect("create dst");
+    let version_before = dst.data_persistence().table().version();
+    let root_before = root_hash(&dst).await;
+
+    let _ = steward::rebuild_pond(&mut dst, &remote, &invalid)
+        .await
+        .expect_err("bad root must abort after streaming the external blob");
+    assert_eq!(dst.data_persistence().table().version(), version_before);
+    assert_eq!(root_hash(&dst).await, root_before);
+
+    let _ = steward::rebuild_pond(&mut dst, &remote, &valid)
+        .await
+        .expect("valid retry");
+    assert_eq!(root_hash(&dst).await, root_hash(&src).await);
 }
 
 /// A pond containing dynamic nodes (factory + config recipes) survives the
@@ -704,6 +892,48 @@ async fn swapped_sibling_names_converge() {
     assert_eq!(outcome.files, 0);
     assert_eq!(read_to_string(&mut dst, "/a.txt").await, "beta");
     assert_eq!(read_to_string(&mut dst, "/b.txt").await, "alpha");
+    assert_eq!(root_hash(&dst).await, root_hash(&src).await);
+}
+
+#[tokio::test]
+async fn rename_cycle_avoids_a_real_temporary_name_collision() {
+    let (_t, mut src) = new_pond("swap-temp-src").await;
+    write_file(&mut src, "/a.txt", b"alpha").await;
+    write_file(&mut src, "/b.txt", b"beta").await;
+    let (_rt, mut remote) = push(&src).await;
+    let graph = fetch_object_graph(&remote, "main").await.expect("fetch");
+    let a_id = graph
+        .manifest
+        .iter()
+        .find(|entry| entry.name == "a.txt")
+        .expect("a.txt manifest entry")
+        .node_id
+        .clone();
+    let collision_path = format!("/.pull-rename-tmp-{a_id}");
+    write_file(&mut src, &collision_path, b"keep").await;
+    repush(&src, &mut remote).await;
+
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), "swap-temp-dst")
+        .await
+        .expect("create dst");
+    let graph = fetch_object_graph(&remote, "main").await.expect("fetch");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("initial rebuild");
+
+    rename(&mut src, "/a.txt", "/tmp.txt").await;
+    rename(&mut src, "/b.txt", "/a.txt").await;
+    rename(&mut src, "/tmp.txt", "/b.txt").await;
+    repush(&src, &mut remote).await;
+    let graph = fetch_object_graph(&remote, "main").await.expect("fetch");
+    let _ = steward::rebuild_pond(&mut dst, &remote, &graph)
+        .await
+        .expect("rename cycle with occupied default temp");
+
+    assert_eq!(read_to_string(&mut dst, "/a.txt").await, "beta");
+    assert_eq!(read_to_string(&mut dst, "/b.txt").await, "alpha");
+    assert_eq!(read_to_string(&mut dst, &collision_path).await, "keep");
     assert_eq!(root_hash(&dst).await, root_hash(&src).await);
 }
 
@@ -1104,6 +1334,364 @@ async fn tampered_manifest_is_rejected_before_commit() {
         empty_root,
         "a rejected pull must not mutate the target pond"
     );
+}
+
+/// A mismatch discovered only after applying the import plan is still rejected
+/// before the Delta transaction commits. The failed attempt leaves no foreign
+/// root behind, and the unmodified graph can be imported immediately afterward.
+#[tokio::test]
+async fn precommit_manifest_root_mismatch_leaves_target_unchanged() {
+    let (_t, mut src) = new_pond("precommit-src").await;
+    write_file(&mut src, "/a.txt", b"alpha").await;
+    let src_id = src
+        .data_persistence()
+        .pond_id()
+        .parse::<uuid7::Uuid>()
+        .expect("source pond id");
+
+    let (_rt, remote) = push(&src).await;
+    let valid = fetch_object_graph(&remote, "main").await.expect("fetch");
+    let mut invalid = valid.clone();
+    invalid.commits[0].1.node_manifest_root = ObjectHash::of_bytes(b"wrong manifest root");
+
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), "precommit-dst")
+        .await
+        .expect("create dst");
+    let version_before = dst.data_persistence().table().version();
+
+    let err = steward::import_pond(&mut dst, &remote, &invalid, src_id)
+        .await
+        .expect_err("advertised manifest-root mismatch must abort");
+    let message = err.to_string();
+    assert!(
+        message.contains("node manifest Merkle root would be"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("manifests match field-by-field"),
+        "unexpected diagnosis: {message}"
+    );
+    assert_eq!(
+        dst.data_persistence().table().version(),
+        version_before,
+        "failed validation must not advance the data Delta table"
+    );
+    assert!(
+        steward::compute_content_tree_for_table(
+            dst.data_persistence().table().clone(),
+            &src_id.to_string(),
+        )
+        .await
+        .is_err(),
+        "failed first import must leave no foreign root"
+    );
+
+    let _ = steward::import_pond(&mut dst, &remote, &valid, src_id)
+        .await
+        .expect("valid retry");
+    assert_eq!(foreign_root_hash(&dst, src_id).await, root_hash(&src).await);
+}
+
+/// Foreign data, the local mount, and its pin share one Delta transaction.
+/// Validation failure leaves none of them behind; success commits all three.
+#[tokio::test]
+async fn graft_import_is_atomic_with_mount_and_pin() {
+    let (_t, mut src) = new_pond("atomic-graft-src").await;
+    write_file(&mut src, "/a.txt", b"alpha").await;
+    let src_id = src
+        .data_persistence()
+        .pond_id()
+        .parse::<uuid7::Uuid>()
+        .expect("source pond id");
+
+    let (_rt, remote) = push(&src).await;
+    let valid = fetch_object_graph(&remote, "main").await.expect("fetch");
+    let mut invalid = valid.clone();
+    invalid.commits[0].1.node_manifest_root = ObjectHash::of_bytes(b"wrong manifest root");
+
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), "atomic-graft-dst")
+        .await
+        .expect("create dst");
+    let version_before = dst.data_persistence().table().version();
+
+    let _ = steward::import_graft(
+        &mut dst,
+        &remote,
+        &invalid,
+        src_id,
+        "upstream",
+        "/imports/upstream",
+    )
+    .await
+    .expect_err("invalid graft must abort");
+    assert_eq!(dst.data_persistence().table().version(), version_before);
+    let tx = dst.begin_read(&meta("inspect-abort")).await.expect("read");
+    assert!(
+        !tx.root()
+            .await
+            .expect("root")
+            .exists(&steward::GraftPin::pin_path("upstream"))
+            .await
+    );
+    let _ = tx.commit().await.expect("close read");
+
+    let _ = steward::import_graft(
+        &mut dst,
+        &remote,
+        &valid,
+        src_id,
+        "upstream",
+        "/imports/upstream",
+    )
+    .await
+    .expect("valid graft");
+    assert_eq!(
+        dst.data_persistence().table().version(),
+        version_before.map(|version| version + 1),
+        "foreign rows, mount, and pin must land in one Delta commit"
+    );
+    assert_eq!(
+        read_to_string(&mut dst, "/imports/upstream/a.txt").await,
+        "alpha"
+    );
+    let pin_yaml = read_to_string(&mut dst, &steward::GraftPin::pin_path("upstream")).await;
+    let pin = steward::GraftPin::from_yaml_bytes(pin_yaml.as_bytes()).expect("parse pin");
+    assert_eq!(pin.foreign_pond_id, src_id.to_string());
+    assert_eq!(pin.pinned_tip, valid.tip.expect("tip").to_hex());
+
+    let committed_version = dst.data_persistence().table().version();
+    let _ = steward::import_graft(
+        &mut dst,
+        &remote,
+        &valid,
+        src_id,
+        "upstream",
+        "/imports/upstream",
+    )
+    .await
+    .expect("idempotent retry");
+    assert_eq!(
+        dst.data_persistence().table().version(),
+        committed_version,
+        "retry after a missing watermark must not create another data commit"
+    );
+}
+
+/// Scoped replacement rebuilds exactly one foreign partition and validates the
+/// replacement before commit, leaving unrelated grafts intact.
+#[tokio::test]
+async fn replace_graft_is_scoped_and_atomic() {
+    let (_t1, mut src1) = new_pond("replace-src-1").await;
+    write_file(&mut src1, "/one.txt", b"one").await;
+    let src1_id = src1
+        .data_persistence()
+        .pond_id()
+        .parse::<uuid7::Uuid>()
+        .expect("source 1 pond id");
+    let (_r1, remote1) = push(&src1).await;
+    let valid1 = fetch_object_graph(&remote1, "main").await.expect("fetch 1");
+
+    let (_t2, mut src2) = new_pond("replace-src-2").await;
+    write_file(&mut src2, "/two.txt", b"two").await;
+    let src2_id = src2
+        .data_persistence()
+        .pond_id()
+        .parse::<uuid7::Uuid>()
+        .expect("source 2 pond id");
+    let (_r2, remote2) = push(&src2).await;
+    let valid2 = fetch_object_graph(&remote2, "main").await.expect("fetch 2");
+
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), "replace-dst")
+        .await
+        .expect("create dst");
+    let _ = steward::import_graft(&mut dst, &remote1, &valid1, src1_id, "one", "/imports/one")
+        .await
+        .expect("import first graft");
+    let _ = steward::import_graft(&mut dst, &remote2, &valid2, src2_id, "two", "/imports/two")
+        .await
+        .expect("import second graft");
+    write_foreign_file(&mut dst, src1_id, "/poison.txt", b"poison").await;
+    let poisoned_root = foreign_root_hash(&dst, src1_id).await;
+    let unrelated_root = foreign_root_hash(&dst, src2_id).await;
+    point_mount_at_foreign_child(&mut dst, src1_id, "/imports", "one", "one.txt").await;
+
+    let mut invalid1 = valid1.clone();
+    invalid1.commits[0].1.node_manifest_root = ObjectHash::of_bytes(b"wrong replacement root");
+    let version_before = dst.data_persistence().table().version();
+    let _ = steward::replace_graft(
+        &mut dst,
+        &remote1,
+        &invalid1,
+        src1_id,
+        "one",
+        "/imports/one",
+    )
+    .await
+    .expect_err("invalid replacement must abort");
+    assert_eq!(dst.data_persistence().table().version(), version_before);
+    assert_eq!(foreign_root_hash(&dst, src1_id).await, poisoned_root);
+    assert_eq!(foreign_root_hash(&dst, src2_id).await, unrelated_root);
+
+    let _ = steward::replace_graft(&mut dst, &remote1, &valid1, src1_id, "one", "/imports/one")
+        .await
+        .expect("replace first graft");
+    assert_eq!(
+        foreign_root_hash(&dst, src1_id).await,
+        root_hash(&src1).await
+    );
+    assert_eq!(foreign_root_hash(&dst, src2_id).await, unrelated_root);
+    assert_eq!(
+        read_to_string(&mut dst, "/imports/one/one.txt").await,
+        "one"
+    );
+    assert_eq!(
+        read_to_string(&mut dst, "/imports/two/two.txt").await,
+        "two"
+    );
+
+    dst.write_transaction(&meta("local-mount-collision"), async |fs| {
+        let root = fs.root().await?;
+        root.open_dir_path("/imports")
+            .await?
+            .remove_entry("one")
+            .await?;
+        let _ = create_file_path(&root, "/imports/one", b"local").await?;
+        Ok(())
+    })
+    .await
+    .expect("create local collision");
+    let collision_version = dst.data_persistence().table().version();
+    let _ = steward::replace_graft(&mut dst, &remote1, &valid1, src1_id, "one", "/imports/one")
+        .await
+        .expect_err("local content must not be replaced");
+    assert_eq!(dst.data_persistence().table().version(), collision_version);
+    assert_eq!(read_to_string(&mut dst, "/imports/one").await, "local");
+
+    dst.write_transaction(&meta("foreign-mount-collision"), async |fs| {
+        let root = fs.root().await?;
+        let imports = root.open_dir_path("/imports").await?;
+        imports.remove_entry("one").await?;
+        let other_root = fs.foreign_root_node(src2_id).await?;
+        let _ = imports.insert_node("one", other_root).await?;
+        Ok(())
+    })
+    .await
+    .expect("create unrelated graft collision");
+    let collision_version = dst.data_persistence().table().version();
+    let _ = steward::replace_graft(&mut dst, &remote1, &valid1, src1_id, "one", "/imports/one")
+        .await
+        .expect_err("another graft must not be replaced");
+    assert_eq!(dst.data_persistence().table().version(), collision_version);
+    assert_eq!(
+        read_to_string(&mut dst, "/imports/one/two.txt").await,
+        "two"
+    );
+}
+
+/// Local rebuilds use the same precommit gate as foreign imports: a bad
+/// advertised root aborts without advancing Delta and does not poison retry.
+#[tokio::test]
+async fn rebuild_manifest_root_mismatch_leaves_target_unchanged() {
+    let (_t, mut src) = new_pond("rebuild-precommit-src").await;
+    write_file(&mut src, "/a.txt", b"alpha").await;
+
+    let (_rt, remote) = push(&src).await;
+    let valid = fetch_object_graph(&remote, "main").await.expect("fetch");
+    let mut invalid = valid.clone();
+    invalid.commits[0].1.node_manifest_root = ObjectHash::of_bytes(b"wrong manifest root");
+
+    let dst_dir = tempdir().expect("dst dir");
+    let mut dst = Ship::create_pond(dst_dir.path().join("pond"), "rebuild-precommit-dst")
+        .await
+        .expect("create dst");
+    let version_before = dst.data_persistence().table().version();
+    let root_before = root_hash(&dst).await;
+
+    let err = steward::rebuild_pond(&mut dst, &remote, &invalid)
+        .await
+        .expect_err("advertised manifest-root mismatch must abort");
+    assert!(
+        err.to_string()
+            .contains("precommit node manifest Merkle root"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        dst.data_persistence().table().version(),
+        version_before,
+        "failed validation must not advance the data Delta table"
+    );
+    assert_eq!(
+        root_hash(&dst).await,
+        root_before,
+        "failed validation must leave local content unchanged"
+    );
+
+    let _ = steward::rebuild_pond(&mut dst, &remote, &valid)
+        .await
+        .expect("valid retry");
+    assert_eq!(root_hash(&dst).await, root_hash(&src).await);
+}
+
+#[tokio::test]
+async fn dropped_and_aborted_writes_reuse_their_sequence() {
+    let (_tmp, mut ship) = new_pond("sequence-reuse").await;
+    let before = ship.last_write_seq();
+
+    let tx = ship
+        .begin_write(&meta("drop"))
+        .await
+        .expect("begin dropped write");
+    assert_eq!(tx.txn_meta().txn_seq, before + 1);
+    drop(tx);
+    assert_eq!(ship.last_write_seq(), before);
+
+    let _ = ship
+        .write_transaction(&meta("abort"), async |_fs| {
+            Err(steward::StewardError::Content(
+                "injected failure".to_string(),
+            ))
+        })
+        .await
+        .expect_err("callback failure must abort");
+    assert_eq!(ship.last_write_seq(), before);
+
+    write_file(&mut ship, "/after.txt", b"after").await;
+    assert_eq!(ship.last_write_seq(), before + 1);
+}
+
+#[tokio::test]
+async fn failed_replay_reuses_its_sequence() {
+    let (_tmp, mut ship) = new_pond("replay-sequence-reuse").await;
+    let before = ship.last_write_seq();
+    let replay_meta = PondTxnMetadata::new(before + 1, meta("replay"));
+
+    let _ = ship
+        .replay_transaction(&replay_meta, |_guard, _fs| {
+            Box::pin(async {
+                Err::<(), _>(steward::StewardError::Content(
+                    "injected replay failure".to_string(),
+                ))
+            })
+        })
+        .await
+        .expect_err("replay callback failure must abort");
+    assert_eq!(ship.last_write_seq(), before);
+
+    let _ = ship
+        .replay_transaction(&replay_meta, |_guard, fs| {
+            Box::pin(async move {
+                let root = fs.root().await?;
+                let _ = create_file_path(&root, "/replayed.txt", b"ok").await?;
+                Ok(())
+            })
+        })
+        .await
+        .expect("retry replay at the same sequence");
+    assert_eq!(ship.last_write_seq(), before + 1);
+    assert_eq!(read_to_string(&mut ship, "/replayed.txt").await, "ok");
 }
 
 /// A source-side change to a node's *metadata alone* replicates.

--- a/crates/tinyfs/src/dir.rs
+++ b/crates/tinyfs/src/dir.rs
@@ -12,7 +12,7 @@ use crate::error::*;
 use crate::metadata::Metadata;
 use crate::node::*;
 use async_trait::async_trait;
-use futures::stream::Stream;
+use futures::{StreamExt, stream::Stream};
 
 /// Lightweight directory entry information without loading the full node.
 /// Contains just enough information to filter entries and determine partition assignment.
@@ -65,12 +65,32 @@ impl DirectoryEntry {
 pub trait Directory: Metadata + Send + Sync {
     async fn get(&self, name: &str) -> Result<Option<Node>>;
 
+    /// Get lightweight entry metadata without loading the referenced node.
+    async fn entry(&self, name: &str) -> Result<Option<DirectoryEntry>> {
+        let mut entries = self.entries().await?;
+        while let Some(entry) = entries.next().await {
+            let entry = entry?;
+            if entry.name == name {
+                return Ok(Some(entry));
+            }
+        }
+        Ok(None)
+    }
+
     async fn insert(&mut self, name: String, id: Node) -> Result<()>;
 
     /// Remove a directory entry by name.
     /// Returns the removed node if it existed, None if not found.
     /// Does NOT delete the underlying node - only removes the directory link.
     async fn remove(&mut self, name: &str) -> Result<Option<Node>>;
+
+    /// Unlink a directory entry without loading the referenced node.
+    ///
+    /// Implementations should override this when dangling entries must remain
+    /// removable. The default preserves compatibility for read-through stores.
+    async fn unlink(&mut self, name: &str) -> Result<bool> {
+        Ok(self.remove(name).await?.is_some())
+    }
 
     /// Returns a stream of directory entries (lightweight metadata) without loading full nodes.
     /// Callers should use batch loading to load multiple nodes efficiently.
@@ -110,6 +130,11 @@ impl Handle {
         dir.get(name).await
     }
 
+    pub async fn entry(&self, name: &str) -> Result<Option<DirectoryEntry>> {
+        let dir = self.0.lock().await;
+        dir.entry(name).await
+    }
+
     pub async fn insert(&self, name: String, id: Node) -> Result<()> {
         log::debug!(
             "Handle::insert() - forwarding to Directory trait: {name}",
@@ -138,6 +163,11 @@ impl Handle {
         log::debug!("Handle::remove() - forwarding to Directory trait: {name}");
         let mut dir = self.0.lock().await;
         dir.remove(name).await
+    }
+
+    pub async fn unlink(&self, name: &str) -> Result<bool> {
+        let mut dir = self.0.lock().await;
+        dir.unlink(name).await
     }
 
     pub async fn entries(

--- a/crates/tinyfs/src/wd.rs
+++ b/crates/tinyfs/src/wd.rs
@@ -121,6 +121,11 @@ impl WD {
         self.dref.get(name).await
     }
 
+    /// Get lightweight entry metadata without loading the referenced node.
+    pub async fn entry(&self, name: &str) -> Result<Option<DirectoryEntry>> {
+        self.dref.handle.entry(name).await
+    }
+
     fn id(&self) -> FileID {
         self.np.id()
     }
@@ -615,12 +620,9 @@ impl WD {
     /// The removed node is dropped -- this is a destructive unlink.
     pub async fn remove_entry(&self, name: &str) -> Result<()> {
         self.check_writable()?;
-        let _node = self
-            .dref
-            .handle
-            .remove(name)
-            .await?
-            .ok_or_else(|| Error::not_found(name))?;
+        if !self.dref.handle.unlink(name).await? {
+            return Err(Error::not_found(name));
+        }
 
         debug!("Removed entry '{}' from directory", name);
 

--- a/crates/tlogfs/src/directory.rs
+++ b/crates/tlogfs/src/directory.rs
@@ -92,6 +92,17 @@ impl Directory for OpLogDirectory {
         Ok(Some(child_node))
     }
 
+    async fn entry(&self, name: &str) -> tinyfs::Result<Option<tinyfs::DirectoryEntry>> {
+        self.state
+            .ensure_directory_loaded(self.id)
+            .await
+            .map_other_context("Failed to load directory")?;
+        self.state
+            .get_directory_entry(self.id, name)
+            .await
+            .map_other_context("Failed to get directory entry")
+    }
+
     async fn insert(&mut self, name: String, node: Node) -> tinyfs::Result<()> {
         debug!("OpLogDirectory::insert('{name}', {:?})", node.id());
 
@@ -161,6 +172,19 @@ impl Directory for OpLogDirectory {
             }
             None => Ok(None),
         }
+    }
+
+    async fn unlink(&mut self, name: &str) -> tinyfs::Result<bool> {
+        self.state
+            .ensure_directory_loaded(self.id)
+            .await
+            .map_other_context("Failed to load directory")?;
+        Ok(self
+            .state
+            .remove_directory_entry(self.id, name)
+            .await
+            .map_other_context("Failed to remove directory entry")?
+            .is_some())
     }
 
     async fn entries(

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -551,6 +551,9 @@ pond pull
 
 # Pull only the named remote
 pond pull upstream
+
+# Discard and atomically rebuild only this named cross-pond graft
+pond pull upstream --rebuild-graft
 ```
 
 > **Cross-pond pull bootstrap (D5.7b.2):** when a pull-mode remote
@@ -561,6 +564,16 @@ pond pull upstream
 > (`PATH = /`, same `store_id`) require a pond that already carries the
 > source `pond_id`; use **`pond restore`** (below) to bootstrap one from
 > a blank machine.
+
+`--rebuild-graft` is an explicit recovery operation for a non-root graft. It
+replaces only that foreign pond partition, validates the replacement before
+commit, and commits the mount and graft pin in the same transaction. It refuses
+to unlink local content or a different pond's graft at the configured path.
+
+Ordinary pulls are fast-forward only: a differing remote tip must descend from
+the recorded `last_pulled_tip`. A stale or out-of-order remote ref is rejected
+rather than rolling a mirror or graft backward. Use `--rebuild-graft` for an
+intentional cross-pond replacement.
 
 ---
 

--- a/docs/logical-series-identity-design.md
+++ b/docs/logical-series-identity-design.md
@@ -1,0 +1,132 @@
+# Logical Series Identity and Physical Packs
+
+> **Status:** Proposed. This is a wire-format change and must not be enabled
+> until mixed-version replication and migration tests pass.
+
+## Problem
+
+Today a series node's `child_hash` is `blake3(dp.series.1 || ordered parquet
+blob hashes)`. Series collapse concatenates live parquet runs into a new blob
+and supersedes the old runs. Although the logical rows are unchanged, the blob
+list, series object, directory hashes, pond root, and commit tip all change.
+Replication therefore treats physical maintenance as a logical edit.
+
+Delta `OPTIMIZE` is not the problem: it rewrites Delta files without changing
+live oplog rows. The identity error is specifically the series-collapse model,
+where physical run layout is stored as logical series history.
+
+## Invariants
+
+1. Appending, deleting, or changing a logical observation changes series
+   identity.
+2. Repacking the same observations does not change series identity, metadata,
+   directory hashes, or the pond root.
+3. Every pack is independently verifiable against the logical range it serves.
+4. A reader can recover after losing all local packs by fetching advertised
+   packs from a remote.
+5. Replicas may choose different valid pack layouts for the same logical
+   series.
+6. No v1 reader may silently interpret v2 identity.
+
+## Model
+
+Separate each series into two layers.
+
+### Logical manifest
+
+The logical manifest is immutable, append-oriented history. Each leaf commits
+to a canonical Arrow representation of a bounded row group:
+
+```text
+logical_leaf = blake3(
+  schema_fingerprint ||
+  canonical_rows ||
+  min_event_time ||
+  max_event_time ||
+  logical_attributes
+)
+```
+
+The series identity is a domain-separated Merkle root over ordered logical
+leaves plus the schema fingerprint and logical row count. It is the only
+series value used by `ManifestEntry.child_hash` and directory folding.
+Physical parquet encoding, compression, file boundaries, and pack location do
+not contribute.
+
+Canonical rows require a frozen specification before implementation: Arrow
+type encoding, null representation, dictionary normalization, timestamp
+timezone handling, floating-point NaN normalization, and row ordering must be
+byte-identical across writers.
+
+### Physical pack index
+
+A pack index maps a contiguous logical-leaf range to one or more content-
+addressed parquet objects:
+
+```text
+pack = {
+  logical_start,
+  logical_end,
+  logical_range_root,
+  parquet_objects,
+  row_count,
+  byte_count
+}
+```
+
+Pack indexes are derived storage metadata. They are excluded from the logical
+content tree, like Delta file layout. A pack is accepted only when decoding it
+recomputes the declared logical range root. Multiple overlapping pack choices
+may coexist; readers choose any verified covering set.
+
+Collapse writes a replacement pack, verifies its logical range root, publishes
+the new pack index atomically, and only then makes superseded packs reclaimable.
+It never edits the logical manifest.
+
+## Wire compatibility
+
+Introduce `dp.series.2` for logical manifests and a separately tagged
+`dp.series-pack.1` object. A tree entry remains structurally unchanged: its
+`child_hash` names either a v1 series object or a v2 logical manifest, detected
+by object magic after fetch.
+
+Commit encoding must advance from `dp.commit.3` to `dp.commit.4` and include a
+content-model version. This deliberately prevents old binaries from accepting
+v2 roots. New binaries read both commit versions during migration but publish
+only the configured version. Remotes retain v1 objects until no published v1
+tip references them.
+
+## Migration
+
+Migration is explicit per pond and resumable:
+
+1. Freeze collapse and record the source v1 tip.
+2. Read each live v1 series in logical row order and produce v2 logical leaves
+   plus an initial verified pack index.
+3. Build the complete v2 manifest and root in a preview transaction.
+4. Verify row counts, schema, event-time bounds, attributes, and canonical
+   logical roots against a second full scan.
+5. Commit one migration transaction and publish a `dp.commit.4` tip.
+6. Keep the v1 tip and its reachable objects pinned through the rollback
+   window; rollback republishes that tip rather than translating backward.
+7. Re-enable collapse using pack-only maintenance.
+
+Migration cannot preserve the old root because v1 commits to parquet bytes and
+v2 commits to canonical logical rows. It produces one intentional root change;
+all later physical repacks must preserve that new root.
+
+## Delivery gates
+
+1. Freeze canonical row encoding with cross-process golden vectors.
+2. Implement v2 logical-manifest and pack codecs without changing writers.
+3. Add a dual reader and mixed v1/v2 fetch tests.
+4. Prototype pack verification and prove repeated collapse preserves the v2
+   series root while changing physical blob layout.
+5. Add interrupted-migration, rollback, remote refetch, out-of-order pack, and
+   corrupt-pack tests.
+6. Enable v2 writing behind a pond setting; make it the default only after
+   deployed readers understand `dp.commit.4`.
+
+The prototype succeeds only if an append changes the logical root, a repack
+does not, and a clean replica reconstructs identical rows using a different
+verified pack selection.


### PR DESCRIPTION
## Summary

- validate predicted replica roots and manifests before committing local rebuilds or foreign imports, with deterministic first-divergence diagnostics
- commit foreign data, mount, and graft pin atomically; treat the control watermark as a trailing idempotent cache
- add `pond pull NAME --rebuild-graft` for validated, single-graft replacement without resetting local or unrelated data
- reject non-fast-forward remote tips using the authoritative graft pin and publish complete commit ancestry from the pond-resident log
- preserve transaction sequence/error invariants and make dangling directory entries safely unlinkable during scoped repair
- document the separate logical-series identity and physical-pack migration project

## Guarantees

- failed validation leaves the data Delta version and folded roots unchanged
- retries begin from clean state
- pins cannot reference unvalidated graft data
- missing or stale watermarks cause harmless recovery or explicit rollback rejection
- scoped rebuild refuses local-content and unrelated-graft collisions

## Tests

- atomic local and foreign validation failure/retry
- graft data + mount + pin atomicity and scoped replacement
- append, collapse, metadata-only divergence, external blobs, and rename cycles
- dropped, aborted, no-op, and replay transaction sequencing
- watermark crash recovery, stale/out-of-order tips, multi-commit ancestry, and authoritative log-tip selection
- end-to-end `--rebuild-graft`, mirror rejection, and graft-pin identity

All affected `tinyfs`, `tlogfs`, `steward`, and `cmd` suites pass.

## Follow-up

Physical series collapse still changes logical roots. `docs/logical-series-identity-design.md` specifies the versioned v2 logical-history/physical-pack project; implementation and migration remain separate work.
